### PR TITLE
Adjustments to the frontend

### DIFF
--- a/backend/app/api/projects_v2.py
+++ b/backend/app/api/projects_v2.py
@@ -307,26 +307,36 @@ async def delete_analysis_project(
         if not project_result.data:
             raise HTTPException(status_code=404, detail="Project not found")
 
-        # Clean up chunks from vectorization system first
+        # Clean up chunks that reference analysis_documents from this project
         try:
-            # Delete chunks associated with this project from the old system
+            # First, get all analysis_documents.id values for this project
+            docs_result = (
+                vectorization_service.supabase.table("analysis_documents")
+                .select("id")
+                .eq("analysis_project_id", project_id)
+                .execute()
+            )
+
+            analysis_doc_ids = [doc["id"] for doc in docs_result.data]
+
+            # Delete chunks that reference these analysis_documents
+            if analysis_doc_ids:
+                vectorization_service.supabase.table("chunks").delete().in_(
+                    "document_id", analysis_doc_ids
+                ).execute()
+                logger.info(
+                    f"Deleted chunks for {len(analysis_doc_ids)} analysis documents"
+                )
+
+            # Also delete any chunks by project_id (legacy/fallback)
             vectorization_service.supabase.table("chunks").delete().eq(
                 "project_id", project_id
             ).execute()
 
-            # Delete documents from vectorization system
-            vectorization_service.supabase.table("documents").delete().eq(
-                "project_id", project_id
-            ).execute()
-
-            logger.info(
-                f"Cleaned up vectorization system data for project {project_id}"
-            )
+            logger.info(f"Cleaned up chunks for analysis project {project_id}")
         except Exception as e:
-            logger.warning(
-                f"Failed to clean up vectorization data for project {project_id}: {e}"
-            )
-            # Don't fail the deletion if vectorization cleanup fails
+            logger.warning(f"Failed to clean up chunks for project {project_id}: {e}")
+            # Don't fail the deletion if chunk cleanup fails
 
         # Delete project (cascading delete will handle documents and extractions)
         vectorization_service.supabase.table("analysis_projects").delete().eq(

--- a/backend/app/services/analysis/storage.py
+++ b/backend/app/services/analysis/storage.py
@@ -214,7 +214,7 @@ class AnalysisStorageService:
 
         Args:
             project_id: The analysis project ID
-            doc_id: The document ID
+            doc_id: The document ID (from analysis_documents.doc_id)
             document_data: Document metadata
             full_text: Full document text (if available)
             use_abstracts_only: Force abstract-only mode
@@ -225,6 +225,26 @@ class AnalysisStorageService:
         try:
             logger.debug(
                 f"Creating chunks for document {doc_id} in project {project_id}"
+            )
+
+            # First, get the analysis_documents.id (UUID) for this doc_id
+            analysis_doc_result = (
+                self.supabase.table("analysis_documents")
+                .select("id")
+                .eq("analysis_project_id", project_id)
+                .eq("doc_id", doc_id)
+                .execute()
+            )
+
+            if not analysis_doc_result.data:
+                logger.error(
+                    f"No analysis document found for doc_id {doc_id} in project {project_id}"
+                )
+                return False
+
+            analysis_doc_uuid = analysis_doc_result.data[0]["id"]
+            logger.debug(
+                f"Found analysis document UUID {analysis_doc_uuid} for doc_id {doc_id}"
             )
 
             # Generate chunks
@@ -241,75 +261,12 @@ class AnalysisStorageService:
                 logger.warning(f"No chunks generated for document {doc_id}")
                 return False
 
-            # Create document in vectorization system with proper data cleaning
-            year = document_data.get("year")
-            published_date = None
-            if year and str(year).isdigit():
-                # Convert year to proper date format (January 1st of that year)
-                published_date = f"{year}-01-01"
-
-            # Clean up authors field
-            authors = document_data.get("authors", [])
-            if not isinstance(authors, list):
-                authors = [str(authors)] if authors else []
-
-            # Clean numeric fields to avoid NaN issues
-            cited_by_count = document_data.get("citation_count", 0)
-            try:
-                cited_by_count = (
-                    int(cited_by_count) if cited_by_count is not None else 0
-                )
-                if pd.isna(cited_by_count) or math.isnan(cited_by_count):
-                    cited_by_count = 0
-            except (ValueError, TypeError):
-                cited_by_count = 0
-
-            confidence = 1.0
-
-            paper_data = {
-                "id": doc_id,
-                "title": document_data.get("title", ""),
-                "abstract": document_data.get("abstract_or_summary", ""),
-                "content": full_text or document_data.get("abstract_or_summary", ""),
-                "doi": document_data.get("doi"),
-                "source_country": document_data.get("source_country"),
-                "source_type": document_data.get("source", "analysis"),
-                "published_date": published_date,  # Proper date format
-                "publication_year": year,  # Keep year in metadata
-                "overton_url": document_data.get("landing_page_url"),
-                "confidence": confidence,
-                "relevance_reason": document_data.get("relevance_reason", ""),
-                "top_line": document_data.get("top_line", ""),
-                "is_relevant": document_data.get("is_relevant", True),
-                "cited_by_count": cited_by_count,
-                "authors": authors,
-            }
-
-            try:
-                # Clean data to prevent JSON serialization issues
-                clean_paper_data = self._clean_data_for_json(paper_data)
-
-                vector_doc_id = await self.vectorization_service.store_document(
-                    clean_paper_data, project_id
-                )
-                if not vector_doc_id:
-                    logger.error(
-                        f"Failed to store document {doc_id} in vectorization system"
-                    )
-                    return False
-            except Exception as e:
-                logger.error(
-                    f"Error storing document {doc_id} in vectorization system: {e}"
-                )
-                logger.debug(f"Document data that failed: {paper_data}")
-                return False
-
-            # Clean up existing chunks
+            # Clean up existing chunks for this document UUID
             self.vectorization_service.supabase.table("chunks").delete().eq(
-                "document_id", vector_doc_id
-            ).execute()
+                "document_id", analysis_doc_uuid
+            ).eq("project_id", project_id).execute()
 
-            # Store chunks with embeddings
+            # Store chunks with embeddings (link to analysis_documents.id UUID)
             chunk_count = 0
             for chunk in chunks:
                 try:
@@ -319,7 +276,7 @@ class AnalysisStorageService:
 
                     self.vectorization_service.supabase.table("chunks").insert(
                         {
-                            "document_id": vector_doc_id,
+                            "document_id": analysis_doc_uuid,  # Link to analysis_documents.id (UUID)
                             "project_id": project_id,
                             "content": chunk.content,
                             "chunk_type": chunk.chunk_type,

--- a/backend/app/services/chatbot/chat_service.py
+++ b/backend/app/services/chatbot/chat_service.py
@@ -145,14 +145,15 @@ class ChatbotService:
             set(c.get("document_id") for c in chunks if c.get("document_id"))
         )
 
-        # Fetch document details
+        # Fetch document details from analysis_documents table
+        # Note: document_ids are now UUIDs from analysis_documents.id
         document_details = {}
         if document_ids:
             try:
                 result = (
-                    vectorization_service.supabase.table("documents")
+                    vectorization_service.supabase.table("analysis_documents")
                     .select(
-                        "id, title, authors, doi, overton_url, source_country, published_date"
+                        "id, doc_id, title, authors, doi, overton_url, source_country, year, published_on"
                     )
                     .in_("id", document_ids)
                     .execute()
@@ -170,6 +171,12 @@ class ChatbotService:
             doc_id = chunk.get("document_id")
             if doc_id and doc_id in document_details:
                 doc_details = document_details[doc_id]
+
+                # Handle published date - prefer published_on, fallback to year
+                published_date = doc_details.get("published_on")
+                if not published_date and doc_details.get("year"):
+                    published_date = f"{doc_details.get('year')}-01-01"
+
                 enriched_chunk.update(
                     {
                         "document_title": doc_details.get("title", ""),
@@ -177,7 +184,8 @@ class ChatbotService:
                         "document_doi": doc_details.get("doi"),
                         "document_overton_url": doc_details.get("overton_url"),
                         "document_source_country": doc_details.get("source_country"),
-                        "document_published_date": doc_details.get("published_date"),
+                        "document_published_date": published_date,
+                        "document_year": doc_details.get("year"),
                     }
                 )
             enriched_chunks.append(enriched_chunk)
@@ -306,6 +314,8 @@ Answer the user's question based on this evidence."""
                         doi=doi,
                         url=url,
                         chunk_type=chunk.get("chunk_type"),
+                        published_date=chunk.get("document_published_date"),
+                        year=chunk.get("document_year"),
                     )
                 )
 

--- a/backend/app/services/chatbot/models.py
+++ b/backend/app/services/chatbot/models.py
@@ -38,6 +38,8 @@ class DocumentReference(BaseModel):
     url: Optional[str] = None
     chunk_type: Optional[str] = None
     relevance_score: Optional[float] = None
+    published_date: Optional[str] = None
+    year: Optional[int] = None
 
 
 class ChatResponse(BaseModel):

--- a/backend/supabase_drop_chunks_fkey.sql
+++ b/backend/supabase_drop_chunks_fkey.sql
@@ -1,0 +1,16 @@
+-- Drop the foreign key constraint that links chunks to documents table
+-- This allows chunks to reference analysis_documents.id directly
+
+-- Drop the foreign key constraint
+ALTER TABLE chunks DROP CONSTRAINT IF EXISTS chunks_document_id_fkey;
+
+-- Add a comment to clarify the new relationship
+COMMENT ON COLUMN chunks.document_id IS 'References analysis_documents.id (UUID) for analysis projects, or documents.id for legacy projects';
+
+-- Optional: Add an index on document_id for performance (if not already exists)
+CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id);
+
+-- Note: Project deletion in projects_v2.py handles cleanup by:
+-- 1. Finding all analysis_documents.id for the project
+-- 2. Deleting chunks WHERE document_id IN (analysis_doc_ids)  
+-- 3. Deleting analysis_project (CASCADE handles analysis_documents and analysis_extractions)

--- a/backend/supabase_update_match_chunks.sql
+++ b/backend/supabase_update_match_chunks.sql
@@ -1,0 +1,44 @@
+-- Updated match_chunks function to work with analysis_documents table only
+-- Simple version for analysis projects
+
+-- Drop existing function first
+DROP FUNCTION IF EXISTS match_chunks(vector, double precision, integer, text);
+
+CREATE OR REPLACE FUNCTION match_chunks(
+  query_embedding vector(1536),
+  match_threshold float,
+  match_count int,
+  project_filter text DEFAULT NULL
+)
+RETURNS TABLE(
+  id uuid,
+  document_id uuid,
+  content text,
+  similarity float,
+  chunk_type text,
+  document_title text,
+  document_authors jsonb,
+  top_line text
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.document_id,
+    c.content,
+    1 - (c.embedding <=> query_embedding) AS similarity,
+    c.chunk_type,
+    ad.title AS document_title,
+    ad.authors AS document_authors,
+    ad.top_line AS top_line
+  FROM chunks c
+  JOIN analysis_documents ad ON c.document_id = ad.id
+  WHERE 
+    (project_filter IS NULL OR c.project_id = project_filter)
+    AND 1 - (c.embedding <=> query_embedding) > match_threshold
+  ORDER BY c.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
   const router = useRouter()
   
   useEffect(() => {
-    router.push('/dashboard')
+    router.push('/v2')
   }, [router])
 
   return null

--- a/frontend/app/v2/layout.tsx
+++ b/frontend/app/v2/layout.tsx
@@ -68,7 +68,9 @@ export default function AgentLayout({
         <div className="p-6 pb-4">
           <div className="flex items-center gap-3">
             <div>
-              <h1 className="text-2xl font-bold">🌐 Policy Atlas</h1>
+              <Link href="/v2">
+                <h1 className="text-2xl font-bold cursor-pointer">🌐 Policy Atlas</h1>
+              </Link>
             </div>
           </div>
         </div>
@@ -77,7 +79,7 @@ export default function AgentLayout({
         <div className="px-6 pb-4">
           <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
             <div className="flex items-center gap-2 mb-1">
-              <Folder className="h-3 w-3 text-slate-500" />
+              <Folder className="h-4 w-4 text-slate-500 -mt-2.5" />
               <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">ACTIVE PROJECT</p>
             </div>
             {activeProject ? (
@@ -185,7 +187,7 @@ export default function AgentLayout({
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col ml-64">
+      <div className="flex-1 flex flex-col ml-64 bg-white">
         {children}
       </div>
     </div>

--- a/frontend/app/v2/layout.tsx
+++ b/frontend/app/v2/layout.tsx
@@ -18,7 +18,8 @@ const sidebarItems = [
 ]
 
 const testItems = [
-  { name: 'Extraction', href: '/v2/test_extraction', icon: Zap },
+  { name: 'Test extraction', href: '/v2/test_extraction', icon: Zap },
+  { name: 'Extractions', href: '/v2/text_extractions', icon: FileText },
 ]
 
 // const quickStats = [

--- a/frontend/app/v2/page.tsx
+++ b/frontend/app/v2/page.tsx
@@ -8,10 +8,10 @@ import { ArrowRight } from 'lucide-react'
 
 export default function V2HomePage() {
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-32">
       {/* Welcome Section */}
-      <section className="space-y-6">
-        <div className="text-center space-y-4">
+      <section className="space-y-12">
+        <div className="text-center space-y-0">
           <div className="flex items-center justify-center gap-3">
             <h1 className="text-4xl font-bold tracking-tight">Welcome to Policy Atlas</h1>
             <Tooltip content={
@@ -30,20 +30,19 @@ export default function V2HomePage() {
         </div>
 
         <div className="text-center space-y-6">
-          <h2 className="text-2xl font-semibold">Get Started</h2>
-          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Create a new analysis project to search, screen, and explore policy and research documents
+          <p className="text-lg max-w-2xl mx-auto">
+            Search evidence on any topic, or browse already existing projects
           </p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <Link href="/v2/search/chat">
               <Button size="lg" className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700">
-                Chat Search (New)
+                Search
                 <ArrowRight className="h-4 w-4" />
               </Button>
             </Link>
             <Link href="/v2/projects">
               <Button size="lg" variant="outline" className="flex items-center gap-2">
-                Browse Projects
+                Projects
                 <ArrowRight className="h-4 w-4" />
               </Button>
             </Link>

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -65,7 +65,7 @@ export default function AnalysisResultsPage() {
   const [summaryData, setSummaryData] = useState<SynthesisSummary | null>(null)
   const [isLoadingSummary, setIsLoadingSummary] = useState(false)
   // const [activeTab, setActiveTab] = useState('summary')
-  const [evidenceSubTab, setEvidenceSubTab] = useState('interventions')
+  const [evidenceSubTab, setEvidenceSubTab] = useState('documents')
 
   
   // Data states
@@ -577,15 +577,6 @@ export default function AnalysisResultsPage() {
                   {/* Evidence Sub-tabs as smaller buttons */}
                   <div className="mb-6">
                     <div className="flex gap-2">
-                    <Button
-                        variant={evidenceSubTab === 'interventions' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => setEvidenceSubTab('interventions')}
-                        className="flex items-center gap-2"
-                      >
-                        <Target className="h-3 w-3" />
-                        Interventions ({interventions.length})
-                      </Button>                      
                       <Button
                         variant={evidenceSubTab === 'documents' ? 'default' : 'outline'}
                         size="sm"
@@ -594,6 +585,15 @@ export default function AnalysisResultsPage() {
                       >
                         <FileText className="h-3 w-3" />
                         Documents ({documents.length})
+                      </Button>
+                      <Button
+                        variant={evidenceSubTab === 'interventions' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => setEvidenceSubTab('interventions')}
+                        className="flex items-center gap-2"
+                      >
+                        <Target className="h-3 w-3" />
+                        Interventions ({interventions.length})
                       </Button>
 
                     </div>

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -49,6 +49,9 @@ interface AnalysisDocument {
   landing_page_url?: string
   full_text_available?: boolean
   extraction_status?: string
+  text_source?: string  // "full_text" or "abstract" - what was used for extraction
+  study_strength?: string  // strongest study type letter from interventions
+  sample_size?: number  // largest sample size from interventions
   cited_by_count?: number  // Citation count from API
 }
 
@@ -417,6 +420,65 @@ export default function AnalysisResultsPage() {
     router.push('/v2/search')
   }
 
+  // Create study strength and sample size mappings from interventions data
+  const { studyStrengthMapping, sampleSizeMapping } = useMemo(() => {
+    const strengthMapping: Record<string, string> = {}
+    const sizeMapping: Record<string, number> = {}
+    
+    // Study type ranking function (same as backend)
+    const getStudyTypeRank = (studyType: string): number => {
+      if (!studyType) return 999
+      const type = studyType.trim().toLowerCase()
+      
+      if (type === 'g') return 1  // RCT - highest quality
+      if (type === 'h') return 2  // Meta-analysis
+      if (type === 'f') return 3  // Quasi-experimental
+      if (type === 'e') return 4  // Comparison of outcomes
+      if (type === 'd') return 5  // Pre/post study
+      if (type === 'c') return 6  // Cross-sectional with controls
+      if (type === 'b') return 7  // Pre/post study
+      if (type === 'a') return 8  // Cross-sectional
+      if (type === 'i') return 9  // Policy recommendation
+      if (type === 'j') return 10 // News/opinion
+      return 999 // Unknown
+    }
+    
+    // Process interventions to find strongest study type and largest sample size per document
+    interventions.forEach(intervention => {
+      intervention.documents?.forEach(doc => {
+        const docId = doc.doc_id
+        if (!docId) return
+        
+        // Get study type from intervention
+        const studyType = intervention.highest_study_type
+        if (studyType) {
+          const currentRank = getStudyTypeRank(studyType)
+          const existingStudyType = strengthMapping[docId]
+          const existingRank = existingStudyType ? getStudyTypeRank(existingStudyType) : 999
+          
+          // Keep the strongest (lowest rank number) study type
+          if (currentRank < existingRank) {
+            strengthMapping[docId] = studyType
+          }
+        }
+        
+        // Get sample size from intervention
+        const sampleSize = intervention.total_sample_size
+        if (sampleSize && sampleSize > 0) {
+          const existingSize = sizeMapping[docId] || 0
+          // Keep the largest sample size
+          if (sampleSize > existingSize) {
+            sizeMapping[docId] = sampleSize
+          }
+        }
+      })
+    })
+    
+    return {
+      studyStrengthMapping: strengthMapping,
+      sampleSizeMapping: sizeMapping
+    }
+  }, [interventions])
 
   // Transform documents for table display and apply filtering
   const { transformedPapers, relevantCount } = useMemo(() => {
@@ -437,7 +499,11 @@ export default function AnalysisResultsPage() {
       top_line: doc.top_line,
       landing_page_url: doc.landing_page_url,
       full_text_available: doc.full_text_available,
-      extraction_status: doc.extraction_status
+      extraction_status: doc.extraction_status,
+      text_source: doc.text_source,
+      source: doc.source,
+      study_strength: studyStrengthMapping[doc.doc_id] || undefined,
+      sample_size: sampleSizeMapping[doc.doc_id] || undefined
     }));
 
     const relevant = allTransformed.filter(doc => doc.is_relevant);
@@ -449,7 +515,7 @@ export default function AnalysisResultsPage() {
       transformedPapers: filtered,
       relevantCount: relevant.length
     };
-  }, [documents, showRelevantOnly]);
+  }, [documents, showRelevantOnly, studyStrengthMapping, sampleSizeMapping]);
 
   return (
     <div className="flex-1 flex flex-col">

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -3,11 +3,9 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { PapersTable } from '@/components/search/papers-table'
 import { InterventionsTable as InterventionsEvidenceTable, InterventionData } from '@/components/search/interventions-table'
 import { Paper } from '@/types/search'
@@ -17,10 +15,7 @@ import {
   ArrowLeft,
   AlertCircle,
   BookOpen,
-  ChevronRight,
-  ChevronDown,
   Target,
-  TrendingUp,
   Bot
 } from 'lucide-react'
 import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
@@ -54,313 +49,7 @@ interface AnalysisDocument {
   cited_by_count?: number  // Citation count from API
 }
 
-interface DocumentDetailResult {
-  document: {
-    id: string
-    doc_id: string
-    title: string
-    source: string
-    year?: number
-    abstract_or_summary?: string
-    is_relevant?: boolean
-    extraction_status?: string
-  }
-  extraction: {
-    issues: Array<{
-      idx?: number
-      label?: string
-      explanation?: string
-      supporting_quote?: string
-    }>
-    interventions: Array<{
-      idx?: number
-      name?: string
-      description?: string
-      type?: string
-      country?: string
-      study_type?: string
-      supporting_quote?: string
-      addresses_issues?: number[]
-      results?: Array<{
-        outcome_variable?: string
-        effect_direction?: string
-        effect_size_type?: string
-        effect_size?: string
-        uncertainty?: string
-        p_value?: string
-        population_measured?: string
-        subgroup_or_dose?: string
-        result_text?: string
-        supporting_quote?: string
-      }>
-    }>
-    mappings?: unknown[]
-    conclusion?: {
-      top_line_summary?: string
-      detailed_explanation?: string
-      supporting_quote?: string
-    }
-    metadata?: Record<string, unknown>
-  }
-}
 
-// Document Detail View Component
-function DocumentDetailView({ extraction }: { 
-  extraction: DocumentDetailResult['extraction']
-}) {
-  const [openSections, setOpenSections] = useState({
-    issues: true,
-    interventions: true,
-    results: false,
-    conclusion: true
-  })
-
-  const toggleSection = (section: keyof typeof openSections) => {
-    setOpenSections(prev => ({ ...prev, [section]: !prev[section] }))
-  }
-
-  const issues = extraction.issues || []
-  const interventions = extraction.interventions || []
-  const conclusion = extraction.conclusion
-
-  return (
-    <div className="space-y-4">
-      {/* Document Header */}
-
-
-      {/* Issues Section */}
-      <Collapsible open={openSections.issues} onOpenChange={() => toggleSection('issues')}>
-        <CollapsibleTrigger asChild>
-          <Card className="cursor-pointer hover:bg-gray-50 border-red-200">
-            <CardHeader className="pb-3">
-              <CardTitle className="flex items-center justify-between text-base">
-                <div className="flex items-center gap-2">
-                  <AlertCircle className="h-4 w-4 text-red-600" />
-                  <span className="text-red-900">Issues & Problems ({issues.length})</span>
-                </div>
-                {openSections.issues ? 
-                  <ChevronDown className="h-4 w-4 text-gray-500" /> : 
-                  <ChevronRight className="h-4 w-4 text-gray-500" />
-                }
-              </CardTitle>
-            </CardHeader>
-          </Card>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="space-y-3 mt-2">
-            {issues.map((issue, index: number) => (
-              <Card key={issue.idx || index} className="border-red-100">
-                <CardContent className="p-4">
-                  <div className="flex items-start gap-3">
-                    <div className="w-6 h-6 bg-red-100 rounded-full flex items-center justify-center flex-shrink-0">
-                                              <span className="text-red-700 font-medium text-sm">{issue.idx !== undefined ? issue.idx : index + 1}</span>
-                    </div>
-                    <div className="flex-1">
-                      <h5 className="font-medium text-red-900 mb-1">{issue.label}</h5>
-                      <p className="text-red-700 text-sm mb-2">{issue.explanation}</p>
-                      {issue.supporting_quote && (
-                        <blockquote className="text-red-600 text-xs italic border-l-4 border-red-200 pl-3">
-                          &ldquo;{issue.supporting_quote}&rdquo;
-                        </blockquote>
-                      )}
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-            {issues.length === 0 && (
-              <p className="text-gray-500 text-sm italic">No issues identified in this document.</p>
-            )}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-
-      {/* Interventions & Results Section */}
-      <Collapsible open={openSections.interventions} onOpenChange={() => toggleSection('interventions')}>
-        <CollapsibleTrigger asChild>
-          <Card className="cursor-pointer hover:bg-gray-50 border-blue-200">
-            <CardHeader className="pb-3">
-              <CardTitle className="flex items-center justify-between text-base">
-                <div className="flex items-center gap-2">
-                  <Target className="h-4 w-4 text-blue-600" />
-                  <span className="text-blue-900">Interventions & Results ({interventions.length})</span>
-                </div>
-                {openSections.interventions ? 
-                  <ChevronDown className="h-4 w-4 text-gray-500" /> : 
-                  <ChevronRight className="h-4 w-4 text-gray-500" />
-                }
-              </CardTitle>
-            </CardHeader>
-          </Card>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="space-y-4 mt-2">
-            {interventions.map((intervention, index: number) => (
-              <Card key={intervention.idx || index} className="border-blue-100">
-                <CardContent className="p-4">
-                  <div className="space-y-3">
-                    {/* Intervention Header */}
-                    <div className="flex items-start gap-3">
-                      <div className="w-6 h-6 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0">
-                        <span className="text-blue-700 font-medium text-sm">{intervention.idx !== undefined ? intervention.idx : index + 1}</span>
-                      </div>
-                      <div className="flex-1">
-                        <h5 className="font-medium text-blue-900 mb-1">{intervention.name}</h5>
-                        <p className="text-blue-700 text-sm mb-2">{intervention.description}</p>
-                        
-                        {/* Intervention Details */}
-                        <div className="flex gap-2 mb-2">
-                          <Badge variant="outline" className="text-xs bg-blue-50">
-                            {intervention.type}
-                          </Badge>
-                          {intervention.country && (
-                            <Badge variant="outline" className="text-xs bg-blue-50">
-                              {intervention.country}
-                            </Badge>
-                          )}
-                          {intervention.study_type && (
-                            <Badge variant="outline" className="text-xs bg-blue-50">
-                              Study: {intervention.study_type}
-                            </Badge>
-                          )}
-                        </div>
-
-                        {/* Issues Addressed */}
-                        {intervention.addresses_issues && intervention.addresses_issues.length > 0 && (
-                          <div className="mb-2">
-                            <span className="text-xs text-blue-600 font-medium">Addresses issues: </span>
-                            {intervention.addresses_issues.map((issueIdx: number) => {
-                              const relatedIssue = issues.find(issue => issue.idx === issueIdx)
-                              const issueTitle = relatedIssue?.label || `Issue ${issueIdx}`
-                              return (
-                                <Badge key={issueIdx} variant="outline" className="text-xs mr-1 bg-red-50 text-red-700" title={issueTitle}>
-                                  #{issueIdx}: {issueTitle}
-                                </Badge>
-                              )
-                            })}
-                          </div>
-                        )}
-
-                        {/* Results for this intervention */}
-                        {intervention.results && intervention.results.length > 0 && (
-                          <div className="mt-3">
-                            <h6 className="font-medium text-green-900 text-sm mb-2 flex items-center gap-1">
-                              <TrendingUp className="h-3 w-3" />
-                              Results ({intervention.results.length})
-                            </h6>
-                            <div className="space-y-2">
-                              {intervention.results.map((result, resultIndex: number) => (
-                                <div key={resultIndex} className="bg-green-50 border-l-4 border-green-200 p-2 rounded">
-                                  <div className="flex items-center gap-2 mb-1">
-                                    <span className="font-medium text-green-900 text-sm">
-                                      {result.outcome_variable}
-                                    </span>
-                                    <Badge variant="outline" className="text-xs bg-green-100 text-green-700">
-                                      {result.effect_direction}
-                                    </Badge>
-                                  </div>
-                                  
-                                  {/* Quantitative measures */}
-                                  {(result.effect_size || result.effect_size_type || result.uncertainty || result.p_value) && (
-                                    <div className="mb-2">
-                                      {result.effect_size_type && (
-                                        <div className="text-xs text-green-600 mb-1">
-                                          <span className="font-medium">Effect Type: </span>
-                                          {result.effect_size_type}
-                                        </div>
-                                      )}
-                                      {result.effect_size && (
-                                        <div className="text-xs text-green-600 mb-1">
-                                          <span className="font-medium">Effect Size: </span>
-                                          {result.effect_size}
-                                        </div>
-                                      )}
-                                      {result.uncertainty && (
-                                        <div className="text-xs text-green-600 mb-1">
-                                          <span className="font-medium">Uncertainty: </span>
-                                          ±{result.uncertainty}
-                                        </div>
-                                      )}
-                                      {result.p_value && (
-                                        <div className="text-xs text-green-600 mb-1">
-                                          <span className="font-medium">P-value: </span>
-                                          {result.p_value}
-                                        </div>
-                                      )}
-                                    </div>
-                                  )}
-                                  
-                                  {/* Population information */}
-                                  {result.population_measured && (
-                                    <div className="mb-2">
-                                      <div className="text-xs text-green-600 mb-1">
-                                        <span className="font-medium">Population: </span>
-                                        {result.population_measured}
-                                      </div>
-                                    </div>
-                                  )}
-                                  
-                                  <p className="text-green-700 text-xs">{result.result_text}</p>
-                                  {result.supporting_quote && (
-                                    <blockquote className="text-green-600 text-xs italic mt-1">
-                                      &ldquo;{result.supporting_quote}&rdquo;
-                                    </blockquote>
-                                  )}
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-            {interventions.length === 0 && (
-              <p className="text-gray-500 text-sm italic">No interventions identified in this document.</p>
-            )}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-
-      {/* Conclusion Section */}
-      {conclusion && (
-        <Collapsible open={openSections.conclusion} onOpenChange={() => toggleSection('conclusion')}>
-          <CollapsibleTrigger asChild>
-            <Card className="cursor-pointer hover:bg-gray-50 border-purple-200">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center justify-between text-base">
-                  <div className="flex items-center gap-2">
-                    <FileText className="h-4 w-4 text-purple-600" />
-                    <span className="text-purple-900">Conclusion</span>
-                  </div>
-                  {openSections.conclusion ? 
-                    <ChevronDown className="h-4 w-4 text-gray-500" /> : 
-                    <ChevronRight className="h-4 w-4 text-gray-500" />
-                  }
-                </CardTitle>
-              </CardHeader>
-            </Card>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <Card className="border-purple-100 mt-2">
-              <CardContent className="p-4">
-                <h5 className="font-medium text-purple-900 mb-2">{conclusion.top_line_summary}</h5>
-                <p className="text-purple-700 text-sm mb-3">{conclusion.detailed_explanation}</p>
-                {conclusion.supporting_quote && (
-                  <blockquote className="text-purple-600 text-xs italic border-l-4 border-purple-200 pl-3">
-                    &ldquo;{conclusion.supporting_quote}&rdquo;
-                  </blockquote>
-                )}
-              </CardContent>
-            </Card>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
-    </div>
-  )
-}
 
 export default function AnalysisResultsPage() {
   const searchParams = useSearchParams()
@@ -384,15 +73,9 @@ export default function AnalysisResultsPage() {
   const [interventions, setInterventions] = useState<InterventionData[]>([])
   const [loadingData, setLoadingData] = useState(false)
   const [dataError, setDataError] = useState<string | null>(null)
-  
-  // Document detail view state
-  const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(null)
-  const [documentDetail, setDocumentDetail] = useState<DocumentDetailResult | null>(null)
-  const [loadingDocumentDetail, setLoadingDocumentDetail] = useState(false)
-  const [documentDetailError, setDocumentDetailError] = useState<string | null>(null)
 
   const { activeProject } = useAnalysisProjectStore()
-  const { fetchWithAuth, getDocumentExtraction, getAnalysisProject, getProjectInterventions } = useAPI()
+  const { fetchWithAuth, getAnalysisProject, getProjectInterventions } = useAPI()
 
   // Get search parameters (memoized to prevent re-runs)
   const searchConfig = useMemo(() => ({
@@ -729,31 +412,6 @@ export default function AnalysisResultsPage() {
     router.push('/v2/search')
   }
 
-  // Load document detail extraction
-  const loadDocumentDetail = useCallback(async (documentId: string) => {
-    if (!effectiveProjectId) return
-    
-    setLoadingDocumentDetail(true)
-    setDocumentDetailError(null)
-    setSelectedDocumentId(documentId)
-    
-    try {
-      const result = await getDocumentExtraction(effectiveProjectId, documentId)
-      setDocumentDetail(result)
-    } catch (error) {
-      console.error('Failed to load document detail:', error)
-      setDocumentDetailError(error instanceof Error ? error.message : 'Failed to load document detail')
-    } finally {
-      setLoadingDocumentDetail(false)
-    }
-  }, [effectiveProjectId, getDocumentExtraction])
-
-  // Close document detail view
-  const closeDocumentDetail = () => {
-    setSelectedDocumentId(null)
-    setDocumentDetail(null)
-    setDocumentDetailError(null)
-  }
 
   // Transform documents for table display
   const transformedPapers: Paper[] = documents.map((doc: AnalysisDocument) => ({
@@ -869,7 +527,7 @@ export default function AnalysisResultsPage() {
         {effectiveProjectId && (
           <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
             <div className="px-6 pt-4">
-              <TabsList className="grid w-full grid-cols-4">
+              <TabsList className="grid w-full grid-cols-3">
                 <TabsTrigger value="evidence" className="flex items-center gap-2">
                   <BookOpen className="h-4 w-4" />
                   Evidence
@@ -877,10 +535,6 @@ export default function AnalysisResultsPage() {
                 <TabsTrigger value="summary" className="flex items-center gap-2">
                   <FileText className="h-4 w-4" />
                   Summary
-                </TabsTrigger>
-                <TabsTrigger value="extraction" className="flex items-center gap-2">
-                  <FileText className="h-4 w-4" />
-                  Extraction
                 </TabsTrigger>
                 <TabsTrigger value="assistant" className="flex items-center gap-2">
                   <Bot className="h-4 w-4" />
@@ -890,168 +544,6 @@ export default function AnalysisResultsPage() {
             </div>
 
             <div className="flex-1 overflow-auto">
-              <TabsContent value="extraction" className="p-6 m-0">
-                <div className="max-w-6xl mx-auto">
-
-
-                  {/* Document List */}
-                  {loadingData ? (
-                    <div className="flex items-center justify-center py-12">
-                      <div className="text-center">
-                        <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
-                        <p className="text-slate-600">Loading documents...</p>
-                      </div>
-                    </div>
-                  ) : dataError ? (
-                    <div className="text-center py-12">
-                      <AlertCircle className="h-12 w-12 text-red-400 mx-auto mb-4" />
-                      <h3 className="text-lg font-medium text-slate-900 mb-2">Error Loading Data</h3>
-                      <p className="text-slate-600">{dataError}</p>
-                    </div>
-                  ) : documents.length > 0 ? (
-                    <div className="space-y-4">
-                      <div className="flex items-center justify-between">
-                      </div>
-                      <div className="space-y-3">
-                        {documents.map((doc) => {
-                          const isExpanded = selectedDocumentId === doc.id
-                          const handleCardClick = (e: React.MouseEvent) => {
-                            // Don't trigger if clicking on a link
-                            if ((e.target as HTMLElement).closest('a')) {
-                              return
-                            }
-                            
-                            if (isExpanded) {
-                              closeDocumentDetail()
-                            } else {
-                              loadDocumentDetail(doc.id)
-                            }
-                          }
-                          
-                          return (
-                            <Card 
-                              key={doc.id} 
-                              className={`border-slate-200 cursor-pointer transition-all hover:shadow-md ${
-                                isExpanded ? 'ring-2 ring-blue-300 bg-blue-50' : ''
-                              }`}
-                              onClick={handleCardClick}
-                            >
-                              <CardContent className="p-4">
-                                {/* Card Header - Always Visible */}
-                                <div className="flex items-start justify-between">
-                                  <div className="flex-1">
-                                    <h3 className="font-semibold text-slate-900 mb-2">
-                                      {doc.landing_page_url ? (
-                                        <a 
-                                          href={doc.landing_page_url} 
-                                          target="_blank" 
-                                          rel="noopener noreferrer"
-                                          className="text-blue-600 hover:text-blue-800 hover:underline"
-                                          onClick={(e) => e.stopPropagation()}
-                                        >
-                                          {doc.title || 'Untitled Document'}
-                                        </a>
-                                      ) : (
-                                        doc.title || 'Untitled Document'
-                                      )}
-                                    </h3>
-                                    <div className="flex items-center gap-2 mb-2">
-                                      <Badge variant="outline" className="text-xs">
-                                        {doc.source || 'Unknown Source'}
-                                      </Badge>
-                                      {doc.year && (
-                                        <Badge variant="outline" className="text-xs">
-                                          {doc.year}
-                                        </Badge>
-                                      )}
-                                      {doc.is_relevant !== null && (
-                                        <Badge 
-                                          variant="outline" 
-                                          className={`text-xs ${
-                                            doc.is_relevant 
-                                              ? 'bg-green-100 text-green-700' 
-                                              : 'bg-red-100 text-red-700'
-                                          }`}
-                                        >
-                                          {doc.is_relevant ? 'Relevant' : 'Not Relevant'}
-                                        </Badge>
-                                      )}
-                                      {/* Extraction Status Indicator */}
-                                      {doc.extraction_status && (
-                                        <Badge 
-                                          variant="outline" 
-                                          className={`text-xs ${
-                                            doc.extraction_status === 'success' 
-                                              ? 'bg-blue-100 text-blue-700' 
-                                              : doc.extraction_status === 'failed'
-                                              ? 'bg-red-100 text-red-700'
-                                              : doc.extraction_status === 'skipped'
-                                              ? 'bg-yellow-100 text-yellow-700'
-                                              : 'bg-gray-100 text-gray-700'
-                                          }`}
-                                        >
-                                          {doc.extraction_status === 'success' ? '✓ Extracted' :
-                                           doc.extraction_status === 'failed' ? '✗ Failed' :
-                                           doc.extraction_status === 'skipped' ? '⊘ Skipped' :
-                                           `✓ ${doc.extraction_status}`}
-                                        </Badge>
-                                      )}
-                                    </div>
-                                    {!isExpanded && doc.abstract_or_summary && (
-                                      <p className="text-slate-600 text-sm line-clamp-2 mb-2">
-                                        {doc.abstract_or_summary}
-                                      </p>
-                                    )}
-                                  </div>
-                                  <div className="flex items-center gap-2 ml-4">
-                                    {isExpanded ? (
-                                      <ChevronDown className="h-4 w-4 text-slate-400" />
-                                    ) : (
-                                      <ChevronRight className="h-4 w-4 text-slate-400" />
-                                    )}
-                                  </div>
-                                </div>
-                                
-                                {/* Expanded Content */}
-                                {isExpanded && (
-                                  <div className="mt-4 pt-4 border-t border-slate-200">
-                                    {loadingDocumentDetail ? (
-                                      <div className="flex items-center justify-center py-8">
-                                        <div className="text-center">
-                                          <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2 text-blue-600" />
-                                          <p className="text-blue-700 text-sm">Loading document details...</p>
-                                        </div>
-                                      </div>
-                                    ) : documentDetailError ? (
-                                      <div className="text-center py-4">
-                                        <AlertCircle className="h-8 w-8 text-red-400 mx-auto mb-2" />
-                                        <p className="text-red-600 text-sm">{documentDetailError}</p>
-                                      </div>
-                                    ) : documentDetail && documentDetail.extraction ? (
-                                      <DocumentDetailView extraction={documentDetail.extraction} />
-                                    ) : documentDetail ? (
-                                      <div className="text-center py-4">
-                                        <FileText className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-                                        <p className="text-gray-600 text-sm">No extraction data available for this document</p>
-                                      </div>
-                                    ) : null}
-                                  </div>
-                                )}
-                              </CardContent>
-                            </Card>
-                          )
-                        })}
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="text-center py-12">
-                      <FileText className="h-12 w-12 text-slate-400 mx-auto mb-4" />
-                      <h3 className="text-lg font-medium text-slate-900 mb-2">No Documents Available</h3>
-                      <p className="text-slate-600">Documents will appear here once the analysis is processed.</p>
-                    </div>
-                  )}
-                </div>
-              </TabsContent>
 
               <TabsContent value="summary" className="p-6 m-0">
                 <div className="max-w-6xl mx-auto">

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -6,6 +6,8 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
 import { PapersTable } from '@/components/search/papers-table'
 import { InterventionsTable as InterventionsEvidenceTable, InterventionData } from '@/components/search/interventions-table'
 import { Paper } from '@/types/search'
@@ -16,7 +18,8 @@ import {
   AlertCircle,
   BookOpen,
   Target,
-  Bot
+  Bot,
+  Filter
 } from 'lucide-react'
 import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
 import { useAPI } from '@/lib/api'
@@ -66,7 +69,9 @@ export default function AnalysisResultsPage() {
   const [isLoadingSummary, setIsLoadingSummary] = useState(false)
   // const [activeTab, setActiveTab] = useState('summary')
   const [evidenceSubTab, setEvidenceSubTab] = useState('documents')
-
+  
+  // Relevance filtering state
+  const [showRelevantOnly, setShowRelevantOnly] = useState(true)
   
   // Data states
   const [documents, setDocuments] = useState<AnalysisDocument[]>([])
@@ -413,26 +418,38 @@ export default function AnalysisResultsPage() {
   }
 
 
-  // Transform documents for table display
-  const transformedPapers: Paper[] = documents.map((doc: AnalysisDocument) => ({
-    id: String(doc.id || doc.doc_id || `doc-${Math.random()}`),
-    title: String(doc.title || 'Untitled'),
-    doi: String(doc.doi || ''),
-    publication_year: Number(doc.year || 0),
-    cited_by_count: Number(doc.cited_by_count || 0),
-    authors: Array.isArray(doc.authors) ? doc.authors : ['Unknown'],
-    is_relevant: Boolean(doc.is_relevant !== false),
-    abstract: doc.abstract_or_summary,
-    relevance_reason: doc.relevance_reason,
-    confidence: doc.relevance_confidence,
-    source_country: doc.source_country,
-    source_type: doc.source_type,
-    venue: doc.venue,
-    top_line: doc.top_line,
-    landing_page_url: doc.landing_page_url,
-    full_text_available: doc.full_text_available,
-    extraction_status: doc.extraction_status
-  }));
+  // Transform documents for table display and apply filtering
+  const { transformedPapers, relevantCount } = useMemo(() => {
+    const allTransformed: Paper[] = documents.map((doc: AnalysisDocument) => ({
+      id: String(doc.id || doc.doc_id || `doc-${Math.random()}`),
+      title: String(doc.title || 'Untitled'),
+      doi: String(doc.doi || ''),
+      publication_year: Number(doc.year || 0),
+      cited_by_count: Number(doc.cited_by_count || 0),
+      authors: Array.isArray(doc.authors) ? doc.authors : ['Unknown'],
+      is_relevant: Boolean(doc.is_relevant !== false),
+      abstract: doc.abstract_or_summary,
+      relevance_reason: doc.relevance_reason,
+      confidence: doc.relevance_confidence,
+      source_country: doc.source_country,
+      source_type: doc.source_type,
+      venue: doc.venue,
+      top_line: doc.top_line,
+      landing_page_url: doc.landing_page_url,
+      full_text_available: doc.full_text_available,
+      extraction_status: doc.extraction_status
+    }));
+
+    const relevant = allTransformed.filter(doc => doc.is_relevant);
+    
+    // Apply filtering based on toggle
+    const filtered = showRelevantOnly ? relevant : allTransformed;
+    
+    return {
+      transformedPapers: filtered,
+      relevantCount: relevant.length
+    };
+  }, [documents, showRelevantOnly]);
 
   return (
     <div className="flex-1 flex flex-col">
@@ -576,26 +593,43 @@ export default function AnalysisResultsPage() {
                 <div className="max-w-6xl mx-auto">
                   {/* Evidence Sub-tabs as smaller buttons */}
                   <div className="mb-6">
-                    <div className="flex gap-2">
-                      <Button
-                        variant={evidenceSubTab === 'documents' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => setEvidenceSubTab('documents')}
-                        className="flex items-center gap-2"
-                      >
-                        <FileText className="h-3 w-3" />
-                        Documents ({documents.length})
-                      </Button>
-                      <Button
-                        variant={evidenceSubTab === 'interventions' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => setEvidenceSubTab('interventions')}
-                        className="flex items-center gap-2"
-                      >
-                        <Target className="h-3 w-3" />
-                        Interventions ({interventions.length})
-                      </Button>
+                    <div className="flex items-center justify-between">
+                      <div className="flex gap-2">
+                        <Button
+                          variant={evidenceSubTab === 'documents' ? 'default' : 'outline'}
+                          size="sm"
+                          onClick={() => setEvidenceSubTab('documents')}
+                          className="flex items-center gap-2"
+                        >
+                          <FileText className="h-3 w-3" />
+                          Documents ({showRelevantOnly ? relevantCount : documents.length})
+                        </Button>
+                        <Button
+                          variant={evidenceSubTab === 'interventions' ? 'default' : 'outline'}
+                          size="sm"
+                          onClick={() => setEvidenceSubTab('interventions')}
+                          className="flex items-center gap-2"
+                        >
+                          <Target className="h-3 w-3" />
+                          Interventions ({interventions.length})
+                        </Button>
+                      </div>
 
+                      {/* Relevance Filter Toggle (only show for documents) */}
+                      {evidenceSubTab === 'documents' && (
+                        <div className="flex items-center gap-3">
+                          <div className="flex items-center gap-2">
+                            <Label htmlFor="relevance-filter" className="text-sm text-slate-700">
+                              Relevant only
+                            </Label>
+                            <Switch
+                              id="relevance-filter"
+                              checked={showRelevantOnly}
+                              onCheckedChange={setShowRelevantOnly}
+                            />
+                          </div>
+                        </div>
+                      )}
                     </div>
                   </div>
 
@@ -615,8 +649,22 @@ export default function AnalysisResultsPage() {
                           <h3 className="text-lg font-medium text-slate-900 mb-2">Error Loading Data</h3>
                           <p className="text-slate-600">{dataError}</p>
                         </div>
-                      ) : documents.length > 0 ? (
+                      ) : transformedPapers.length > 0 ? (
                         <PapersTable papers={transformedPapers} />
+                      ) : documents.length > 0 && showRelevantOnly ? (
+                        <div className="text-center py-12">
+                          <FileText className="h-12 w-12 text-slate-400 mx-auto mb-4" />
+                          <h3 className="text-lg font-medium text-slate-900 mb-2">No Relevant Documents</h3>
+                          <p className="text-slate-600 mb-4">All {documents.length} documents in this project were marked as non-relevant.</p>
+                          <Button 
+                            variant="outline" 
+                            onClick={() => setShowRelevantOnly(false)}
+                            className="flex items-center gap-2"
+                          >
+                            <Filter className="h-4 w-4" />
+                            Show All Documents
+                          </Button>
+                        </div>
                       ) : (
                         <div className="text-center py-12">
                           <FileText className="h-12 w-12 text-slate-400 mx-auto mb-4" />

--- a/frontend/app/v2/text_extractions/page.tsx
+++ b/frontend/app/v2/text_extractions/page.tsx
@@ -1,0 +1,635 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { 
+  FileText, 
+  Loader2,
+  ArrowLeft,
+  AlertCircle,
+  ChevronRight,
+  ChevronDown,
+  Target,
+  TrendingUp
+} from 'lucide-react'
+import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
+import { useAPI } from '@/lib/api'
+
+interface AnalysisDocument {
+  id: string
+  doc_id: string
+  title: string
+  source: string
+  authors?: string[]
+  year?: number
+  abstract_or_summary?: string
+  is_relevant?: boolean
+  relevance_reason?: string
+  relevance_confidence?: number
+  source_country?: string
+  source_type?: string
+  venue?: string
+  top_line?: string
+  doi?: string
+  landing_page_url?: string
+  full_text_available?: boolean
+  extraction_status?: string
+  cited_by_count?: number
+}
+
+interface DocumentDetailResult {
+  document: {
+    id: string
+    doc_id: string
+    title: string
+    source: string
+    year?: number
+    abstract_or_summary?: string
+    is_relevant?: boolean
+    extraction_status?: string
+  }
+  extraction: {
+    issues: Array<{
+      idx?: number
+      label?: string
+      explanation?: string
+      supporting_quote?: string
+    }>
+    interventions: Array<{
+      idx?: number
+      name?: string
+      description?: string
+      type?: string
+      country?: string
+      study_type?: string
+      supporting_quote?: string
+      addresses_issues?: number[]
+      results?: Array<{
+        outcome_variable?: string
+        effect_direction?: string
+        effect_size_type?: string
+        effect_size?: string
+        uncertainty?: string
+        p_value?: string
+        population_measured?: string
+        subgroup_or_dose?: string
+        result_text?: string
+        supporting_quote?: string
+      }>
+    }>
+    mappings?: unknown[]
+    conclusion?: {
+      top_line_summary?: string
+      detailed_explanation?: string
+      supporting_quote?: string
+    }
+    metadata?: Record<string, unknown>
+  }
+}
+
+// Document Detail View Component
+function DocumentDetailView({ extraction }: { 
+  extraction: DocumentDetailResult['extraction']
+}) {
+  const [openSections, setOpenSections] = useState({
+    issues: true,
+    interventions: true,
+    results: false,
+    conclusion: true
+  })
+
+  const toggleSection = (section: keyof typeof openSections) => {
+    setOpenSections(prev => ({ ...prev, [section]: !prev[section] }))
+  }
+
+  const issues = extraction.issues || []
+  const interventions = extraction.interventions || []
+  const conclusion = extraction.conclusion
+
+  return (
+    <div className="space-y-4">
+      {/* Issues Section */}
+      <Collapsible open={openSections.issues} onOpenChange={() => toggleSection('issues')}>
+        <CollapsibleTrigger asChild>
+          <Card className="cursor-pointer hover:bg-gray-50 border-red-200">
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="h-4 w-4 text-red-600" />
+                  <span className="text-red-900 font-medium">Issues & Problems ({issues.length})</span>
+                </div>
+                {openSections.issues ? 
+                  <ChevronDown className="h-4 w-4 text-gray-500" /> : 
+                  <ChevronRight className="h-4 w-4 text-gray-500" />
+                }
+              </div>
+            </CardContent>
+          </Card>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="space-y-3 mt-2">
+            {issues.map((issue, index: number) => (
+              <Card key={issue.idx || index} className="border-red-100">
+                <CardContent className="p-4">
+                  <div className="flex items-start gap-3">
+                    <div className="w-6 h-6 bg-red-100 rounded-full flex items-center justify-center flex-shrink-0">
+                      <span className="text-red-700 font-medium text-sm">{issue.idx !== undefined ? issue.idx : index + 1}</span>
+                    </div>
+                    <div className="flex-1">
+                      <h5 className="font-medium text-red-900 mb-1">{issue.label}</h5>
+                      <p className="text-red-700 text-sm mb-2">{issue.explanation}</p>
+                      {issue.supporting_quote && (
+                        <blockquote className="text-red-600 text-xs italic border-l-4 border-red-200 pl-3">
+                          &ldquo;{issue.supporting_quote}&rdquo;
+                        </blockquote>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+            {issues.length === 0 && (
+              <p className="text-gray-500 text-sm italic">No issues identified in this document.</p>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Interventions & Results Section */}
+      <Collapsible open={openSections.interventions} onOpenChange={() => toggleSection('interventions')}>
+        <CollapsibleTrigger asChild>
+          <Card className="cursor-pointer hover:bg-gray-50 border-blue-200">
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Target className="h-4 w-4 text-blue-600" />
+                  <span className="text-blue-900 font-medium">Interventions & Results ({interventions.length})</span>
+                </div>
+                {openSections.interventions ? 
+                  <ChevronDown className="h-4 w-4 text-gray-500" /> : 
+                  <ChevronRight className="h-4 w-4 text-gray-500" />
+                }
+              </div>
+            </CardContent>
+          </Card>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="space-y-4 mt-2">
+            {interventions.map((intervention, index: number) => (
+              <Card key={intervention.idx || index} className="border-blue-100">
+                <CardContent className="p-4">
+                  <div className="space-y-3">
+                    {/* Intervention Header */}
+                    <div className="flex items-start gap-3">
+                      <div className="w-6 h-6 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0">
+                        <span className="text-blue-700 font-medium text-sm">{intervention.idx !== undefined ? intervention.idx : index + 1}</span>
+                      </div>
+                      <div className="flex-1">
+                        <h5 className="font-medium text-blue-900 mb-1">{intervention.name}</h5>
+                        <p className="text-blue-700 text-sm mb-2">{intervention.description}</p>
+                        
+                        {/* Intervention Details */}
+                        <div className="flex gap-2 mb-2">
+                          <Badge variant="outline" className="text-xs bg-blue-50">
+                            {intervention.type}
+                          </Badge>
+                          {intervention.country && (
+                            <Badge variant="outline" className="text-xs bg-blue-50">
+                              {intervention.country}
+                            </Badge>
+                          )}
+                          {intervention.study_type && (
+                            <Badge variant="outline" className="text-xs bg-blue-50">
+                              Study: {intervention.study_type}
+                            </Badge>
+                          )}
+                        </div>
+
+                        {/* Issues Addressed */}
+                        {intervention.addresses_issues && intervention.addresses_issues.length > 0 && (
+                          <div className="mb-2">
+                            <span className="text-xs text-blue-600 font-medium">Addresses issues: </span>
+                            {intervention.addresses_issues.map((issueIdx: number) => {
+                              const relatedIssue = issues.find(issue => issue.idx === issueIdx)
+                              const issueTitle = relatedIssue?.label || `Issue ${issueIdx}`
+                              return (
+                                <Badge key={issueIdx} variant="outline" className="text-xs mr-1 bg-red-50 text-red-700" title={issueTitle}>
+                                  #{issueIdx}: {issueTitle}
+                                </Badge>
+                              )
+                            })}
+                          </div>
+                        )}
+
+                        {/* Results for this intervention */}
+                        {intervention.results && intervention.results.length > 0 && (
+                          <div className="mt-3">
+                            <h6 className="font-medium text-green-900 text-sm mb-2 flex items-center gap-1">
+                              <TrendingUp className="h-3 w-3" />
+                              Results ({intervention.results.length})
+                            </h6>
+                            <div className="space-y-2">
+                              {intervention.results.map((result, resultIndex: number) => (
+                                <div key={resultIndex} className="bg-green-50 border-l-4 border-green-200 p-2 rounded">
+                                  <div className="flex items-center gap-2 mb-1">
+                                    <span className="font-medium text-green-900 text-sm">
+                                      {result.outcome_variable}
+                                    </span>
+                                    <Badge variant="outline" className="text-xs bg-green-100 text-green-700">
+                                      {result.effect_direction}
+                                    </Badge>
+                                  </div>
+                                  
+                                  {/* Quantitative measures */}
+                                  {(result.effect_size || result.effect_size_type || result.uncertainty || result.p_value) && (
+                                    <div className="mb-2">
+                                      {result.effect_size_type && (
+                                        <div className="text-xs text-green-600 mb-1">
+                                          <span className="font-medium">Effect Type: </span>
+                                          {result.effect_size_type}
+                                        </div>
+                                      )}
+                                      {result.effect_size && (
+                                        <div className="text-xs text-green-600 mb-1">
+                                          <span className="font-medium">Effect Size: </span>
+                                          {result.effect_size}
+                                        </div>
+                                      )}
+                                      {result.uncertainty && (
+                                        <div className="text-xs text-green-600 mb-1">
+                                          <span className="font-medium">Uncertainty: </span>
+                                          ±{result.uncertainty}
+                                        </div>
+                                      )}
+                                      {result.p_value && (
+                                        <div className="text-xs text-green-600 mb-1">
+                                          <span className="font-medium">P-value: </span>
+                                          {result.p_value}
+                                        </div>
+                                      )}
+                                    </div>
+                                  )}
+                                  
+                                  {/* Population information */}
+                                  {result.population_measured && (
+                                    <div className="mb-2">
+                                      <div className="text-xs text-green-600 mb-1">
+                                        <span className="font-medium">Population: </span>
+                                        {result.population_measured}
+                                      </div>
+                                    </div>
+                                  )}
+                                  
+                                  <p className="text-green-700 text-xs">{result.result_text}</p>
+                                  {result.supporting_quote && (
+                                    <blockquote className="text-green-600 text-xs italic mt-1">
+                                      &ldquo;{result.supporting_quote}&rdquo;
+                                    </blockquote>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+            {interventions.length === 0 && (
+              <p className="text-gray-500 text-sm italic">No interventions identified in this document.</p>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Conclusion Section */}
+      {conclusion && (
+        <Collapsible open={openSections.conclusion} onOpenChange={() => toggleSection('conclusion')}>
+          <CollapsibleTrigger asChild>
+            <Card className="cursor-pointer hover:bg-gray-50 border-purple-200">
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <FileText className="h-4 w-4 text-purple-600" />
+                    <span className="text-purple-900 font-medium">Conclusion</span>
+                  </div>
+                  {openSections.conclusion ? 
+                    <ChevronDown className="h-4 w-4 text-gray-500" /> : 
+                    <ChevronRight className="h-4 w-4 text-gray-500" />
+                  }
+                </div>
+              </CardContent>
+            </Card>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <Card className="border-purple-100 mt-2">
+              <CardContent className="p-4">
+                <h5 className="font-medium text-purple-900 mb-2">{conclusion.top_line_summary}</h5>
+                <p className="text-purple-700 text-sm mb-3">{conclusion.detailed_explanation}</p>
+                {conclusion.supporting_quote && (
+                  <blockquote className="text-purple-600 text-xs italic border-l-4 border-purple-200 pl-3">
+                    &ldquo;{conclusion.supporting_quote}&rdquo;
+                  </blockquote>
+                )}
+              </CardContent>
+            </Card>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  )
+}
+
+export default function ExtractionsPage() {
+  const router = useRouter()
+  const [documents, setDocuments] = useState<AnalysisDocument[]>([])
+  const [loadingData, setLoadingData] = useState(false)
+  const [dataError, setDataError] = useState<string | null>(null)
+  
+  // Document detail view state
+  const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(null)
+  const [documentDetail, setDocumentDetail] = useState<DocumentDetailResult | null>(null)
+  const [loadingDocumentDetail, setLoadingDocumentDetail] = useState(false)
+  const [documentDetailError, setDocumentDetailError] = useState<string | null>(null)
+
+  const { activeProject } = useAnalysisProjectStore()
+  const { fetchWithAuth, getDocumentExtraction } = useAPI()
+
+  // Use only active project ID
+  const effectiveProjectId = activeProject?.id || ''
+
+  // Load documents data
+  const loadData = useCallback(async () => {
+    if (!effectiveProjectId) return
+
+    setLoadingData(true)
+    setDataError(null)
+
+    try {
+      const docsResponse = await fetchWithAuth(`/api/analysis-projects/${effectiveProjectId}/documents`)
+      setDocuments(docsResponse.documents || [])
+    } catch (error) {
+      console.error('Failed to load project documents:', error)
+      setDataError(error instanceof Error ? error.message : 'Failed to load data')
+    } finally {
+      setLoadingData(false)
+    }
+  }, [effectiveProjectId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load data when project changes
+  useEffect(() => {
+    if (effectiveProjectId) {
+      loadData()
+    }
+  }, [effectiveProjectId, loadData])
+
+  // Load document detail extraction
+  const loadDocumentDetail = useCallback(async (documentId: string) => {
+    if (!effectiveProjectId) return
+    
+    setLoadingDocumentDetail(true)
+    setDocumentDetailError(null)
+    setSelectedDocumentId(documentId)
+    
+    try {
+      const result = await getDocumentExtraction(effectiveProjectId, documentId)
+      setDocumentDetail(result)
+    } catch (error) {
+      console.error('Failed to load document detail:', error)
+      setDocumentDetailError(error instanceof Error ? error.message : 'Failed to load document detail')
+    } finally {
+      setLoadingDocumentDetail(false)
+    }
+  }, [effectiveProjectId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Close document detail view
+  const closeDocumentDetail = () => {
+    setSelectedDocumentId(null)
+    setDocumentDetail(null)
+    setDocumentDetailError(null)
+  }
+
+  const goBackToResults = () => {
+    router.push('/v2/results')
+  }
+
+  return (
+    <div className="flex-1 flex flex-col">
+      {/* Header */}
+      <div className="border-b border-slate-200 bg-white px-8 py-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="flex items-center gap-4 mb-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={goBackToResults}
+                className="flex items-center gap-2"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to Results
+              </Button>
+            </div>
+            <h1 className="text-3xl font-bold text-slate-900 flex items-center gap-3">
+              Extractions
+            </h1>
+            <p className="text-slate-600 mt-1">
+              {activeProject ? (
+                <>Project: {activeProject.title}</>
+              ) : (
+                <>No Project Selected</>
+              )}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="flex-1 bg-slate-50 p-6">
+        <div className="max-w-6xl mx-auto">
+          {/* Show empty state if no project is selected */}
+          {!effectiveProjectId && (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center p-8">
+                <FileText className="h-16 w-16 text-slate-400 mx-auto mb-4" />
+                <h3 className="text-lg font-medium text-slate-900 mb-2">No Project Selected</h3>
+                <p className="text-slate-600 mb-6">
+                  Please select a project to view document extractions.
+                </p>
+                <Button onClick={() => router.push('/v2/projects')} variant="outline">
+                  <FileText className="h-4 w-4 mr-2" />
+                  View Projects
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Document List */}
+          {effectiveProjectId && (
+            <>
+              {loadingData ? (
+                <div className="flex items-center justify-center py-12">
+                  <div className="text-center">
+                    <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
+                    <p className="text-slate-600">Loading documents...</p>
+                  </div>
+                </div>
+              ) : dataError ? (
+                <div className="text-center py-12">
+                  <AlertCircle className="h-12 w-12 text-red-400 mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-slate-900 mb-2">Error Loading Data</h3>
+                  <p className="text-slate-600">{dataError}</p>
+                </div>
+              ) : documents.length > 0 ? (
+                <div className="space-y-4">
+                  <div className="space-y-3">
+                    {documents.map((doc) => {
+                      const isExpanded = selectedDocumentId === doc.id
+                      const handleCardClick = (e: React.MouseEvent) => {
+                        // Don't trigger if clicking on a link
+                        if ((e.target as HTMLElement).closest('a')) {
+                          return
+                        }
+                        
+                        if (isExpanded) {
+                          closeDocumentDetail()
+                        } else {
+                          loadDocumentDetail(doc.id)
+                        }
+                      }
+                      
+                      return (
+                        <Card 
+                          key={doc.id} 
+                          className={`border-slate-200 cursor-pointer transition-all hover:shadow-md ${
+                            isExpanded ? 'ring-2 ring-blue-300 bg-blue-50' : ''
+                          }`}
+                          onClick={handleCardClick}
+                        >
+                          <CardContent className="p-4">
+                            {/* Card Header - Always Visible */}
+                            <div className="flex items-start justify-between">
+                              <div className="flex-1">
+                                <h3 className="font-semibold text-slate-900 mb-2">
+                                  {doc.landing_page_url ? (
+                                    <a 
+                                      href={doc.landing_page_url} 
+                                      target="_blank" 
+                                      rel="noopener noreferrer"
+                                      className="text-blue-600 hover:text-blue-800 hover:underline"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      {doc.title || 'Untitled Document'}
+                                    </a>
+                                  ) : (
+                                    doc.title || 'Untitled Document'
+                                  )}
+                                </h3>
+                                <div className="flex items-center gap-2 mb-2">
+                                  <Badge variant="outline" className="text-xs">
+                                    {doc.source || 'Unknown Source'}
+                                  </Badge>
+                                  {doc.year && (
+                                    <Badge variant="outline" className="text-xs">
+                                      {doc.year}
+                                    </Badge>
+                                  )}
+                                  {doc.is_relevant !== null && (
+                                    <Badge 
+                                      variant="outline" 
+                                      className={`text-xs ${
+                                        doc.is_relevant 
+                                          ? 'bg-green-100 text-green-700' 
+                                          : 'bg-red-100 text-red-700'
+                                      }`}
+                                    >
+                                      {doc.is_relevant ? 'Relevant' : 'Not Relevant'}
+                                    </Badge>
+                                  )}
+                                  {/* Extraction Status Indicator */}
+                                  {doc.extraction_status && (
+                                    <Badge 
+                                      variant="outline" 
+                                      className={`text-xs ${
+                                        doc.extraction_status === 'success' 
+                                          ? 'bg-blue-100 text-blue-700' 
+                                          : doc.extraction_status === 'failed'
+                                          ? 'bg-red-100 text-red-700'
+                                          : doc.extraction_status === 'skipped'
+                                          ? 'bg-yellow-100 text-yellow-700'
+                                          : 'bg-gray-100 text-gray-700'
+                                      }`}
+                                    >
+                                      {doc.extraction_status === 'success' ? '✓ Extracted' :
+                                       doc.extraction_status === 'failed' ? '✗ Failed' :
+                                       doc.extraction_status === 'skipped' ? '⊘ Skipped' :
+                                       `✓ ${doc.extraction_status}`}
+                                    </Badge>
+                                  )}
+                                </div>
+                                {!isExpanded && doc.abstract_or_summary && (
+                                  <p className="text-slate-600 text-sm line-clamp-2 mb-2">
+                                    {doc.abstract_or_summary}
+                                  </p>
+                                )}
+                              </div>
+                              <div className="flex items-center gap-2 ml-4">
+                                {isExpanded ? (
+                                  <ChevronDown className="h-4 w-4 text-slate-400" />
+                                ) : (
+                                  <ChevronRight className="h-4 w-4 text-slate-400" />
+                                )}
+                              </div>
+                            </div>
+                            
+                            {/* Expanded Content */}
+                            {isExpanded && (
+                              <div className="mt-4 pt-4 border-t border-slate-200">
+                                {loadingDocumentDetail ? (
+                                  <div className="flex items-center justify-center py-8">
+                                    <div className="text-center">
+                                      <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2 text-blue-600" />
+                                      <p className="text-blue-700 text-sm">Loading document details...</p>
+                                    </div>
+                                  </div>
+                                ) : documentDetailError ? (
+                                  <div className="text-center py-4">
+                                    <AlertCircle className="h-8 w-8 text-red-400 mx-auto mb-2" />
+                                    <p className="text-red-600 text-sm">{documentDetailError}</p>
+                                  </div>
+                                ) : documentDetail && documentDetail.extraction ? (
+                                  <DocumentDetailView extraction={documentDetail.extraction} />
+                                ) : documentDetail ? (
+                                  <div className="text-center py-4">
+                                    <FileText className="h-8 w-8 text-gray-400 mx-auto mb-2" />
+                                    <p className="text-gray-600 text-sm">No extraction data available for this document</p>
+                                  </div>
+                                ) : null}
+                              </div>
+                            )}
+                          </CardContent>
+                        </Card>
+                      )
+                    })}
+                  </div>
+                </div>
+              ) : (
+                <div className="text-center py-12">
+                  <FileText className="h-12 w-12 text-slate-400 mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-slate-900 mb-2">No Documents Available</h3>
+                  <p className="text-slate-600">Documents will appear here once the analysis is processed.</p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/chatbot/V2ChatInterface.tsx
+++ b/frontend/components/chatbot/V2ChatInterface.tsx
@@ -10,6 +10,22 @@ import ReactMarkdown from 'react-markdown'
 import { useUser } from '@clerk/nextjs'
 import Image from 'next/image'
 
+// Helper function to process in-text citations
+function processInTextCitations(content: string, references: { url?: string }[]): string {
+  // Replace [Document X] with clickable [X] links
+  return content.replace(/\[Document (\d+)\]/g, (match, docNum) => {
+    const refIndex = parseInt(docNum) - 1
+    if (refIndex >= 0 && refIndex < references.length) {
+      const ref = references[refIndex]
+      const url = ref.url
+      if (url) {
+        return `[[${docNum}]](${url})`
+      }
+    }
+    return `[${docNum}]`
+  })
+}
+
 interface V2ChatInterfaceProps {
   className?: string
   placeholder?: string
@@ -174,37 +190,99 @@ export function V2ChatInterface({
               }`}
             >
               <div className="prose prose-sm max-w-none">
-                <ReactMarkdown>{message.content}</ReactMarkdown>
+                <ReactMarkdown
+                  components={{
+                    a: ({ href, children, ...props }) => (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:text-blue-800 hover:underline"
+                        {...props}
+                      >
+                        {children}
+                      </a>
+                    ),
+                  }}
+                >
+                  {message.role === 'assistant' && message.references
+                    ? processInTextCitations(message.content, message.references)
+                    : message.content
+                  }
+                </ReactMarkdown>
               </div>
               
               {/* Show references for assistant messages */}
               {message.role === 'assistant' && message.references && (
                 <div className="mt-3 pt-3 border-t border-gray-200">
-                  <p className="text-xs font-medium text-gray-600 mb-2">References:</p>
                   <div className="space-y-2">
-                    {message.references.map((ref, idx) => (
-                      <div key={ref.document_id} className="text-xs">
-                        <div className="font-medium text-gray-800">
-                          [{idx + 1}] {ref.title}
-                        </div>
-                        {ref.authors && ref.authors.length > 0 && (
-                          <div className="text-gray-600">
-                            {ref.authors.slice(0, 3).join(', ')}
-                            {ref.authors.length > 3 && ' et al.'}
+                    {message.references.map((ref, idx) => {
+                      // Helper function to process and truncate authors
+                      const formatAuthors = (authors: string[] | string) => {
+                        if (!authors) return ''
+                        
+                        let authorText = ''
+                        
+                        if (Array.isArray(authors)) {
+                          authorText = authors.join(', ')
+                        } else {
+                          authorText = String(authors)
+                        }
+                        
+                        // Simple approach: strip all brackets, quotes, and extra spaces
+                        authorText = authorText
+                          .replace(/[\[\]'"]/g, '') // Remove all brackets and quotes
+                          .replace(/,\s*,/g, ',') // Fix double commas
+                          .replace(/^\s*,|,\s*$/g, '') // Remove leading/trailing commas
+                          .trim()
+                        
+                        // Truncate if too long
+                        if (authorText.length <= 60) return authorText
+                        
+                        // Find the last complete author name within ~50 chars
+                        const truncated = authorText.substring(0, 50)
+                        const lastComma = truncated.lastIndexOf(', ')
+                        if (lastComma > 20) {
+                          return truncated.substring(0, lastComma) + ' et al.'
+                        }
+                        return truncated + '...'
+                      }
+
+                      return (
+                        <div key={ref.document_id} className="text-xs">
+                          <div className="font-medium text-gray-800">
+                            [{idx + 1}]{' '}
+                            {ref.url ? (
+                              <a
+                                href={ref.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:text-blue-800 hover:underline inline-flex items-center gap-1"
+                              >
+                                {ref.title}
+                                <ExternalLink className="h-3 w-3" />
+                              </a>
+                            ) : (
+                              ref.title
+                            )}
+                            {(ref.published_date || ref.year) && (
+                              <span className="font-normal text-gray-600">
+                                {' '}({
+                                  ref.published_date 
+                                    ? new Date(ref.published_date).getFullYear()
+                                    : ref.year
+                                })
+                              </span>
+                            )}
                           </div>
-                        )}
-                        {ref.url && (
-                          <a
-                            href={ref.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800"
-                          >
-                            View document <ExternalLink className="h-3 w-3" />
-                          </a>
-                        )}
-                      </div>
-                    ))}
+                          {ref.authors && (
+                            <div className="text-gray-600">
+                              {formatAuthors(ref.authors)}
+                            </div>
+                          )}
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               )}

--- a/frontend/components/search/papers-table.tsx
+++ b/frontend/components/search/papers-table.tsx
@@ -5,6 +5,7 @@ import { Table } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import type { Paper } from '@/types/search'
 import { Check, X } from 'lucide-react'
+import { Tooltip } from '@/components/ui/tooltip'
 
 interface PapersTableProps {
   papers: Paper[]
@@ -58,13 +59,31 @@ export function PapersTable({ papers }: PapersTableProps) {
 
 
 
+  // Helper function to get study type rank and description (reversed: 10 = strongest)
+  const getStudyTypeInfo = (studyType?: string) => {
+    if (!studyType) return { rank: 0, sortRank: 999, description: 'Unknown study type' }
+    const type = studyType.trim().toLowerCase()
+    
+    if (type === 'g') return { rank: 10, sortRank: 1, description: 'Randomized Controlled Trial (highest quality)' }
+    if (type === 'h') return { rank: 9, sortRank: 2, description: 'Meta-analysis' }
+    if (type === 'f') return { rank: 8, sortRank: 3, description: 'Quasi-experimental study' }
+    if (type === 'e') return { rank: 7, sortRank: 4, description: 'Comparison of outcomes in treated group' }
+    if (type === 'd') return { rank: 6, sortRank: 5, description: 'Study measures outcome pre and post' }
+    if (type === 'c') return { rank: 5, sortRank: 6, description: 'Cross-sectional with control variables' }
+    if (type === 'b') return { rank: 4, sortRank: 7, description: 'Pre/post study (no control group)' }
+    if (type === 'a') return { rank: 3, sortRank: 8, description: 'Purely cross-sectional study' }
+    if (type === 'i') return { rank: 2, sortRank: 9, description: 'Policy recommendation/theoretical modeling' }
+    if (type === 'j') return { rank: 1, sortRank: 10, description: 'News article/opinion piece (lowest quality)' }
+    return { rank: 0, sortRank: 999, description: 'Unknown study type' }
+  }
+
   // Combine base columns with extracted field columns
   const columns: ColumnsType<DataType> = [
     {
       title: 'Year',
       dataIndex: 'publication_year',
       key: 'publication_year',
-      width: '8%',
+      width: '6%',
       sorter: (a, b) => a.publication_year - b.publication_year,
       render: (text) => (
         <span>{text && text > 0 ? text : 'Unknown'}</span>
@@ -74,9 +93,9 @@ export function PapersTable({ papers }: PapersTableProps) {
       title: 'Title',
       dataIndex: 'title',
       key: 'title',
-      width: '25%',
+      width: '20%',
       render: (text, record) => {
-        const maxLength = 100 // Truncate after 100 characters for titles
+        const maxLength = 80 // Truncate after 80 characters for titles
         // Prioritize landing_page_url, fallback to DOI, then overton_url
         const linkUrl = record.landing_page_url || (record.doi ? `${record.doi}` : record.overton_url)
         
@@ -108,7 +127,7 @@ export function PapersTable({ papers }: PapersTableProps) {
       title: 'Top Line',
       dataIndex: 'top_line',
       key: 'top_line',
-      width: '78%',
+      width: '20%',
       render: (text, record) => (
         <div className="text-sm text-gray-700 whitespace-normal leading-tight">
           {record.top_line || 'No summary available'}
@@ -119,7 +138,7 @@ export function PapersTable({ papers }: PapersTableProps) {
       title: 'Country',
       dataIndex: 'source_country',
       key: 'source_country',
-      width: '12%',
+      width: '8%',
       sorter: (a, b) => (a.source_country || 'Academic').localeCompare(b.source_country || 'Academic'),
       render: (text) => (
         <span>{text || 'Academic'}</span>
@@ -129,11 +148,11 @@ export function PapersTable({ papers }: PapersTableProps) {
       title: 'Authors',
       dataIndex: 'authorsDisplay',
       key: 'authors',
-      width: '20%',
+      width: '12%',
       sorter: (a, b) => a.authorsDisplay.localeCompare(b.authorsDisplay),
       render: (text, record) => {
         const authorsText = record.authors?.join(', ') || 'Unknown'
-        const maxLength = 80 // Truncate after 80 characters
+        const maxLength = 60 // Truncate after 60 characters
         
         return (
           <div className="text-sm text-gray-700 whitespace-normal leading-tight" title={authorsText}>
@@ -149,7 +168,7 @@ export function PapersTable({ papers }: PapersTableProps) {
       title: 'Citations',
       dataIndex: 'cited_by_count',
       key: 'cited_by_count',
-      width: '8%',
+      width: '6%',
       sorter: (a, b) => a.cited_by_count - b.cited_by_count,
       render: (text) => (
         <span className={text > 100 ? 'text-green-600 font-semibold' : ''}>
@@ -158,11 +177,61 @@ export function PapersTable({ papers }: PapersTableProps) {
       ),
     },
     {
+      title: 'Strength',
+      dataIndex: 'study_strength',
+      key: 'study_strength',
+      width: '6%',
+      sorter: (a, b) => {
+        const aSortRank = getStudyTypeInfo(a.study_strength).sortRank
+        const bSortRank = getStudyTypeInfo(b.study_strength).sortRank
+        return aSortRank - bSortRank // Lower sortRank = stronger study (for sorting)
+      },
+      render: (text, record) => {
+        const studyType = record.study_strength
+        if (!studyType) {
+          return <span className="text-gray-400 text-xs">-</span>
+        }
+        
+        const { rank, description } = getStudyTypeInfo(studyType)
+        
+        return (
+          <Tooltip content={description}>
+            <span className="inline-block px-2 py-1 rounded text-xs font-medium text-gray-700 bg-gray-100 cursor-help">
+              {rank === 0 ? '-' : rank}
+            </span>
+          </Tooltip>
+        )
+      },
+    },
+    {
+      title: 'Sample Size',
+      dataIndex: 'sample_size',
+      key: 'sample_size',
+      width: '8%',
+      sorter: (a, b) => (a.sample_size || 0) - (b.sample_size || 0),
+      render: (text, record) => {
+        const sampleSize = record.sample_size
+        if (!sampleSize || sampleSize <= 0) {
+          return <span className="text-gray-400 text-xs">-</span>
+        }
+        
+        // Format large numbers with commas
+        const formatted = sampleSize.toLocaleString()
+        
+        return (
+          <span className="text-sm text-gray-700">
+            {formatted}
+          </span>
+        )
+      },
+    },
+    {
       title: 'Relevance',
       dataIndex: 'confidence',
       key: 'confidence',
-      width: '10%',
+      width: '8%',
       sorter: (a, b) => (a.confidence || 0) - (b.confidence || 0),
+      defaultSortOrder: 'descend',
       render: (text, record) => (
         <div className="flex items-center gap-1">
           <span>{record.confidence ? (record.confidence * 100).toFixed(1) : 'N/A'}</span>
@@ -175,23 +244,26 @@ export function PapersTable({ papers }: PapersTableProps) {
       ),
     },
     {
-      title: 'Full Text',
-      dataIndex: 'full_text_available',
-      key: 'full_text_available',
+      title: 'Source',
+      dataIndex: 'source',
+      key: 'source',
       width: '6%',
-      sorter: (a, b) => {
-        const aVal = a.full_text_available === true ? 1 : a.full_text_available === false ? 0 : -1
-        const bVal = b.full_text_available === true ? 1 : b.full_text_available === false ? 0 : -1
-        return aVal - bVal
-      },
+      sorter: (a, b) => (a.source || '').localeCompare(b.source || ''),
       render: (text, record) => {
-        if (record.full_text_available === true) {
-          return <span className="text-green-600 font-semibold">✓</span>
-        } else if (record.full_text_available === false) {
-          return <span className="text-red-600">✗</span>
-        } else {
-          return <span className="text-gray-400">?</span>
+        const source = record.source || 'unknown'
+        let displayText = source
+        
+        if (source === 'openalex') {
+          displayText = 'OpenAlex'
+        } else if (source === 'overton') {
+          displayText = 'Overton'
         }
+        
+        return (
+          <span className="text-sm text-gray-700">
+            {displayText}
+          </span>
+        )
       },
     },
     {
@@ -199,26 +271,51 @@ export function PapersTable({ papers }: PapersTableProps) {
       dataIndex: 'extraction_status',
       key: 'extraction_status',
       width: '8%',
-      sorter: (a, b) => (a.extraction_status || 'unknown').localeCompare(b.extraction_status || 'unknown'),
+      sorter: (a, b) => {
+        const getStatusPriority = (status: string, textSource?: string) => {
+          if (status === 'completed') return textSource === 'full_text' ? 3 : 2
+          if (status === 'skipped') return 1
+          return 0 // failed, not processed, unknown
+        }
+        
+        const aPriority = getStatusPriority(a.extraction_status || 'unknown', a.text_source)
+        const bPriority = getStatusPriority(b.extraction_status || 'unknown', b.text_source)
+        return aPriority - bPriority
+      },
       render: (text, record) => {
         const status = record.extraction_status || 'unknown'
+        const textSource = record.text_source
+        
         let color = 'text-gray-500'
         let bgColor = 'bg-gray-100'
+        let displayText = 'not processed'
         
-        if (status === 'success') {
+        if (status === 'completed') {
           color = 'text-green-700'
           bgColor = 'bg-green-100'
+          if (textSource === 'full_text') {
+            displayText = 'completed: full-text'
+          } else if (textSource === 'abstract') {
+            displayText = 'completed: abstract'
+          } else {
+            displayText = 'completed'
+          }
         } else if (status === 'failed') {
-          color = 'text-red-700'
-          bgColor = 'bg-red-100'
+          color = 'text-gray-600'
+          bgColor = 'bg-gray-100'
+          displayText = 'not processed'
         } else if (status === 'skipped') {
           color = 'text-yellow-700'
           bgColor = 'bg-yellow-100'
+          displayText = 'skipped'
+        } else {
+          // unknown or any other status
+          displayText = 'not processed'
         }
         
         return (
           <span className={`inline-block px-2 py-1 rounded text-xs font-medium ${color} ${bgColor}`}>
-            {status}
+            {displayText}
           </span>
         )
       },
@@ -243,6 +340,7 @@ export function PapersTable({ papers }: PapersTableProps) {
         size="small"
         bordered
         rowClassName={(record) => record.is_relevant ? 'bg-green-50' : 'bg-white'}
+        sortDirections={['descend', 'ascend']}
       />
     </div>
   )

--- a/frontend/components/search/papers-table.tsx
+++ b/frontend/components/search/papers-table.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { Table } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import type { Paper } from '@/types/search'
+import { Check, X } from 'lucide-react'
 
 interface PapersTableProps {
   papers: Paper[]
@@ -160,10 +161,17 @@ export function PapersTable({ papers }: PapersTableProps) {
       title: 'Relevance',
       dataIndex: 'confidence',
       key: 'confidence',
-      width: '8%',
+      width: '10%',
       sorter: (a, b) => (a.confidence || 0) - (b.confidence || 0),
       render: (text, record) => (
-        <span>{record.confidence ? (record.confidence * 100).toFixed(1) : 'N/A'}</span>
+        <div className="flex items-center gap-1">
+          <span>{record.confidence ? (record.confidence * 100).toFixed(1) : 'N/A'}</span>
+          {record.is_relevant ? (
+            <Check className="h-3 w-3 text-green-600" />
+          ) : (
+            <X className="h-3 w-3 text-red-500" />
+          )}
+        </div>
       ),
     },
     {
@@ -221,11 +229,6 @@ export function PapersTable({ papers }: PapersTableProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
-        <div className="text-sm text-gray-500">
-          Showing {tableData.length} results
-        </div>
-      </div>
       
       <Table
         columns={columns}

--- a/frontend/lib/v2ChatStore.ts
+++ b/frontend/lib/v2ChatStore.ts
@@ -15,6 +15,8 @@ export interface DocumentReference {
   doi?: string
   url?: string
   chunk_type?: string
+  published_date?: string
+  year?: number
 }
 
 export interface ChatResponse {

--- a/frontend/types/search.ts
+++ b/frontend/types/search.ts
@@ -40,6 +40,10 @@ export interface SearchParams {
     // Processing status fields
     full_text_available?: boolean
     extraction_status?: string
+    text_source?: string  // "full_text" or "abstract" - what was used for extraction
+    study_strength?: string  // strongest study type letter from interventions
+    sample_size?: number  // largest sample size from interventions
+    source?: string  // "openalex" or "overton"
     // Extracted fields (dynamically added based on extraction_fields parameter)
     [key: string]: string | number | boolean | string[] | undefined
   }


### PR DESCRIPTION
# UI & Workflow Improvements

## 0. Overall
- [x] Adjust workflow so that the first page after triggering search is **Evidence – Documents**
- [x] Move **“Extractions”** tab under **Test** in the sidebar  
- [x] Cleaner UI: polish the landing page  
- [x] Lead users to **v2 pages** after login (instead of the old dashboard)  

---

## 2. Evidence – Documents
- [x] Hide non-relevant documents by default; add a toggle to show them if wanted  
- [x] Add **study type, sample size, and source (Overton/OpenAlex)** to the documents table to make spotting important works easier  

---

## 5. RAG Chatbot
- [x] Cleaner UI: show references in a more **compact way**  