### PR TITLE
Summary evidence tab

### DIFF
--- a/backend/app/api/projects_v2.py
+++ b/backend/app/api/projects_v2.py
@@ -73,8 +73,8 @@ async def get_synthesis_summary(
         if cached:
             return cached
 
-        # If analysis still running, return appropriate response
-        if project_status == "running":
+        # If analysis still running or synthesising, return appropriate response
+        if project_status in ["running", "synthesising"]:
             # Check synthesis status
             synthesis_status = await get_synthesis_status(project_id)
 
@@ -84,11 +84,17 @@ async def get_synthesis_summary(
                     detail="Synthesis is running. Please wait for completion.",
                 )
             elif synthesis_status == "none":
-                # Analysis still running, synthesis not started
-                raise HTTPException(
-                    status_code=202,
-                    detail="Analysis is still running. Synthesis will start automatically when analysis completes.",
-                )
+                # Analysis still running, synthesis not started yet
+                if project_status == "running":
+                    raise HTTPException(
+                        status_code=202,
+                        detail="Analysis is still running. Synthesis will start automatically when analysis completes.",
+                    )
+                else:  # project_status == "synthesising"
+                    raise HTTPException(
+                        status_code=202,
+                        detail="Synthesis is starting. Please wait for completion.",
+                    )
 
         # For completed projects without cache, try to trigger synthesis (fallback)
         if project_status == "completed":

--- a/backend/app/api/projects_v2.py
+++ b/backend/app/api/projects_v2.py
@@ -2096,33 +2096,38 @@ async def download_documents_csv(
 async def get_project_feedback(
     project_id: str, current_user: CurrentUser = Depends(get_current_user)
 ):
-    """Get user feedback for a specific project"""
+    """Get user feedback for a specific project from the user_feedback table"""
     try:
-        # Get project with user feedback
+        # Check if project exists
         project_result = (
             vectorization_service.supabase.table("analysis_projects")
-            .select("user_feedback")
+            .select("id")
             .eq("id", project_id)
             .execute()
         )
-
         if not project_result.data:
             raise HTTPException(status_code=404, detail="Project not found")
 
-        user_feedback = project_result.data[0].get("user_feedback")
-
-        # Filter feedback for current user
-        if user_feedback and user_feedback.get("user_id") == current_user.user_id:
+        # Get feedback for this user and project
+        feedback_result = (
+            vectorization_service.supabase.table("user_feedback")
+            .select("rating, comment, updated_at")
+            .eq("project_id", project_id)
+            .eq("user_id", current_user.user_id)
+            .order("updated_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        if feedback_result.data and len(feedback_result.data) > 0:
+            feedback = feedback_result.data[0]
             return {
                 "feedback": {
-                    "rating": user_feedback.get("rating"),
-                    "comment": user_feedback.get("comment", ""),
-                    "updated_at": user_feedback.get("updated_at"),
+                    "rating": feedback.get("rating"),
+                    "comment": feedback.get("comment", ""),
+                    "updated_at": feedback.get("updated_at"),
                 }
             }
-
         return {"feedback": None}
-
     except HTTPException:
         raise
     except Exception as e:
@@ -2136,22 +2141,19 @@ async def save_project_feedback(
     request: dict,
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    """Save or update user feedback for a specific project"""
+    """Save user feedback for a specific project as a new row in user_feedback table (no overwrite)"""
     try:
         # Validate request
         rating = request.get("rating")
         comment = request.get("comment", "").strip()
-
         if not isinstance(rating, int) or rating < 1 or rating > 5:
             raise HTTPException(
                 status_code=400, detail="Rating must be an integer between 1 and 5"
             )
-
         if len(comment) > 500:
             raise HTTPException(
                 status_code=400, detail="Comment must be 500 characters or less"
             )
-
         # Check if project exists
         project_result = (
             vectorization_service.supabase.table("analysis_projects")
@@ -2159,29 +2161,26 @@ async def save_project_feedback(
             .eq("id", project_id)
             .execute()
         )
-
         if not project_result.data:
             raise HTTPException(status_code=404, detail="Project not found")
-
-        # Prepare feedback data
+        # Insert new feedback row
         feedback_data = {
+            "project_id": project_id,
+            "user_id": current_user.user_id,
+            "user_email": getattr(current_user, "email", None),
+            "user_name": getattr(current_user, "name", None),
             "rating": rating,
             "comment": comment,
-            "user_id": current_user.user_id,
+            "created_at": datetime.utcnow().isoformat(),
             "updated_at": datetime.utcnow().isoformat(),
         }
-
-        # Update project with feedback
         result = (
-            vectorization_service.supabase.table("analysis_projects")
-            .update({"user_feedback": feedback_data})
-            .eq("id", project_id)
+            vectorization_service.supabase.table("user_feedback")
+            .insert(feedback_data)
             .execute()
         )
-
         if not result.data:
             raise HTTPException(status_code=500, detail="Failed to save feedback")
-
         return {
             "message": "Feedback saved successfully",
             "feedback": {
@@ -2190,7 +2189,6 @@ async def save_project_feedback(
                 "updated_at": feedback_data["updated_at"],
             },
         }
-
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/app/api/projects_v2.py
+++ b/backend/app/api/projects_v2.py
@@ -1381,8 +1381,10 @@ async def get_issue_intervention_navigator(
             predicted_impact = conclusion.get("predicted_impact", {}) or {}
 
             doc_scores[doc_id] = {
-                "impact_score": evidence_strength.get("stars"),
-                "evidence_score": predicted_impact.get("stars"),
+                "impact_score": predicted_impact.get("stars"),
+                "evidence_score": evidence_strength.get("stars"),
+                "impact_justification": predicted_impact.get("justification", ""),
+                "evidence_justification": evidence_strength.get("justification", ""),
             }
 
             # Get mappings from extraction results
@@ -1563,6 +1565,12 @@ async def get_issue_intervention_navigator(
                                         "evidence_score": doc_scores.get(
                                             doc.get("doc_id"), {}
                                         ).get("evidence_score"),
+                                        "impact_justification": doc_scores.get(
+                                            doc.get("doc_id"), {}
+                                        ).get("impact_justification", ""),
+                                        "evidence_justification": doc_scores.get(
+                                            doc.get("doc_id"), {}
+                                        ).get("evidence_justification", ""),
                                         "results": intervention_results,
                                         "source_documents": [
                                             {
@@ -1588,6 +1596,9 @@ async def get_issue_intervention_navigator(
                         {
                             "theme_name": intervention_theme_name,
                             "description": intervention_description,
+                            "impact_summary": intervention_theme.get(
+                                "impact_summary", ""
+                            ),
                             "frequency": len(shared_docs),
                             "avg_impact_score": round(avg_impact_score, 1)
                             if avg_impact_score

--- a/backend/app/services/analysis/storage.py
+++ b/backend/app/services/analysis/storage.py
@@ -389,8 +389,8 @@ class AnalysisStorageService:
                     storage_project_id, result.extractions_json_path
                 )
 
-            # 4. Mark project as completed
-            await self._mark_project_completed(storage_project_id)
+            # 4. Mark project as analysis completed (ready for synthesis)
+            await self._mark_analysis_completed(storage_project_id)
 
             logger.info(
                 f"Successfully stored analysis run {result.run_id} to project {storage_project_id}"
@@ -626,13 +626,13 @@ class AnalysisStorageService:
                 f"Successfully uploaded {len(extraction_items)} extraction items"
             )
 
-    async def _mark_project_completed(self, project_id: str) -> None:
-        """Mark analysis project as completed."""
+    async def _mark_analysis_completed(self, project_id: str) -> None:
+        """Mark analysis extraction as completed, ready for synthesis."""
         response = (
             self.supabase.table("analysis_projects")
             .update(
                 {
-                    "status": "completed",
+                    "status": "synthesising",
                 }
             )
             .eq("id", project_id)
@@ -640,9 +640,9 @@ class AnalysisStorageService:
         )
 
         if not response.data:
-            raise Exception("Failed to mark project as completed")
+            raise Exception("Failed to mark project as synthesising")
 
-        logger.info(f"Marked analysis project {project_id} as completed")
+        logger.info(f"Marked analysis project {project_id} as synthesising")
 
     async def _mark_project_failed(self, run_id: str, error_message: str) -> None:
         """Mark analysis project as failed."""

--- a/backend/supabase_alter_user_feedback_user_id_to_text.sql
+++ b/backend/supabase_alter_user_feedback_user_id_to_text.sql
@@ -1,0 +1,9 @@
+-- Change user_id column in user_feedback to text to support Clerk string IDs
+ALTER TABLE user_feedback
+    ALTER COLUMN user_id TYPE text USING user_id::text;
+
+-- Remove old foreign key constraint if it exists (optional, since auth.users may not be a uuid table)
+ALTER TABLE user_feedback DROP CONSTRAINT IF EXISTS user_feedback_user_id_fkey;
+
+-- Optionally, add a comment for clarity
+COMMENT ON COLUMN user_feedback.user_id IS 'Clerk user ID (text, not uuid)';

--- a/backend/supabase_create_user_feedback_table.sql
+++ b/backend/supabase_create_user_feedback_table.sql
@@ -1,0 +1,21 @@
+-- Create user_feedback table for storing project feedback as structured columns
+CREATE TABLE IF NOT EXISTS user_feedback (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id uuid REFERENCES analysis_projects(id) ON DELETE CASCADE,
+    user_id uuid REFERENCES auth.users(id),
+    user_email text,
+    user_name text,
+    rating integer NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    comment text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    -- Add any additional metadata columns as needed
+    -- e.g., feedback_type, context, etc.
+    CONSTRAINT fk_project FOREIGN KEY(project_id) REFERENCES analysis_projects(id)
+);
+
+-- Index for faster lookup by project
+CREATE INDEX IF NOT EXISTS idx_user_feedback_project_id ON user_feedback(project_id);
+
+-- Index for faster lookup by user
+CREATE INDEX IF NOT EXISTS idx_user_feedback_user_id ON user_feedback(user_id);

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -17,6 +17,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <base target="_blank" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       </head>
       <LayoutWrapper>
         {children}

--- a/frontend/app/v2/layout.tsx
+++ b/frontend/app/v2/layout.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Search, FileText, FolderOpen, Folder, Zap, ChevronRight, ChevronDown, HelpCircle, Target } from 'lucide-react'
+import { Search, FileText, FolderOpen, Folder, Zap, ChevronRight, ChevronDown, HelpCircle } from 'lucide-react'
 import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
 import { FeedbackButton } from '@/components/ui/feedback-button'
 import { FeedbackModal } from '@/components/ui/feedback-modal'
@@ -22,7 +22,6 @@ const sidebarItems = [
 const testItems = [
   { name: 'Test extraction', href: '/v2/test_extraction', icon: Zap },
   { name: 'Extractions', href: '/v2/text_extractions', icon: FileText },
-  { name: 'Interventions', href: '/v2/interventions', icon: Target },
 ]
 
 // const quickStats = [

--- a/frontend/app/v2/projects/page.tsx
+++ b/frontend/app/v2/projects/page.tsx
@@ -10,6 +10,8 @@ import { FolderOpen, Plus, Search, Edit, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useAPI } from '@/lib/api'
 import { useAnalysisProjectStore, AnalysisProject } from '@/lib/analysisProjectStore'
+import { Switch } from '@/components/ui/switch'
+import { useUser } from '@clerk/nextjs'
 
 export default function ProjectsPage() {
   const router = useRouter()
@@ -30,7 +32,7 @@ export default function ProjectsPage() {
     error,
     setError
   } = useAnalysisProjectStore()
-
+  const { user } = useUser()
 
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showInfoDialog, setShowInfoDialog] = useState(false)
@@ -38,6 +40,7 @@ export default function ProjectsPage() {
   const [isCreating, setIsCreating] = useState(false)
   const [editProjectDialog, setEditProjectDialog] = useState<AnalysisProject | null>(null)
   const [editForm, setEditForm] = useState({ title: '', description: '' })
+  const [showMyProjectsOnly, setShowMyProjectsOnly] = useState(false)
 
   useEffect(() => {
     loadProjects()
@@ -131,6 +134,21 @@ export default function ProjectsPage() {
     }
   }
 
+  // Determine the user's full name, email, and email username for filtering
+  const currentUserFullName = user?.fullName || ''
+  const currentUserEmail = user?.emailAddresses?.[0]?.emailAddress || ''
+  const currentUserEmailUsername = currentUserEmail.split('@')[0] || ''
+
+  // Filter projects if toggle is on (match by full name, email, or email username)
+  const displayedProjects = showMyProjectsOnly
+    ? projects.filter(
+        p =>
+          p.created_by_name === currentUserFullName ||
+          p.created_by_name === currentUserEmail ||
+          p.created_by_name === currentUserEmailUsername
+      )
+    : projects
+
   return (
     <div className="flex-1 flex flex-col">
       <div className="border-b border-slate-200 bg-white px-8 py-6">
@@ -144,7 +162,17 @@ export default function ProjectsPage() {
         <div className="max-w-6xl mx-auto">
           <div className="flex items-center justify-between mb-8">
             <h2 className="text-xl font-semibold text-slate-900"></h2>
-            <div className="flex gap-2">
+            <div className="flex gap-2 items-center">
+              <div className="flex items-center gap-2 mr-2">
+                <Switch
+                  checked={showMyProjectsOnly}
+                  onCheckedChange={setShowMyProjectsOnly}
+                  id="show-my-projects-switch"
+                />
+                <label htmlFor="show-my-projects-switch" className="text-sm text-slate-700 select-none cursor-pointer">
+                  Show my projects
+                </label>
+              </div>
               <Button 
                 onClick={() => setShowInfoDialog(true)}
                 variant="outline"
@@ -159,7 +187,7 @@ export default function ProjectsPage() {
             <div className="flex items-center justify-center py-12">
               <div className="text-slate-500">Loading projects...</div>
             </div>
-          ) : projects.length === 0 ? (
+          ) : displayedProjects.length === 0 ? (
             <div className="text-center py-12">
               <div className="bg-slate-50 rounded-lg p-8">
                 <FolderOpen className="h-12 w-12 text-slate-400 mx-auto mb-4" />
@@ -178,7 +206,7 @@ export default function ProjectsPage() {
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {projects.map((project) => (
+              {displayedProjects.map((project) => (
                 <Card 
                   key={project.id} 
                   className={`border-slate-200 hover:border-blue-300 transition-colors cursor-pointer ${
@@ -353,4 +381,4 @@ export default function ProjectsPage() {
       </main>
     </div>
   )
-} 
+}

--- a/frontend/app/v2/projects/page.tsx
+++ b/frontend/app/v2/projects/page.tsx
@@ -149,6 +149,16 @@ export default function ProjectsPage() {
       )
     : projects
 
+  // Helper: can the current user delete this project?
+  const canDeleteProject = (project: AnalysisProject) => {
+    if (currentUserFullName === 'Karlis Kanders') return true
+    return (
+      project.created_by_name === currentUserFullName ||
+      project.created_by_name === currentUserEmail ||
+      project.created_by_name === currentUserEmailUsername
+    )
+  }
+
   return (
     <div className="flex-1 flex flex-col">
       <div className="border-b border-slate-200 bg-white px-8 py-6">
@@ -221,20 +231,24 @@ export default function ProjectsPage() {
                         <span className="truncate max-w-[180px]">{project.title}</span>
                       </div>
                       <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
-                        <Button 
-                          variant="ghost" 
-                          size="sm"
-                          onClick={() => openEditDialog(project)}
-                        >
-                          <Edit className="h-3 w-3" />
-                        </Button>
-                        <Button 
-                          variant="ghost" 
-                          size="sm"
-                          onClick={() => handleDeleteProject(project.id)}
-                        >
-                          <Trash2 className="h-3 w-3" />
-                        </Button>
+                        {canDeleteProject(project) && (
+                          <Button 
+                            variant="ghost" 
+                            size="sm"
+                            onClick={() => openEditDialog(project)}
+                          >
+                            <Edit className="h-3 w-3" />
+                          </Button>
+                        )}
+                        {canDeleteProject(project) && (
+                          <Button 
+                            variant="ghost" 
+                            size="sm"
+                            onClick={() => handleDeleteProject(project.id)}
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        )}
                       </div>
                     </CardTitle>
                   </CardHeader>

--- a/frontend/app/v2/results/ExecutiveBriefing.tsx
+++ b/frontend/app/v2/results/ExecutiveBriefing.tsx
@@ -23,8 +23,8 @@ export function ExecutiveBriefing({ briefing }: ExecutiveBriefingProps) {
         {briefing ? (
           <p className="text-base leading-relaxed whitespace-pre-wrap">{briefing}</p>
         ) : (
-          <div className="bg-yellow-50 border border-yellow-200 rounded p-3 text-yellow-800 text-sm">
-            Executive briefing is currently unavailable. Please try again later.
+          <div>
+            We are preparing the executive briefing. Please come back a bit later.
           </div>
         )}
       </CardContent>

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -106,7 +106,7 @@ export default function AnalysisResultsPage() {
   
   // Interventions view state
   const [interventionsGroupByIssues, setInterventionsGroupByIssues] = useState(false)
-  const [interventionsSortBy, setInterventionsSortBy] = useState<'frequency' | 'impact' | 'evidence'>('impact')
+  const [interventionsSortBy, setInterventionsSortBy] = useState<'frequency' | 'impact' | 'evidence'>('frequency')
   const [isPreparingInterventionsDownload, setIsPreparingInterventionsDownload] = useState(false)
   
   // Data states
@@ -564,6 +564,68 @@ export default function AnalysisResultsPage() {
   }, [activeTab, effectiveProjectId])
 
 
+  // --- Stat Cards for Summary Tab ---
+  // Intervention group and intervention counts from navigator API
+  const [navigatorStats, setNavigatorStats] = useState({
+    interventionGroupCount: null as number | null,
+    interventionCount: null as number | null,
+    loading: true,
+    error: null as string | null,
+  });
+
+  useEffect(() => {
+    async function fetchNavigatorStats() {
+      if (!effectiveProjectId) return;
+      setNavigatorStats(prev => ({ ...prev, loading: true, error: null }));
+      try {
+        const response = await fetchWithAuth(`/api/analysis-projects/${effectiveProjectId}/issue-intervention-navigator`);
+        // Count unique intervention themes (groups)
+        const interventionThemeNames = new Set<string>();
+        const interventionNames = new Set<string>();
+        if (response?.issue_themes) {
+          response.issue_themes.forEach((issue: { related_interventions?: { theme_name?: string; detailed_interventions?: { name?: string }[] }[] }) => {
+            issue.related_interventions?.forEach((intervention) => {
+              if (intervention.theme_name) interventionThemeNames.add(intervention.theme_name);
+              // Count unique detailed interventions by name
+              intervention.detailed_interventions?.forEach((d) => {
+                if (d.name) interventionNames.add(d.name);
+              });
+            });
+          });
+        }
+        setNavigatorStats({
+          interventionGroupCount: interventionThemeNames.size,
+          interventionCount: interventionNames.size,
+          loading: false,
+          error: null,
+        });
+        if (typeof window !== 'undefined') {
+          console.log('[StatCards] Intervention themes:', Array.from(interventionThemeNames));
+          console.log('[StatCards] Detailed interventions:', Array.from(interventionNames));
+        }
+      } catch (err) {
+        setNavigatorStats({
+          interventionGroupCount: null,
+          interventionCount: null,
+          loading: false,
+          error: (err as Error)?.message || 'Failed to load intervention stats',
+        });
+      }
+    }
+    fetchNavigatorStats();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [effectiveProjectId]);
+
+  const overtonCount = documents.filter(doc => doc.source === 'overton').length;
+  const openalexCount = documents.filter(doc => doc.source === 'openalex').length;
+  // Debug output
+  if (typeof window !== 'undefined') {
+    // console.log('[StatCards] Unique intervention names:', uniqueInterventionNames);
+    // console.log('[StatCards] Unique group names:', uniqueGroupNames);
+    console.log('[StatCards] Interventions raw:', interventions);
+    console.log('[StatCards] Overton:', overtonCount, 'OpenAlex:', openalexCount);
+  }
+
   // Create study strength and sample size mappings from interventions data
   const { studyStrengthMapping, sampleSizeMapping } = useMemo(() => {
     const strengthMapping: Record<string, string> = {}
@@ -847,9 +909,36 @@ export default function AnalysisResultsPage() {
             </div>
 
             <div className="flex-1 overflow-auto">
-
               <TabsContent value="summary" className="p-6 m-0">
                 <div className="max-w-6xl mx-auto">
+                  {/* Stat Cards Row - only in summary tab */}
+                  <div className="flex flex-wrap gap-4 mb-8">
+                    <div className="bg-white rounded-lg shadow p-4 flex-1 min-w-[140px] text-center">
+                      <div className="text-2xl font-bold">{overtonCount}</div>
+                      <div className="text-xs text-slate-500">Policy documents (Overton)</div>
+                    </div>
+                    <div className="bg-white rounded-lg shadow p-4 flex-1 min-w-[140px] text-center">
+                      <div className="text-2xl font-bold">{openalexCount}</div>
+                      <div className="text-xs text-slate-500">Academic documents (OpenAlex)</div>
+                    </div>
+                    <div className="bg-white rounded-lg shadow p-4 flex-1 min-w-[140px] text-center">
+                      <div className="text-2xl font-bold">{navigatorStats.loading ? '...' : navigatorStats.interventionGroupCount ?? '-'}</div>
+                      <div className="text-xs text-slate-500">Intervention themes</div>
+                    </div>
+                    <div className="bg-white rounded-lg shadow p-4 flex-1 min-w-[140px] text-center">
+                      <div className="text-2xl font-bold">{navigatorStats.loading ? '...' : navigatorStats.interventionCount ?? '-'}</div>
+                      <div className="text-xs text-slate-500">Interventions</div>
+                    </div>
+                    <button
+                      className="bg-blue-600 hover:bg-blue-700 text-white rounded-lg px-6 flex items-center font-semibold transition min-w-[180px] justify-center shadow-md shadow-blue-200/40"
+                      style={{ color: 'white' }}
+                      onClick={() => setActiveTab('evidence')}
+                    >
+                      Explore Interventions
+                      <span className="ml-2">→</span>
+                    </button>
+                  </div>
+                  {/* Executive Briefing and charts */}
                   {isLoadingSummary && (
                     <div className="flex items-center justify-center py-12">
                       <div className="text-center">

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -444,7 +444,9 @@ export default function AnalysisResultsPage() {
           setAnalysisComplete(true)
           return true
         } else if (project.status === 'running') {
-          console.log('🔄 Analysis still RUNNING - continuing to poll')
+          console.log('🔄 Analysis still RUNNING (extraction phase) - continuing to poll')
+        } else if (project.status === 'synthesising') {
+          console.log('🔄 Analysis SYNTHESISING (generating summary) - continuing to poll')
         } else {
           console.log(`⚠️ Unknown status: ${project.status} - continuing to poll`)
         }
@@ -651,22 +653,21 @@ export default function AnalysisResultsPage() {
         return { stage: 'extracting', progress: 50, text: 'Extracting intervention data from documents...' }
       }
       
-      // Check if extraction is complete (all docs processed)
-      if (extractedDocs >= totalRelevantDocs && totalRelevantDocs > 0) {
-        // Analysis done, synthesis running
-        return { 
-          stage: 'synthesising', 
-          progress: 75, 
-          text: 'Generating summary and insights...' 
-        }
-      }
-      
       // Still extracting - scale progress from 50% to 70%
       const extractionProgress = Math.round((extractedDocs / totalRelevantDocs) * 20) + 50
       return { 
         stage: 'extracting', 
         progress: Math.min(extractionProgress, 70), 
         text: `Extracting intervention data from documents... (${extractedDocs}/${totalRelevantDocs})` 
+      }
+    }
+    
+    if (status === 'synthesising') {
+      // Extraction complete, synthesis in progress
+      return { 
+        stage: 'synthesising', 
+        progress: 85, 
+        text: 'Generating summary and insights...' 
       }
     }
     

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -19,7 +19,6 @@ import {
   Filter,
   Brain,
   BarChart3,
-  AlertTriangle,
   Download
 } from 'lucide-react'
 import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
@@ -33,7 +32,7 @@ import { V2ChatInterface } from '@/components/chatbot/V2ChatInterface'
 import { V2ChatbotWidget } from '@/components/chatbot/V2ChatbotWidget'
 import NetworkVisualizer from '@/components/network/NetworkVisualizer'
 import { ProjectCharts } from '@/components/charts/ProjectCharts'
-import EvidenceThematicView from '@/components/v2/evidence/EvidenceThematicView'
+import { InterventionsNavigator } from '@/components/v2/interventions/InterventionsNavigator'
 import type { InterventionData } from '@/components/search/interventions-table'
 import { PapersTable } from '@/components/search/papers-table'
 import { SearchPlanModal } from '@/components/v2/results/SearchPlanModal'
@@ -101,7 +100,7 @@ export default function AnalysisResultsPage() {
   const [isLoadingSummary, setIsLoadingSummary] = useState(false)
   // const [activeTab, setActiveTab] = useState('summary')
   const [insightsSubTab, setInsightsSubTab] = useState('charts')
-  const [evidenceSubTab, setEvidenceSubTab] = useState('documents')
+  const [evidenceSubTab, setEvidenceSubTab] = useState('interventions')
   
   // Relevance filtering state
   const [showRelevantOnly, setShowRelevantOnly] = useState(true)
@@ -111,6 +110,11 @@ export default function AnalysisResultsPage() {
   
   // Documents download state
   const [isPreparingDocumentsDownload, setIsPreparingDocumentsDownload] = useState(false)
+  
+  // Interventions view state
+  const [interventionsGroupByIssues, setInterventionsGroupByIssues] = useState(false)
+  const [interventionsSortBy, setInterventionsSortBy] = useState<'frequency' | 'impact' | 'evidence'>('impact')
+  const [isPreparingInterventionsDownload, setIsPreparingInterventionsDownload] = useState(false)
   
   // Data states
   const [documents, setDocuments] = useState<AnalysisDocument[]>([])
@@ -281,6 +285,53 @@ export default function AnalysisResultsPage() {
       alert('Failed to download documents CSV. Please try again.')
     } finally {
       setIsPreparingDocumentsDownload(false)
+    }
+  }, [effectiveProjectId, fetchWithAuth, getToken, activeProject?.title])
+  
+  const handleDownloadInterventionsCSV = useCallback(async () => {
+    if (!effectiveProjectId) return
+    
+    setIsPreparingInterventionsDownload(true)
+    
+    try {
+      const response = await fetchWithAuth(`/api/analysis-projects/${effectiveProjectId}/download/interventions-csv`)
+      
+      if (response.download_key) {
+        const token = await getToken()
+        const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+        const cleanBaseUrl = baseUrl.replace(/\/$/, '')
+        
+        const downloadResponse = await fetch(`${cleanBaseUrl}/api/download/${response.download_key}`, {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'text/csv',
+          },
+        })
+        
+        if (downloadResponse.ok) {
+          const projectName = activeProject?.title || 'project'
+          const cleanProjectName = projectName.replace(/[^a-zA-Z0-9\s]/g, '').replace(/\s+/g, '_')
+          const timestamp = new Date().toISOString().slice(0, 19).replace(/[-:]/g, '').replace('T', '_')
+          const filename = `${cleanProjectName}_interventions_${timestamp}.csv`
+
+          const blob = await downloadResponse.blob()
+          const url = window.URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = filename
+          document.body.appendChild(a)
+          a.click()
+          window.URL.revokeObjectURL(url)
+          document.body.removeChild(a)
+        } else {
+          alert('Failed to download file')
+        }
+      }
+    } catch (err) {
+      console.error('Failed to download interventions CSV:', err)
+      alert('Failed to download interventions CSV. Please try again.')
+    } finally {
+      setIsPreparingInterventionsDownload(false)
     }
   }, [effectiveProjectId, fetchWithAuth, getToken, activeProject?.title])
   
@@ -841,15 +892,6 @@ export default function AnalysisResultsPage() {
                     <div className="flex items-center justify-between">
                       <div className="flex gap-2">
                         <Button
-                          variant={evidenceSubTab === 'documents' ? 'default' : 'outline'}
-                          size="sm"
-                          onClick={() => setEvidenceSubTab('documents')}
-                          className="flex items-center gap-2"
-                        >
-                          <FileText className="h-3 w-3" />
-                          Documents ({showRelevantOnly ? relevantCount : documents.length})
-                        </Button>
-                        <Button
                           variant={evidenceSubTab === 'interventions' ? 'default' : 'outline'}
                           size="sm"
                           onClick={() => setEvidenceSubTab('interventions')}
@@ -859,13 +901,13 @@ export default function AnalysisResultsPage() {
                           Interventions
                         </Button>
                         <Button
-                          variant={evidenceSubTab === 'issues' ? 'default' : 'outline'}
+                          variant={evidenceSubTab === 'documents' ? 'default' : 'outline'}
                           size="sm"
-                          onClick={() => setEvidenceSubTab('issues')}
+                          onClick={() => setEvidenceSubTab('documents')}
                           className="flex items-center gap-2"
                         >
-                          <AlertTriangle className="h-3 w-3" />
-                          Key Issues
+                          <FileText className="h-3 w-3" />
+                          Documents ({showRelevantOnly ? relevantCount : documents.length})
                         </Button>
                       </div>
 
@@ -908,10 +950,67 @@ export default function AnalysisResultsPage() {
                           </div>
                         </div>
                       )}
+                      
+                      {/* Controls for interventions */}
+                      {evidenceSubTab === 'interventions' && (
+                        <div className="flex items-center gap-6">
+                          <div className="flex items-center gap-2">
+                            <Label htmlFor="group-by-issues" className="text-sm text-slate-700">
+                              Group by issues
+                            </Label>
+                            <Switch
+                              id="group-by-issues"
+                              checked={interventionsGroupByIssues}
+                              onCheckedChange={setInterventionsGroupByIssues}
+                            />
+                          </div>
+                          
+                          <div className="flex items-center gap-2">
+                            <Label className="text-sm text-slate-700">Sort by:</Label>
+                            <select 
+                              value={interventionsSortBy}
+                              onChange={(e) => setInterventionsSortBy(e.target.value as 'frequency' | 'impact' | 'evidence')}
+                              className="text-sm border rounded px-2 py-1 bg-white"
+                            >
+                              <option value="impact">Impact</option>
+                              <option value="evidence">Evidence</option>
+                              <option value="frequency">Frequency</option>
+                            </select>
+                          </div>
+                          
+                          {/* Interventions Download Button */}
+                          <div className="flex items-center gap-2">
+                            <Button
+                              onClick={handleDownloadInterventionsCSV}
+                              disabled={isPreparingInterventionsDownload}
+                              variant="outline"
+                              size="sm"
+                              className="flex items-center gap-2"
+                            >
+                              <Download className="h-4 w-4" />
+                              {isPreparingInterventionsDownload ? 'Downloading...' : 'Download'}
+                            </Button>
+                          </div>
+                        </div>
+                      )}
                     </div>
                   </div>
 
                   {/* Content based on active sub-tab */}
+                  {evidenceSubTab === 'interventions' && (
+                    <div>
+                      <InterventionsNavigator 
+                        showHeader={false}
+                        viewMode={interventionsGroupByIssues ? 'grouped' : 'all'}
+                        onViewModeChange={(mode) => setInterventionsGroupByIssues(mode === 'grouped')}
+                        sortBy={interventionsSortBy}
+                        onSortByChange={setInterventionsSortBy}
+                        onDownload={handleDownloadInterventionsCSV}
+                        isPreparingDownload={isPreparingInterventionsDownload}
+                      />
+                    </div>
+                  )}
+
                   {evidenceSubTab === 'documents' && (
                     <div>
                       {loadingData ? (
@@ -950,18 +1049,6 @@ export default function AnalysisResultsPage() {
                           <p className="text-slate-600">Documents will appear here once the analysis is processed.</p>
                         </div>
                       )}
-                    </div>
-                  )}
-
-                  {evidenceSubTab === 'interventions' && (
-                    <div>
-                      <EvidenceThematicView projectId={effectiveProjectId} themeType="intervention" />
-                    </div>
-                  )}
-
-                  {evidenceSubTab === 'issues' && (
-                    <div>
-                      <EvidenceThematicView projectId={effectiveProjectId} themeType="issue" />
                     </div>
                   )}
                 </div>

--- a/frontend/app/v2/results/page.tsx
+++ b/frontend/app/v2/results/page.tsx
@@ -17,20 +17,15 @@ import {
   Target,
   Bot,
   Filter,
-  Brain,
-  BarChart3,
   Download
 } from 'lucide-react'
 import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
 import { useAPI } from '@/lib/api'
 import { useAuth } from '@clerk/nextjs'
 import { SynthesisSummary } from '@/types/search'
-import { KeyIssuesTable } from './KeyIssuesTable'
-import { InterventionsTable } from './InterventionsTable'
 import { ExecutiveBriefing } from './ExecutiveBriefing'
 import { V2ChatInterface } from '@/components/chatbot/V2ChatInterface'
 import { V2ChatbotWidget } from '@/components/chatbot/V2ChatbotWidget'
-import NetworkVisualizer from '@/components/network/NetworkVisualizer'
 import { ProjectCharts } from '@/components/charts/ProjectCharts'
 import { InterventionsNavigator } from '@/components/v2/interventions/InterventionsNavigator'
 import type { InterventionData } from '@/components/search/interventions-table'
@@ -95,11 +90,9 @@ export default function AnalysisResultsPage() {
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const hasStartedPollingRef = useRef<string | null>(null) // Track which project we're polling
   const lastRefreshTimeRef = useRef<number>(0) // Throttle refreshes
-  const [activeTab, setActiveTab] = useState('evidence')
+  const [activeTab, setActiveTab] = useState('summary')
   const [summaryData, setSummaryData] = useState<SynthesisSummary | null>(null)
   const [isLoadingSummary, setIsLoadingSummary] = useState(false)
-  // const [activeTab, setActiveTab] = useState('summary')
-  const [insightsSubTab, setInsightsSubTab] = useState('charts')
   const [evidenceSubTab, setEvidenceSubTab] = useState('interventions')
   
   // Relevance filtering state
@@ -836,22 +829,18 @@ export default function AnalysisResultsPage() {
         {effectiveProjectId && (
           <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
             <div className="px-6 pt-4">
-              <TabsList className="grid w-full grid-cols-4">
-                <TabsTrigger value="evidence" className="flex items-center gap-2">
-                  <BookOpen className="h-4 w-4" />
-                  Evidence
-                </TabsTrigger>
+              <TabsList className="grid w-full grid-cols-3">
                 <TabsTrigger value="summary" className="flex items-center gap-2">
                   <FileText className="h-4 w-4" />
                   Summary
                 </TabsTrigger>
+                <TabsTrigger value="evidence" className="flex items-center gap-2">
+                  <BookOpen className="h-4 w-4" />
+                  Evidence
+                </TabsTrigger>
                 <TabsTrigger value="assistant" className="flex items-center gap-2">
                   <Bot className="h-4 w-4" />
                   Assistant
-                </TabsTrigger>
-                <TabsTrigger value="insights" className="flex items-center gap-2">
-                  <Brain className="h-4 w-4" />
-                  Insights
                 </TabsTrigger>
               </TabsList>
             </div>
@@ -871,8 +860,7 @@ export default function AnalysisResultsPage() {
                   {summaryData && (
                     <div className="space-y-8">
                       <ExecutiveBriefing briefing={summaryData.executive_briefing} />
-                      <KeyIssuesTable issues={summaryData.key_issues || []} />
-                      <InterventionsTable interventions={summaryData.interventions || []} />
+                      <ProjectCharts projectId={effectiveProjectId} projectTitle={activeProject?.title} />
                     </div>
                   )}
                   {!isLoadingSummary && !summaryData && (
@@ -1060,47 +1048,6 @@ export default function AnalysisResultsPage() {
                   placeholder="Ask about the evidence in this project..."
                   className="h-full"
                 />
-              </TabsContent>
-
-              <TabsContent value="insights" className="p-6 m-0">
-                <div className="max-w-6xl mx-auto">
-                  {/* Insights Sub-tabs as smaller buttons */}
-                  <div className="mb-6">
-                    <div className="flex gap-2">
-                      <Button
-                        variant={insightsSubTab === 'charts' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => setInsightsSubTab('charts')}
-                        className="flex items-center gap-2"
-                      >
-                        <BarChart3 className="h-3 w-3" />
-                        Charts
-                      </Button>
-                      <Button
-                        variant={insightsSubTab === 'network' ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => setInsightsSubTab('network')}
-                        className="flex items-center gap-2"
-                      >
-                        <Brain className="h-3 w-3" />
-                        Network
-                      </Button>
-                    </div>
-                  </div>
-
-                  {/* Content based on active sub-tab */}
-                  {insightsSubTab === 'network' && (
-                    <div>
-                      <NetworkVisualizer />
-                    </div>
-                  )}
-
-                  {insightsSubTab === 'charts' && (
-                    <div>
-                      <ProjectCharts projectId={effectiveProjectId} projectTitle={activeProject?.title} />
-                    </div>
-                  )}
-                </div>
               </TabsContent>
             </div>
           </Tabs>

--- a/frontend/components/v2/interventions/InterventionsNavigator.tsx
+++ b/frontend/components/v2/interventions/InterventionsNavigator.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
 import { Loader2, ChevronRight, ChevronDown, Target, AlertTriangle, Star, Download } from 'lucide-react'
 import { NavigatorInterventionsTable } from '@/components/v2/interventions/NavigatorInterventionsTable'
+import { type InterventionData } from '@/components/search/interventions-table'
 
 interface IssueTheme {
   theme_name: string
@@ -92,6 +93,10 @@ export function InterventionsNavigator({
   const [expandedIssues, setExpandedIssues] = useState<Set<string>>(new Set())
   const [expandedInterventions, setExpandedInterventions] = useState<Set<string>>(new Set())
   
+  // Fallback state for extracted interventions (when synthesis is not done)
+  const [fallbackInterventions, setFallbackInterventions] = useState<InterventionData[] | null>(null)
+  const [loadingFallback, setLoadingFallback] = useState(false)
+  
   // Use external state if provided, otherwise use internal state
   const [internalViewMode, setInternalViewMode] = useState<'grouped' | 'all'>('all')
   const [internalSortBy, setInternalSortBy] = useState<'frequency' | 'impact' | 'evidence'>('impact')
@@ -130,6 +135,27 @@ export function InterventionsNavigator({
     if (!activeProject?.id) return
     loadNavigatorData()
   }, [activeProject?.id, loadNavigatorData])
+  
+  // Load fallback interventions if navigator data is empty
+  useEffect(() => {
+    const loadFallback = async () => {
+      if (!activeProject?.id) return
+      if (!data || data.issue_themes.length > 0) return // Only load if navigator is empty
+      
+      setLoadingFallback(true)
+      try {
+        const response = await fetchWithAuth(`/api/analysis-projects/${activeProject.id}/interventions`)
+        setFallbackInterventions(response.interventions || [])
+      } catch (err) {
+        console.error('Failed to load fallback interventions:', err)
+        setFallbackInterventions([])
+      } finally {
+        setLoadingFallback(false)
+      }
+    }
+    
+    loadFallback()
+  }, [activeProject?.id, data]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleIssue = useCallback((themeName: string) => {
     setExpandedIssues(prev => {
@@ -327,6 +353,25 @@ export function InterventionsNavigator({
       evidence_justification: detail.evidence_justification,
     }))
   }, [])
+  
+  // Convert fallback interventions to navigator format
+  const convertFallbackToNavigatorFormat = useCallback((interventions: InterventionData[]) => {
+    return interventions.map((intervention) => ({
+      name: intervention.name,
+      type: intervention.type,
+      country: intervention.country,
+      description: intervention.description,
+      result_count: intervention.result_count,
+      results_summary: intervention.results_summary,
+      total_sample_size: intervention.total_sample_size,
+      documents: intervention.documents,
+      // These fields might not be present in fallback data, but include them if available
+      impact_score: undefined,
+      evidence_score: undefined,
+      impact_justification: undefined,
+      evidence_justification: undefined,
+    }))
+  }, [])
 
   if (!activeProject) {
     return (
@@ -428,16 +473,38 @@ export function InterventionsNavigator({
         {data && (
           <div className="space-y-6">
             {data.issue_themes.length === 0 ? (
-              <Card>
-                <CardContent className="p-8 text-center">
-                  <AlertTriangle className="h-12 w-12 text-amber-400 mx-auto mb-4" />
-                  <h3 className="text-lg font-medium text-slate-900 mb-2">No Issue-Intervention Mappings Found</h3>
-                  <p className="text-slate-600">
-                    This project doesn&apos;t have any extracted mappings between issues and interventions yet.
-                    This happens when documents are still being processed or don&apos;t contain linked policy interventions.
-                  </p>
-                </CardContent>
-              </Card>
+              loadingFallback ? (
+                <div className="flex items-center justify-center py-12">
+                  <div className="text-center">
+                    <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
+                    <p className="text-slate-600">Loading extracted interventions...</p>
+                  </div>
+                </div>
+              ) : fallbackInterventions && fallbackInterventions.length > 0 ? (
+                <div className="space-y-4">
+                  <Card>
+                    <CardContent className="p-4">
+                      <div className="flex items-center gap-2 text-sm text-slate-600 mb-2">
+                        <AlertTriangle className="h-4 w-4 text-amber-500" />
+                        <span>Synthesis pending - showing extracted interventions (ungrouped)</span>
+                      </div>
+                    </CardContent>
+                  </Card>
+                  <NavigatorInterventionsTable 
+                    interventions={convertFallbackToNavigatorFormat(fallbackInterventions)} 
+                  />
+                </div>
+              ) : (
+                <Card>
+                  <CardContent className="p-8 text-center">
+                    <AlertTriangle className="h-12 w-12 text-amber-400 mx-auto mb-4" />
+                    <h3 className="text-lg font-medium text-slate-900 mb-2">No Interventions Found</h3>
+                    <p className="text-slate-600">
+                      This happens when documents are still being processed.
+                    </p>
+                  </CardContent>
+                </Card>
+              )
             ) : viewMode === 'all' ? (
               <div className="space-y-4">
                 {getAllInterventions.map((intervention) => (

--- a/frontend/components/v2/interventions/InterventionsNavigator.tsx
+++ b/frontend/components/v2/interventions/InterventionsNavigator.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import { Switch } from '@/components/ui/switch'
 import { Loader2, ChevronRight, ChevronDown, Target, AlertTriangle, Star, Download } from 'lucide-react'
 import { NavigatorInterventionsTable } from '@/components/v2/interventions/NavigatorInterventionsTable'
 
@@ -21,6 +22,7 @@ interface IssueTheme {
 interface InterventionTheme {
   theme_name: string
   description: string
+  impact_summary?: string
   frequency: number
   avg_impact_score?: number
   avg_evidence_score?: number
@@ -33,9 +35,11 @@ interface DetailedIntervention {
   type?: string
   country?: string
   study_type?: string
-  sample_size?: number
+  sample_size?: number | null
   impact_score?: number
   evidence_score?: number
+  impact_justification?: string
+  evidence_justification?: string
   document_url?: string
   results: Array<{
     outcome_variable?: string
@@ -59,7 +63,25 @@ interface NavigatorData {
   issue_themes: IssueTheme[]
 }
 
-export default function InterventionsNavigatorPage() {
+interface InterventionsNavigatorProps {
+  showHeader?: boolean
+  viewMode?: 'grouped' | 'all'
+  onViewModeChange?: (mode: 'grouped' | 'all') => void
+  sortBy?: 'frequency' | 'impact' | 'evidence'
+  onSortByChange?: (sortBy: 'frequency' | 'impact' | 'evidence') => void
+  onDownload?: () => void
+  isPreparingDownload?: boolean
+}
+
+export function InterventionsNavigator({ 
+  showHeader = true,
+  viewMode: externalViewMode,
+  onViewModeChange,
+  sortBy: externalSortBy,
+  onSortByChange,
+  onDownload,
+  isPreparingDownload: externalIsPreparingDownload
+}: InterventionsNavigatorProps) {
   const { activeProject } = useAnalysisProjectStore()
   const { fetchWithAuth } = useAPI()
   const { getToken } = useAuth()
@@ -69,9 +91,17 @@ export default function InterventionsNavigatorPage() {
   const [error, setError] = useState<string | null>(null)
   const [expandedIssues, setExpandedIssues] = useState<Set<string>>(new Set())
   const [expandedInterventions, setExpandedInterventions] = useState<Set<string>>(new Set())
-  const [viewMode, setViewMode] = useState<'grouped' | 'all'>('grouped')
-  const [sortBy, setSortBy] = useState<'frequency' | 'impact' | 'evidence'>('impact')
-  const [isPreparingDownload, setIsPreparingDownload] = useState(false)
+  
+  // Use external state if provided, otherwise use internal state
+  const [internalViewMode, setInternalViewMode] = useState<'grouped' | 'all'>('all')
+  const [internalSortBy, setInternalSortBy] = useState<'frequency' | 'impact' | 'evidence'>('impact')
+  const [internalIsPreparingDownload, setInternalIsPreparingDownload] = useState(false)
+  
+  const viewMode = externalViewMode ?? internalViewMode
+  const setViewMode = onViewModeChange ?? setInternalViewMode
+  const sortBy = externalSortBy ?? internalSortBy
+  const setSortBy = onSortByChange ?? setInternalSortBy
+  const isPreparingDownload = externalIsPreparingDownload ?? internalIsPreparingDownload
 
   const loadNavigatorData = useCallback(async () => {
     if (!activeProject?.id) return
@@ -126,14 +156,20 @@ export default function InterventionsNavigatorPage() {
   }, [])
 
   const handleDownloadCSV = useCallback(async () => {
+    // Use external handler if provided
+    if (onDownload) {
+      onDownload()
+      return
+    }
+    
+    // Otherwise use internal download logic
     if (!activeProject?.id) return
     
-    setIsPreparingDownload(true)
+    setInternalIsPreparingDownload(true)
     
     try {
       const response = await fetchWithAuth(`/api/analysis-projects/${activeProject.id}/download/interventions-csv`)
       
-      // Immediately trigger download using the download key
       if (response.download_key) {
         const token = await getToken()
         const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
@@ -147,13 +183,10 @@ export default function InterventionsNavigatorPage() {
         })
         
         if (downloadResponse.ok) {
-          // Simple approach: generate filename on frontend with project name
           const projectName = activeProject?.title || 'project'
           const cleanProjectName = projectName.replace(/[^a-zA-Z0-9\s]/g, '').replace(/\s+/g, '_')
           const timestamp = new Date().toISOString().slice(0, 19).replace(/[-:]/g, '').replace('T', '_')
           const filename = `${cleanProjectName}_interventions_${timestamp}.csv`
-          
-          console.log('Generated filename:', filename)
 
           const blob = await downloadResponse.blob()
           const url = window.URL.createObjectURL(blob)
@@ -172,9 +205,9 @@ export default function InterventionsNavigatorPage() {
       console.error('Failed to download CSV:', err)
       alert('Failed to download CSV. Please try again.')
     } finally {
-      setIsPreparingDownload(false)
+      setInternalIsPreparingDownload(false)
     }
-  }, [activeProject?.id, activeProject?.title, fetchWithAuth, getToken])
+  }, [activeProject?.id, activeProject?.title, fetchWithAuth, getToken, onDownload])
 
   const renderStars = useCallback((score?: number) => {
     if (!score) return null
@@ -195,7 +228,6 @@ export default function InterventionsNavigatorPage() {
     )
   }, [])
 
-  // Sort interventions based on current sortBy criteria
   const sortInterventions = useCallback((interventions: InterventionTheme[]) => {
     return [...interventions].sort((a, b) => {
       switch (sortBy) {
@@ -205,12 +237,11 @@ export default function InterventionsNavigatorPage() {
           return (b.avg_evidence_score || 0) - (a.avg_evidence_score || 0)
         case 'frequency':
         default:
-          return b.frequency - a.frequency
+          return (b.detailed_interventions?.length || 0) - (a.detailed_interventions?.length || 0)
       }
     })
   }, [sortBy])
 
-  // Get all unique interventions with aggregated data for "All Interventions" view
   const getAllInterventions = useMemo(() => {
     if (!data) return []
     
@@ -221,7 +252,6 @@ export default function InterventionsNavigatorPage() {
         const key = intervention.theme_name
         if (interventionsMap.has(key)) {
           const existing = interventionsMap.get(key)
-          // Aggregate frequencies and scores
           existing.frequency += intervention.frequency
           if (intervention.avg_impact_score) {
             existing.impact_scores.push(intervention.avg_impact_score)
@@ -229,7 +259,18 @@ export default function InterventionsNavigatorPage() {
           if (intervention.avg_evidence_score) {
             existing.evidence_scores.push(intervention.avg_evidence_score)
           }
-          existing.detailed_interventions.push(...(intervention.detailed_interventions || []))
+          // Keep the first impact_summary we encounter (if current doesn't have one)
+          if (!existing.impact_summary && intervention.impact_summary) {
+            existing.impact_summary = intervention.impact_summary
+          }
+          // Deduplicate detailed interventions by name
+          const newDetails = intervention.detailed_interventions || []
+          newDetails.forEach(detail => {
+            const exists = existing.detailed_interventions.some((d: DetailedIntervention) => d.name === detail.name)
+            if (!exists) {
+              existing.detailed_interventions.push(detail)
+            }
+          })
         } else {
           interventionsMap.set(key, {
             ...intervention,
@@ -241,7 +282,6 @@ export default function InterventionsNavigatorPage() {
       })
     })
     
-    // Calculate final aggregated scores
     const interventions = Array.from(interventionsMap.values()).map(intervention => ({
       ...intervention,
       avg_impact_score: intervention.impact_scores.length > 0 
@@ -252,11 +292,9 @@ export default function InterventionsNavigatorPage() {
         : undefined
     }))
     
-    // Sort by selected criteria using the memoized sort function
     return sortInterventions(interventions)
   }, [data, sortInterventions])
 
-  // Convert DetailedIntervention to NavigatorInterventionData format for NavigatorInterventionsTable
   const convertToNavigatorInterventionData = useCallback((detailedInterventions: DetailedIntervention[]) => {
     return detailedInterventions.map((detail) => ({
       name: detail.name,
@@ -285,6 +323,8 @@ export default function InterventionsNavigatorPage() {
       })) || [],
       impact_score: detail.impact_score,
       evidence_score: detail.evidence_score,
+      impact_justification: detail.impact_justification,
+      evidence_justification: detail.evidence_justification,
     }))
   }, [])
 
@@ -301,79 +341,70 @@ export default function InterventionsNavigatorPage() {
   }
 
   return (
-    <div className="flex-1 flex flex-col">
-      {/* Header */}
-      <div className="border-b border-slate-200 bg-white px-8 py-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-slate-900">Interventions Navigator</h1>
-          </div>
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2">
-              <Button
-                variant={viewMode === 'grouped' ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setViewMode('grouped')}
-              >
-                By Issues
-              </Button>
-              <Button
-                variant={viewMode === 'all' ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setViewMode('all')}
-              >
-                All Interventions
-              </Button>
-            </div>
-            
-            <div className="flex items-center gap-2">
-              <Label className="text-sm">Sort by:</Label>
-              <select 
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as 'frequency' | 'impact' | 'evidence')}
-                className="text-sm border rounded px-2 py-1"
-              >
-                <option value="impact">Impact</option>
-                <option value="evidence">Evidence</option>
-                <option value="frequency">Frequency</option>
-              </select>
-            </div>
-            
-            {/* Download Button */}
-            <div className="flex items-center gap-2">
-              <Button
-                onClick={handleDownloadCSV}
-                disabled={isPreparingDownload || !data || data.issue_themes.length === 0}
-                variant="outline"
-                size="sm"
-                className="flex items-center gap-2"
-              >
-                <Download className="h-4 w-4" />
-                {isPreparingDownload ? 'Downloading...' : 'Download'}
-              </Button>
+    <div className="flex flex-col h-full">
+      {/* Header - only show on standalone page */}
+      {showHeader && (
+        <div className="mb-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-6">
+              <div className="flex items-center gap-2">
+                <Label htmlFor="standalone-group-by-issues" className="text-sm text-slate-700">
+                  Group by issues
+                </Label>
+                <Switch
+                  id="standalone-group-by-issues"
+                  checked={viewMode === 'grouped'}
+                  onCheckedChange={(checked) => setViewMode(checked ? 'grouped' : 'all')}
+                />
+              </div>
+              
+              <div className="flex items-center gap-2">
+                <Label className="text-sm text-slate-700">Sort by:</Label>
+                <select 
+                  value={sortBy}
+                  onChange={(e) => setSortBy(e.target.value as 'frequency' | 'impact' | 'evidence')}
+                  className="text-sm border rounded px-2 py-1 bg-white"
+                >
+                  <option value="impact">Impact</option>
+                  <option value="evidence">Evidence</option>
+                  <option value="frequency">Frequency</option>
+                </select>
+              </div>
+              
+              <div className="flex items-center gap-2">
+                <Button
+                  onClick={handleDownloadCSV}
+                  disabled={isPreparingDownload || !data || data.issue_themes.length === 0}
+                  variant="outline"
+                  size="sm"
+                  className="flex items-center gap-2"
+                >
+                  <Download className="h-4 w-4" />
+                  {isPreparingDownload ? 'Downloading...' : 'Download'}
+                </Button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-
+      )}
+      
       {/* Content */}
-      <div className="flex-1 bg-slate-50 p-6">
-        <div className="max-w-6xl mx-auto">
-          {loading && (
-            <div className="flex items-center justify-center py-12">
-              <div className="text-center">
-                <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
-                <p className="text-slate-600">Loading interventions data...</p>
-              </div>
+      <div className="flex-1">
+        {loading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="text-center">
+              <Loader2 className="h-8 w-8 animate-spin mx-auto mb-4" />
+              <p className="text-slate-600">Loading interventions data...</p>
             </div>
-          )}
+          </div>
+        )}
 
-          {error && (
-            <div className="text-center py-12">
-              <AlertTriangle className="h-12 w-12 text-red-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-slate-900 mb-2">Error Loading Data</h3>
-              <p className="text-slate-600">{error}</p>
-              <div className="flex gap-2 mt-4">
+        {error && (
+          <div className="text-center py-12">
+            <AlertTriangle className="h-12 w-12 text-red-400 mx-auto mb-4" />
+            <h3 className="text-lg font-medium text-slate-900 mb-2">Error Loading Data</h3>
+            <p className="text-slate-600">{error}</p>
+            <div className="flex gap-2 mt-4 justify-center">
               <Button onClick={loadNavigatorData}>
                 Try Again
               </Button>
@@ -391,89 +422,99 @@ export default function InterventionsNavigatorPage() {
                 Debug Themes
               </Button>
             </div>
-            </div>
-          )}
+          </div>
+        )}
 
-          {data && (
-            <div className="space-y-6">
-
-              {data.issue_themes.length === 0 ? (
-                <Card>
-                  <CardContent className="p-8 text-center">
-                    <AlertTriangle className="h-12 w-12 text-amber-400 mx-auto mb-4" />
-                    <h3 className="text-lg font-medium text-slate-900 mb-2">No Issue-Intervention Mappings Found</h3>
-                    <p className="text-slate-600">
-                      This project doesn&apos;t have any extracted mappings between issues and interventions yet.
-                      This happens when documents are still being processed or don&apos;t contain linked policy interventions.
-                    </p>
-                  </CardContent>
-                </Card>
-              ) : viewMode === 'all' ? (
-                // All Interventions View
-                <div className="space-y-4">
-                  {getAllInterventions.map((intervention) => (
-                    <Card key={intervention.theme_name} className="overflow-hidden">
-                      <CardHeader className="pb-2">
-                        <div 
-                          className="flex items-center justify-between cursor-pointer"
-                          onClick={() => toggleIntervention(`all-${intervention.theme_name}`)}
-                        >
-                          <div className="flex-1">
-                            <div className="flex items-center gap-3">
-                              <h5 className="font-medium text-lg">{intervention.theme_name}</h5>
-                              <Badge variant="outline">{intervention.frequency} documents</Badge>
-                            </div>
-                            {expandedInterventions.has(`all-${intervention.theme_name}`) && (
-                              <p className="text-sm text-slate-600 mt-1">{intervention.description}</p>
-                            )}
+        {data && (
+          <div className="space-y-6">
+            {data.issue_themes.length === 0 ? (
+              <Card>
+                <CardContent className="p-8 text-center">
+                  <AlertTriangle className="h-12 w-12 text-amber-400 mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-slate-900 mb-2">No Issue-Intervention Mappings Found</h3>
+                  <p className="text-slate-600">
+                    This project doesn&apos;t have any extracted mappings between issues and interventions yet.
+                    This happens when documents are still being processed or don&apos;t contain linked policy interventions.
+                  </p>
+                </CardContent>
+              </Card>
+            ) : viewMode === 'all' ? (
+              <div className="space-y-4">
+                {getAllInterventions.map((intervention) => (
+                  <Card key={intervention.theme_name} className="overflow-hidden">
+                    <CardHeader className="pb-2">
+                      <div 
+                        className="flex items-center justify-between cursor-pointer"
+                        onClick={() => toggleIntervention(`all-${intervention.theme_name}`)}
+                      >
+                        <div className="flex-1">
+                          <div className="flex items-center gap-3">
+                            <h5 className="font-medium text-lg">{intervention.theme_name}</h5>
                           </div>
-                          
-                          {/* Impact and Evidence Scores - Right Side */}
-                          <div className="flex items-center gap-4 ml-4">
-                            {intervention.avg_impact_score && (
-                              <div className="text-right">
-                                <div className="text-xs text-slate-500">Impact:</div>
-                                {renderStars(intervention.avg_impact_score)}
-                              </div>
-                            )}
-                            {intervention.avg_evidence_score && (
-                              <div className="text-right">
-                                <div className="text-xs text-slate-500">Evidence:</div>
-                                {renderStars(intervention.avg_evidence_score)}
-                              </div>
-                            )}
-                            <div className="ml-2">
-                              {expandedInterventions.has(`all-${intervention.theme_name}`) ? (
-                                <ChevronDown className="h-4 w-4" />
-                              ) : (
-                                <ChevronRight className="h-4 w-4" />
+                          {expandedInterventions.has(`all-${intervention.theme_name}`) && (
+                            <div className="mt-1 space-y-1">
+                              <p className="text-sm text-slate-600">{intervention.description}</p>
+                              {intervention.impact_summary && (
+                                <p className="text-sm text-slate-600">
+                                  <span className="font-semibold">Impact: </span>
+                                  {intervention.impact_summary}
+                                </p>
                               )}
                             </div>
-                          </div>
+                          )}
                         </div>
-                      </CardHeader>
-
-                      {expandedInterventions.has(`all-${intervention.theme_name}`) && (
-                        <CardContent className="pt-0">
-                          {intervention.detailed_interventions?.length ? (
-                            <div className="space-y-3">
-                              <h6 className="text-sm font-medium text-slate-700">Detailed Interventions:</h6>
-                              <NavigatorInterventionsTable 
-                                interventions={convertToNavigatorInterventionData(intervention.detailed_interventions)}
-                              />
-                            </div>
-                          ) : (
-                            <div className="text-sm text-slate-600">
-                              <p>This intervention theme appears in <strong>{intervention.frequency}</strong> documents across multiple issues.</p>
+                        
+                        <div className="flex items-start gap-4 ml-4">
+                          {intervention.avg_impact_score && (
+                            <div className="text-right">
+                              <div className="text-xs text-slate-500">Impact:</div>
+                              {renderStars(intervention.avg_impact_score)}
                             </div>
                           )}
-                        </CardContent>
-                      )}
-                    </Card>
-                  ))}
-                </div>
-              ) : (
-                data.issue_themes.map((issue) => (
+                          {intervention.avg_evidence_score && (
+                            <div className="text-right">
+                              <div className="text-xs text-slate-500">Evidence:</div>
+                              {renderStars(intervention.avg_evidence_score)}
+                            </div>
+                          )}
+                          <div className="text-right">
+                            <div className="text-xs text-slate-500">Frequency:</div>
+                            <div className="flex items-center gap-1">
+                              <span className="text-xs text-slate-600">{intervention.detailed_interventions?.length || 0}</span>
+                            </div>
+                          </div>
+                          <div className="ml-2">
+                            {expandedInterventions.has(`all-${intervention.theme_name}`) ? (
+                              <ChevronDown className="h-4 w-4" />
+                            ) : (
+                              <ChevronRight className="h-4 w-4" />
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </CardHeader>
+
+                    {expandedInterventions.has(`all-${intervention.theme_name}`) && (
+                      <CardContent className="pt-0">
+                        {intervention.detailed_interventions?.length ? (
+                          <div className="space-y-3">
+                            <h6 className="text-sm font-medium text-slate-700">Detailed Interventions:</h6>
+                            <NavigatorInterventionsTable 
+                              interventions={convertToNavigatorInterventionData(intervention.detailed_interventions)}
+                            />
+                          </div>
+                        ) : (
+                          <div className="text-sm text-slate-600">
+                            <p>This intervention theme appears in <strong>{intervention.frequency}</strong> documents across multiple issues.</p>
+                          </div>
+                        )}
+                      </CardContent>
+                    )}
+                  </Card>
+                ))}
+              </div>
+            ) : (
+              data.issue_themes.map((issue) => (
                 <Card key={issue.theme_name} className="overflow-hidden">
                   <CardHeader className="pb-3">
                     <div 
@@ -482,7 +523,6 @@ export default function InterventionsNavigatorPage() {
                     >
                       <div className="flex-1">
                         <CardTitle className="text-lg flex items-center gap-3">
-                          
                           {issue.theme_name}
                           <Badge variant="secondary">{issue.frequency} documents</Badge>
                         </CardTitle>
@@ -504,7 +544,6 @@ export default function InterventionsNavigatorPage() {
                     <CardContent className="pt-0">
                       <div className="space-y-4">
                         <h4 className="font-medium text-slate-900 flex items-center gap-2">
-                          
                           Interventions:
                         </h4>
                         
@@ -518,15 +557,21 @@ export default function InterventionsNavigatorPage() {
                                 <div className="flex-1">
                                   <div className="flex items-center gap-3">
                                     <h5 className="font-medium">{intervention.theme_name}</h5>
-                                    <Badge variant="outline">{intervention.frequency} documents</Badge>
                                   </div>
                                   {expandedInterventions.has(`${issue.theme_name}-${intervention.theme_name}`) && (
-                                    <p className="text-sm text-slate-600 mt-1">{intervention.description}</p>
+                                    <div className="mt-1 space-y-1">
+                                      <p className="text-sm text-slate-600">{intervention.description}</p>
+                                      {intervention.impact_summary && (
+                                        <p className="text-sm text-slate-600">
+                                          <span className="font-semibold">Impact: </span>
+                                          {intervention.impact_summary}
+                                        </p>
+                                      )}
+                                    </div>
                                   )}
                                 </div>
                                 
-                                {/* Impact and Evidence Scores - Right Side */}
-                                <div className="flex items-center gap-4 ml-4">
+                                <div className="flex items-start gap-4 ml-4">
                                   {intervention.avg_impact_score && (
                                     <div className="text-right">
                                       <div className="text-xs text-slate-500">Impact:</div>
@@ -539,6 +584,12 @@ export default function InterventionsNavigatorPage() {
                                       {renderStars(intervention.avg_evidence_score)}
                                     </div>
                                   )}
+                                  <div className="text-right">
+                                    <div className="text-xs text-slate-500">Frequency:</div>
+                                    <div className="flex items-center gap-1">
+                                      <span className="text-xs text-slate-600">{intervention.detailed_interventions?.length || 0}</span>
+                                    </div>
+                                  </div>
                                   <div className="ml-2">
                                     {expandedInterventions.has(`${issue.theme_name}-${intervention.theme_name}`) ? (
                                       <ChevronDown className="h-4 w-4" />
@@ -572,11 +623,10 @@ export default function InterventionsNavigatorPage() {
                     </CardContent>
                   )}
                 </Card>
-                ))
-              )}
-            </div>
-          )}
-        </div>
+              ))
+            )}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/components/v2/interventions/InterventionsNavigator.tsx
+++ b/frontend/components/v2/interventions/InterventionsNavigator.tsx
@@ -479,8 +479,8 @@ export function InterventionsNavigator({
                           )}
                           <div className="text-right">
                             <div className="text-xs text-slate-500">Frequency:</div>
-                            <div className="flex items-center gap-1">
-                              <span className="text-xs text-slate-600">{intervention.detailed_interventions?.length || 0}</span>
+                            <div className="flex items-center gap-1 justify-end">
+                              <span className="text-xs text-slate-600 text-right">{intervention.detailed_interventions?.length || 0}</span>
                             </div>
                           </div>
                           <div className="ml-2">

--- a/frontend/components/v2/interventions/NavigatorInterventionsTable.tsx
+++ b/frontend/components/v2/interventions/NavigatorInterventionsTable.tsx
@@ -304,15 +304,10 @@ export function NavigatorInterventionsTable({ interventions, loading = false }: 
                                 </div>
                               </div>
                               
-                              {/* Population and subgroup info */}
-                              {(result.population_measured || result.subgroup_or_dose) && (
+                              {/* Population info */}
+                              {result.population_measured && (
                                 <div className="mt-2 text-xs text-gray-600">
-                                  {result.population_measured && (
-                                    <div><span className="font-medium">Population:</span> {result.population_measured}</div>
-                                  )}
-                                  {result.subgroup_or_dose && (
-                                    <div><span className="font-medium">Subgroup/Dose:</span> {result.subgroup_or_dose}</div>
-                                  )}
+                                  <div><span className="font-medium">Population:</span> {result.population_measured}</div>
                                 </div>
                               )}
                             </div>

--- a/frontend/components/v2/interventions/NavigatorInterventionsTable.tsx
+++ b/frontend/components/v2/interventions/NavigatorInterventionsTable.tsx
@@ -8,8 +8,7 @@ import { Tooltip } from '@/components/ui/tooltip'
 import { 
   ChevronUp, 
   ChevronDown, 
-  Target,
-  Star
+  Target
 } from 'lucide-react'
 
 interface NavigatorInterventionData {
@@ -39,6 +38,8 @@ interface NavigatorInterventionData {
   }>
   impact_score?: number
   evidence_score?: number
+  impact_justification?: string
+  evidence_justification?: string
 }
 
 interface NavigatorInterventionsTableProps {
@@ -84,33 +85,37 @@ export function NavigatorInterventionsTable({ interventions, loading = false }: 
     })
   }, [interventions, sortField, sortDirection])
 
-  const toggleRowExpansion = (interventionName: string) => {
+  const toggleRowExpansion = (interventionKey: string) => {
     const newExpanded = new Set(expandedRows)
-    if (newExpanded.has(interventionName)) {
-      newExpanded.delete(interventionName)
+    if (newExpanded.has(interventionKey)) {
+      newExpanded.delete(interventionKey)
     } else {
-      newExpanded.add(interventionName)
+      newExpanded.add(interventionKey)
     }
     setExpandedRows(newExpanded)
   }
 
-  const renderStars = (score?: number) => {
+  const renderRating = (score?: number, justification?: string, defaultText?: string) => {
     if (!score) return <span className="text-xs text-gray-400">—</span>
-    return (
-      <div className="flex items-center gap-1">
-        <div className="flex">
-          {[1, 2, 3, 4, 5].map((i) => (
-            <Star
-              key={i}
-              className={`h-3 w-3 ${
-                i <= Math.round(score) ? 'fill-yellow-400 text-yellow-400' : 'text-slate-300'
-              }`}
-            />
-          ))}
-        </div>
-        <span className="text-xs text-slate-600">{score.toFixed(1)}</span>
-      </div>
+    
+    const rating = Math.round(score)
+    const ratingDisplay = (
+      <span className="inline-block px-2 py-0.5 rounded text-center font-medium bg-blue-100 text-blue-800 text-xs cursor-help">
+        {rating}/5
+      </span>
     )
+    
+    const tooltipText = justification || defaultText
+    
+    if (tooltipText) {
+      return (
+        <Tooltip content={tooltipText}>
+          <span>{ratingDisplay}</span>
+        </Tooltip>
+      )
+    }
+    
+    return ratingDisplay
   }
 
   const SortButton = ({ field, children }: { field: SortField; children: React.ReactNode }) => (
@@ -160,10 +165,10 @@ export function NavigatorInterventionsTable({ interventions, loading = false }: 
         <div className="col-span-2">
           <SortButton field="country">Country</SortButton>
         </div>
-        <div className="col-span-1 text-center">
+        <div className="col-span-2">
           <SortButton field="type">Type</SortButton>
         </div>
-        <div className="col-span-2">
+        <div className="col-span-1">
           <SortButton field="impact_score">Impact</SortButton>
         </div>
         <div className="col-span-2">
@@ -176,15 +181,16 @@ export function NavigatorInterventionsTable({ interventions, loading = false }: 
 
       {/* Rows */}
       {sortedInterventions.map((intervention, index) => {
-        const isExpanded = expandedRows.has(intervention.name)
+        const interventionKey = `${intervention.name}-${index}`
+        const isExpanded = expandedRows.has(interventionKey)
         
         return (
-          <Card key={`${intervention.name}-${index}`} className="border-gray-200">
+          <Card key={interventionKey} className="border-gray-200">
             <CardContent className="p-0">
               {/* Main Row */}
               <div 
                 className="grid grid-cols-12 gap-4 px-4 py-3 cursor-pointer hover:bg-gray-50"
-                onClick={() => toggleRowExpansion(intervention.name)}
+                onClick={() => toggleRowExpansion(interventionKey)}
               >
                 <div className="col-span-3">
                   <div>
@@ -198,27 +204,35 @@ export function NavigatorInterventionsTable({ interventions, loading = false }: 
                   </span>
                 </div>
                 
-                <div className="col-span-1 text-center">
+                <div className="col-span-2">
                   <span className="text-sm text-gray-700">
                     {intervention.type && intervention.type !== 'Unknown' ? intervention.type : '—'}
                   </span>
                 </div>
                 
-                <div className="col-span-2">
-                  {renderStars(intervention.impact_score)}
+                <div className="col-span-1">
+                  {renderRating(
+                    intervention.impact_score, 
+                    intervention.impact_justification,
+                    'Predicted impact of this intervention based on reported outcomes'
+                  )}
                 </div>
                 
                 <div className="col-span-2">
-                  {renderStars(intervention.evidence_score)}
+                  {renderRating(
+                    intervention.evidence_score,
+                    intervention.evidence_justification,
+                    'Quality of evidence supporting this intervention based on study design and methodology'
+                  )}
                 </div>
                 
                 <div className="col-span-2 text-center">
-                  {intervention.total_sample_size ? (
+                  {intervention.total_sample_size != null && intervention.total_sample_size > 0 ? (
                     <span className="text-sm text-gray-700">
                       {intervention.total_sample_size.toLocaleString()}
                     </span>
                   ) : (
-                    <span className="text-xs text-gray-500">—</span>
+                    <span className="text-xs text-gray-500">n/a</span>
                   )}
                 </div>
               </div>

--- a/frontend/lib/analysisProjectStore.ts
+++ b/frontend/lib/analysisProjectStore.ts
@@ -9,7 +9,7 @@ export interface AnalysisProject {
   query?: string
   total_references: number
   relevant_references: number
-  status: 'created' | 'running' | 'completed' | 'failed' | 'uploading'
+  status: 'created' | 'running' | 'synthesising' | 'completed' | 'failed' | 'uploading'
   created_at: string
   created_by_user_id?: string
   created_by_name?: string

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -20,6 +20,10 @@ export const fetchWithAuthExternal = async (
   }
 
   if (!token) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn("No authentication token available (external fetch)");
+      return null;
+    }
     console.error("No authentication token available (external fetch)");
     throw new Error("No authentication token available - please sign in");
   }
@@ -83,6 +87,10 @@ export function useAPI() {
     const token = await getToken();
     
     if (!token) {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn("No authentication token available");
+        return null;
+      }
       console.error("No authentication token available");
       throw new Error("No authentication token available - please sign in");
     }
@@ -282,4 +290,4 @@ export function useAPI() {
     generateSubQuestions,
     getAnalysisFindings
   };
-} 
+}

--- a/frontend/lib/feedbackStore.ts
+++ b/frontend/lib/feedbackStore.ts
@@ -51,7 +51,7 @@ export async function fetchProjectFeedback(projectId: string): Promise<FeedbackD
     const { fetchWithAuthExternal } = await import('./api')
     
     const data = await fetchWithAuthExternal(`api/analysis-projects/${projectId}/feedback`)
-    return data.feedback
+    return data?.feedback || null
   } catch (error: unknown) {
     console.error('Error fetching project feedback:', error)
     // If it's a 404, return null (no feedback exists)
@@ -74,6 +74,10 @@ export async function saveProjectFeedback(
       method: 'POST',
       body: JSON.stringify(feedback),
     })
+    
+    if (!data?.feedback) {
+      throw new Error('Invalid response from server')
+    }
     
     return data.feedback
   } catch (error: unknown) {

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <text y="50%" x="50%" dominant-baseline="middle" text-anchor="middle" font-size="48">🌐</text>
+</svg>


### PR DESCRIPTION
Reorganised the Results page
- Summary is now the default, first tab and has basic search stats, exec briefing and charts
- Evidence tab now has the "interventions navigator" (default view) and documents table

Projects page:
- Toggle to show only user's projects
- Removed delete and edit buttons from non-user projects (nb: quick fix for frontend only; in principle users can still delete other projects via API)

User feedback:
- A new table on Supabase to collect user feedback (can have multiple feedback instances per project)

Favicon
- Changed favicon from the default one
