### PR TITLE
Langfuse Tracking

### DIFF
--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -726,6 +726,7 @@ async def generate_policy_assistant_response(
     conversation: ConversationRecord,
     user_message: str,
     project_id: str = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    user_id: Optional[str] = None,
 ) -> tuple[str, str, str, bool, bool, bool]:
     """Generate response using simplified LangChain conversation manager or RAG"""
 
@@ -780,7 +781,10 @@ async def generate_policy_assistant_response(
             response_content,
             analysis,
         ) = await simplified_conversation_manager.generate_response(
-            message_dicts, user_message
+            message_dicts,
+            user_message,
+            policy_project_id=project_id,
+            policy_user_id=user_id,
         )
 
         return (
@@ -836,6 +840,7 @@ async def chat_with_policy_assistant(
             conversation,
             request.message,
             request.project_id or "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+            user_id=current_user.user_id,
         )
 
         # Add assistant message to conversation
@@ -1282,7 +1287,9 @@ async def extract_key_insights(
     try:
         # Extract insights
         insights = await advanced_rag_service.extract_key_insights(
-            user_query=request.query, project_id=request.project_id
+            user_query=request.query,
+            project_id=request.project_id,
+            policy_user_id=current_user.user_id,
         )
 
         # Review the insights
@@ -1294,6 +1301,7 @@ async def extract_key_insights(
             insights = await advanced_rag_service.extract_key_insights(
                 user_query=f"{request.query} - provide more detailed analysis",
                 project_id=request.project_id,
+                policy_user_id=current_user.user_id,
             )
             review = await advanced_rag_service.review_insights(insights)
 

--- a/backend/app/api/projects_v2.py
+++ b/backend/app/api/projects_v2.py
@@ -454,9 +454,22 @@ async def trigger_synthesis_for_project(project_id: str) -> None:
     try:
         logger.info(f"Starting synthesis for project {project_id}")
 
+        project_user_id = None
+        try:
+            project_row = (
+                vectorization_service.supabase.table("analysis_projects")
+                .select("created_by_user_id")
+                .eq("id", project_id)
+                .execute()
+            )
+            if project_row.data:
+                project_user_id = project_row.data[0].get("created_by_user_id")
+        except Exception:
+            project_user_id = None
+
         # Run synthesis
         synthesis_agent = SynthesisAgent()
-        final_state = await synthesis_agent.run(project_id)
+        final_state = await synthesis_agent.run(project_id, user_id=project_user_id)
 
         # Remove the placeholder run before creating the final one (async to avoid blocking)
         supabase = vectorization_service.supabase

--- a/backend/app/services/advanced_rag.py
+++ b/backend/app/services/advanced_rag.py
@@ -1,9 +1,12 @@
 import logging
+import os
+from datetime import datetime
 from typing import List, Dict, Any
 from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 from app.core.config import settings
 from app.services.vectorization import vectorization_service
+from langfuse import Langfuse
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +89,7 @@ class AdvancedRAGService:
     def __init__(self):
         self._openai_client = None
         self._vectorization = vectorization_service
+        self._langfuse = None
 
     @property
     def openai_client(self):
@@ -94,6 +98,12 @@ class AdvancedRAGService:
                 raise ValueError("OPENAI_API_KEY is required for advanced RAG service")
             self._openai_client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
         return self._openai_client
+
+    @property
+    def langfuse(self) -> Langfuse:
+        if self._langfuse is None:
+            self._langfuse = Langfuse()
+        return self._langfuse
 
     async def extract_key_insights(
         self, user_query: str, project_id: str = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
@@ -132,6 +142,15 @@ class AdvancedRAGService:
         self, user_query: str, project_id: str
     ) -> List[Dict[str, Any]]:
         """Gather evidence from multiple search perspectives for comprehensive insights"""
+        # Start Langfuse trace for retrieval phase
+        session_id = f"retrieval:{project_id}:{datetime.utcnow().isoformat()}"
+        trace = self.langfuse.trace(
+            name="retrieval.insights",
+            user_id=os.environ.get("LANGFUSE_USER_ID"),
+            session_id=session_id,
+            tags=["component:retrieval", f"project:{project_id}"],
+            metadata={"phase": "insights", "query": user_query},
+        )
 
         # Multiple search queries to ensure comprehensive coverage
         search_queries = [
@@ -147,12 +166,20 @@ class AdvancedRAGService:
 
         for query in search_queries:
             try:
+                span = trace.span(
+                    name="retrieval.search",
+                    tags=["component:retrieval"],
+                    metadata={"query": query},
+                )
+                span.start()
                 evidence = await self._vectorization.search_similar_content(
                     query=query,
                     project_id=project_id,
                     match_threshold=0.6,  # Lower threshold for broader coverage
                     match_count=10,  # More documents per query
                 )
+                span.update(metadata={"returned": len(evidence or [])})
+                span.end()
 
                 # Add unique documents only
                 for doc in evidence:
@@ -169,6 +196,12 @@ class AdvancedRAGService:
             all_evidence = await self._enrich_evidence_with_details(
                 all_evidence, project_id
             )
+
+        # Finalize trace
+        try:
+            trace.update(metadata={"total_returned": len(all_evidence)})
+        finally:
+            trace.end()
 
         return all_evidence[:15]  # Limit to top 15 most relevant pieces
 
@@ -481,6 +514,15 @@ INSIGHTS:
         self, user_query: str, project_id: str
     ) -> List[Dict[str, Any]]:
         """Gather evidence specifically focused on policy implications and recommendations"""
+        # Start Langfuse trace for retrieval phase
+        session_id = f"retrieval:{project_id}:{datetime.utcnow().isoformat()}"
+        trace = self.langfuse.trace(
+            name="retrieval.policy",
+            user_id=os.environ.get("LANGFUSE_USER_ID"),
+            session_id=session_id,
+            tags=["component:retrieval", f"project:{project_id}"],
+            metadata={"phase": "policy", "query": user_query},
+        )
 
         # Policy-focused search queries
         policy_queries = [
@@ -497,12 +539,20 @@ INSIGHTS:
 
         for query in policy_queries:
             try:
+                span = trace.span(
+                    name="retrieval.search",
+                    tags=["component:retrieval"],
+                    metadata={"query": query},
+                )
+                span.start()
                 evidence = await self._vectorization.search_similar_content(
                     query=query,
                     project_id=project_id,
                     match_threshold=0.6,
                     match_count=8,
                 )
+                span.update(metadata={"returned": len(evidence or [])})
+                span.end()
 
                 # Add unique documents only
                 for doc in evidence:
@@ -521,6 +571,12 @@ INSIGHTS:
             all_evidence = await self._enrich_evidence_with_details(
                 all_evidence, project_id
             )
+
+        # Finalize trace
+        try:
+            trace.update(metadata={"total_returned": len(all_evidence)})
+        finally:
+            trace.end()
 
         return all_evidence[:12]  # Limit to top 12 most relevant pieces
 

--- a/backend/app/services/advanced_rag.py
+++ b/backend/app/services/advanced_rag.py
@@ -1,10 +1,10 @@
 import logging
-from datetime import datetime
 from typing import List, Dict, Any, Optional
 from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 from app.core.config import settings
 from app.services.vectorization import vectorization_service
+from app.utils.llm.llm_utils import resolve_langfuse_session_id
 from langfuse import Langfuse
 
 logger = logging.getLogger(__name__)
@@ -145,12 +145,12 @@ class AdvancedRAGService:
     ) -> List[Dict[str, Any]]:
         """Gather evidence from multiple search perspectives for comprehensive insights"""
         # Start Langfuse trace for retrieval phase
-        session_id = f"retrieval:{project_id}:{datetime.utcnow().isoformat()}"
+        session_id = resolve_langfuse_session_id(project_id)
         trace = self.langfuse.trace(
             name="retrieval.insights",
             user_id=policy_user_id,
             session_id=session_id,
-            tags=["component:retrieval", f"project:{project_id}"],
+            tags=["component:retrieval"],
             metadata={
                 "phase": "insights",
                 "query": user_query,
@@ -525,12 +525,12 @@ INSIGHTS:
     ) -> List[Dict[str, Any]]:
         """Gather evidence specifically focused on policy implications and recommendations"""
         # Start Langfuse trace for retrieval phase
-        session_id = f"retrieval:{project_id}:{datetime.utcnow().isoformat()}"
+        session_id = resolve_langfuse_session_id(project_id)
         trace = self.langfuse.trace(
             name="retrieval.policy",
             user_id=policy_user_id,
             session_id=session_id,
-            tags=["component:retrieval", f"project:{project_id}"],
+            tags=["component:retrieval"],
             metadata={
                 "phase": "policy",
                 "query": user_query,

--- a/backend/app/services/advanced_rag.py
+++ b/backend/app/services/advanced_rag.py
@@ -1,7 +1,6 @@
 import logging
-import os
 from datetime import datetime
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 from app.core.config import settings
@@ -106,14 +105,17 @@ class AdvancedRAGService:
         return self._langfuse
 
     async def extract_key_insights(
-        self, user_query: str, project_id: str = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+        self,
+        user_query: str,
+        project_id: str = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        policy_user_id: Optional[str] = None,
     ) -> InsightExtraction:
         """Extract key insights from evidence using RAG"""
 
         try:
             # Get comprehensive evidence from multiple search angles
             insights_contexts = await self._gather_insights_evidence(
-                user_query, project_id
+                user_query, project_id, policy_user_id=policy_user_id
             )
 
             if not insights_contexts:
@@ -139,17 +141,22 @@ class AdvancedRAGService:
             )
 
     async def _gather_insights_evidence(
-        self, user_query: str, project_id: str
+        self, user_query: str, project_id: str, policy_user_id: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """Gather evidence from multiple search perspectives for comprehensive insights"""
         # Start Langfuse trace for retrieval phase
         session_id = f"retrieval:{project_id}:{datetime.utcnow().isoformat()}"
         trace = self.langfuse.trace(
             name="retrieval.insights",
-            user_id=os.environ.get("LANGFUSE_USER_ID"),
+            user_id=policy_user_id,
             session_id=session_id,
             tags=["component:retrieval", f"project:{project_id}"],
-            metadata={"phase": "insights", "query": user_query},
+            metadata={
+                "phase": "insights",
+                "query": user_query,
+                "policy_project_id": project_id,
+                "policy_user_id": policy_user_id,
+            },
         )
 
         # Multiple search queries to ensure comprehensive coverage
@@ -479,12 +486,15 @@ INSIGHTS:
         user_query: str,
         insights: InsightExtraction = None,
         project_id: str = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        policy_user_id: Optional[str] = None,
     ) -> PolicyRecommendations:
         """Generate policy recommendations based on evidence and insights"""
 
         try:
             # Get evidence from multiple angles focused on policy implications
-            policy_contexts = await self._gather_policy_evidence(user_query, project_id)
+            policy_contexts = await self._gather_policy_evidence(
+                user_query, project_id, policy_user_id=policy_user_id
+            )
 
             if not policy_contexts:
                 return PolicyRecommendations(
@@ -511,17 +521,22 @@ INSIGHTS:
             )
 
     async def _gather_policy_evidence(
-        self, user_query: str, project_id: str
+        self, user_query: str, project_id: str, policy_user_id: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """Gather evidence specifically focused on policy implications and recommendations"""
         # Start Langfuse trace for retrieval phase
         session_id = f"retrieval:{project_id}:{datetime.utcnow().isoformat()}"
         trace = self.langfuse.trace(
             name="retrieval.policy",
-            user_id=os.environ.get("LANGFUSE_USER_ID"),
+            user_id=policy_user_id,
             session_id=session_id,
             tags=["component:retrieval", f"project:{project_id}"],
-            metadata={"phase": "policy", "query": user_query},
+            metadata={
+                "phase": "policy",
+                "query": user_query,
+                "policy_project_id": project_id,
+                "policy_user_id": policy_user_id,
+            },
         )
 
         # Policy-focused search queries

--- a/backend/app/services/analysis/extractor_langchain.py
+++ b/backend/app/services/analysis/extractor_langchain.py
@@ -63,6 +63,7 @@ class LangChainExtractionConfig:
     temperature: float = 0.0
     concurrency: int = 3
     project_id: Optional[str] = None  # For interim storage
+    user_id: Optional[str] = None  # Policy Atlas user initiating the run
 
 
 class LangChainExtractorService:
@@ -74,6 +75,8 @@ class LangChainExtractorService:
         self.workflow = ExtractionWorkflow(
             model=config.model,
             temperature=config.temperature,
+            policy_project_id=config.project_id,
+            policy_user_id=config.user_id,
         )
         # Initialize storage service for interim storage
         self.storage_service = AnalysisStorageService() if config.project_id else None

--- a/backend/app/services/analysis/relevance.py
+++ b/backend/app/services/analysis/relevance.py
@@ -30,10 +30,18 @@ class RelevanceService:
     - Classify document type (research_paper | policy_document | other)
     """
 
-    def __init__(self, query: str, export_dir: Optional[str] = None):
+    def __init__(
+        self,
+        query: str,
+        export_dir: Optional[str] = None,
+        project_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ):
         self.query = query
         self.export_dir = Path(export_dir) if export_dir else Path("./temp")
         self.export_dir.mkdir(parents=True, exist_ok=True)
+        self.project_id = project_id
+        self.user_id = user_id
 
         # System message for relevance and document type assessment
         self.system_message = RELEVANCE_SYSTEM_PROMPT(query)
@@ -277,6 +285,13 @@ class RelevanceService:
             system_message=self.system_message,
             session_name=session_name,
             output_fields=self.fields,
+            component_tags=[
+                "component:relevance",
+                "component:relevance.batch_check",
+            ],
+            policy_project_id=self.project_id,
+            policy_user_id=self.user_id,
+            run_name="relevance.batch_check",
         )
 
         # Run relevance assessment

--- a/backend/app/services/analysis/relevance.py
+++ b/backend/app/services/analysis/relevance.py
@@ -283,7 +283,7 @@ class RelevanceService:
         processor = batch_check.LLMProcessor(
             output_path=output_path,
             system_message=self.system_message,
-            session_name=session_name,
+            session_name=None,
             output_fields=self.fields,
             component_tags=[
                 "component:relevance",

--- a/backend/app/services/analysis/service.py
+++ b/backend/app/services/analysis/service.py
@@ -100,7 +100,10 @@ class AnalysisService:
             with StageTimer(monitor, "relevance"):
                 logger.info("Run %s starting relevance checking", run_id)
                 relevance_service = RelevanceService(
-                    query=config.query, export_dir=str(run_export_dir)
+                    query=config.query,
+                    export_dir=str(run_export_dir),
+                    project_id=project_id,
+                    user_id=user_id,
                 )
                 references_csv = await relevance_service.check_relevance(
                     str(references_csv)

--- a/backend/app/services/analysis/service.py
+++ b/backend/app/services/analysis/service.py
@@ -197,6 +197,7 @@ class AnalysisService:
                     temperature=0.0,
                     concurrency=settings.BATCH_SIZE_EXTRACTION,
                     project_id=project_id,
+                    user_id=user_id,
                 )
             )
 

--- a/backend/app/services/analysis/workflow_langchain.py
+++ b/backend/app/services/analysis/workflow_langchain.py
@@ -6,14 +6,17 @@ Implements: Issues → Interventions → Mapping → Results (per intervention l
 import json
 import logging
 from typing import Any, Dict, List, Optional, TypedDict
-from datetime import datetime
 
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 
 from app.core.config import settings
-from app.utils.llm.llm_utils import get_langfuse_handler, build_langfuse_metadata
+from app.utils.llm.llm_utils import (
+    get_langfuse_handler,
+    build_langfuse_metadata,
+    resolve_langfuse_session_id,
+)
 from .prompts import (
     ISSUES_PROMPT,
     INTERVENTIONS_PROMPT,
@@ -70,6 +73,7 @@ class ExtractionWorkflow:
             openai_api_key=settings.OPENAI_API_KEY,
             request_timeout=120.0,  # 2 minute timeout to prevent hanging
         )
+        self.model_name = model
         self.json_parser = JsonOutputParser()
         self.workflow = self._build_workflow()
         self.policy_project_id = policy_project_id
@@ -101,8 +105,8 @@ class ExtractionWorkflow:
 
     async def run(self, paper_id: str, full_text: str) -> DocumentExtractionBundle:
         """Run the complete extraction workflow."""
-        # Create a per-run Langfuse session and propagate handler via closure
-        session_id = f"extraction:{paper_id}:{datetime.utcnow().isoformat()}"
+        # Create a per-project Langfuse session and propagate handler via closure
+        session_id = resolve_langfuse_session_id(self.policy_project_id)
         self._langfuse_session_id = session_id
         self._langfuse_handler = get_langfuse_handler(session_id=session_id)
 
@@ -172,6 +176,7 @@ class ExtractionWorkflow:
                 "component:extraction.issues",
                 f"paper:{state['paper_id']}",
             ]
+            tags.append(f"model:{self.model_name}")
             result = await chain.ainvoke(
                 {"full_text": state["full_text"]},
                 config={
@@ -204,6 +209,7 @@ class ExtractionWorkflow:
                 "component:extraction.interventions",
                 f"paper:{state['paper_id']}",
             ]
+            tags.append(f"model:{self.model_name}")
             result = await chain.ainvoke(
                 {"full_text": state["full_text"]},
                 config={
@@ -254,6 +260,7 @@ class ExtractionWorkflow:
                 "component:extraction.mappings",
                 f"paper:{state['paper_id']}",
             ]
+            tags.append(f"model:{self.model_name}")
             result = await chain.ainvoke(
                 {
                     "full_text": state["full_text"],
@@ -299,6 +306,7 @@ class ExtractionWorkflow:
                         "component:extraction.results",
                         f"paper:{state['paper_id']}",
                     ]
+                    tags.append(f"model:{self.model_name}")
 
                     result = await chain.ainvoke(
                         {
@@ -366,6 +374,7 @@ class ExtractionWorkflow:
                 "component:extraction.conclusions",
                 f"paper:{state['paper_id']}",
             ]
+            tags.append(f"model:{self.model_name}")
             result = await chain.ainvoke(
                 {
                     "full_text": state["full_text"],

--- a/backend/app/services/analysis/workflow_langchain.py
+++ b/backend/app/services/analysis/workflow_langchain.py
@@ -6,12 +6,14 @@ Implements: Issues → Interventions → Mapping → Results (per intervention l
 import json
 import logging
 from typing import Any, Dict, List, TypedDict
+from datetime import datetime
 
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 
 from app.core.config import settings
+from app.utils.llm.llm_utils import get_langfuse_handler
 from .prompts import (
     ISSUES_PROMPT,
     INTERVENTIONS_PROMPT,
@@ -89,6 +91,10 @@ class ExtractionWorkflow:
 
     async def run(self, paper_id: str, full_text: str) -> DocumentExtractionBundle:
         """Run the complete extraction workflow."""
+        # Create a per-run Langfuse session and propagate handler via closure
+        session_id = f"extraction:{paper_id}:{datetime.utcnow().isoformat()}"
+        self._langfuse_handler = get_langfuse_handler(session_id=session_id)
+
         initial_state = WorkflowState(
             paper_id=paper_id,
             full_text=full_text,
@@ -139,7 +145,21 @@ class ExtractionWorkflow:
         """Stage A: Extract issues."""
         try:
             chain = ISSUES_PROMPT | self.llm | self.json_parser
-            result = await chain.ainvoke({"full_text": state["full_text"]})
+            result = await chain.ainvoke(
+                {"full_text": state["full_text"]},
+                config={
+                    "callbacks": [getattr(self, "_langfuse_handler", None)]
+                    if getattr(self, "_langfuse_handler", None)
+                    else [],
+                    "tags": [
+                        "component:extraction",
+                        "component:extraction.issues",
+                        f"paper:{state['paper_id']}",
+                    ],
+                    "metadata": {"paper_id": state["paper_id"]},
+                    "run_name": "extraction.issues",
+                },
+            )
 
             extraction = IssuesExtraction(**result)
             logger.info(f"Extracted {len(extraction.issues)} issues")
@@ -154,7 +174,21 @@ class ExtractionWorkflow:
         """Stage B: Extract interventions."""
         try:
             chain = INTERVENTIONS_PROMPT | self.llm | self.json_parser
-            result = await chain.ainvoke({"full_text": state["full_text"]})
+            result = await chain.ainvoke(
+                {"full_text": state["full_text"]},
+                config={
+                    "callbacks": [getattr(self, "_langfuse_handler", None)]
+                    if getattr(self, "_langfuse_handler", None)
+                    else [],
+                    "tags": [
+                        "component:extraction",
+                        "component:extraction.interventions",
+                        f"paper:{state['paper_id']}",
+                    ],
+                    "metadata": {"paper_id": state["paper_id"]},
+                    "run_name": "extraction.interventions",
+                },
+            )
 
             extraction = InterventionsExtraction(**result)
             logger.info(f"Extracted {len(extraction.interventions)} interventions")
@@ -192,7 +226,19 @@ class ExtractionWorkflow:
                     "full_text": state["full_text"],
                     "issues_json": issues_json,
                     "interventions_json": interventions_json,
-                }
+                },
+                config={
+                    "callbacks": [getattr(self, "_langfuse_handler", None)]
+                    if getattr(self, "_langfuse_handler", None)
+                    else [],
+                    "tags": [
+                        "component:extraction",
+                        "component:extraction.mappings",
+                        f"paper:{state['paper_id']}",
+                    ],
+                    "metadata": {"paper_id": state["paper_id"]},
+                    "run_name": "extraction.mappings",
+                },
             )
 
             extraction = MappingsExtraction(**result)
@@ -222,7 +268,22 @@ class ExtractionWorkflow:
                         {
                             "full_text": state["full_text"],
                             "one_intervention_json": one_intervention_json,
-                        }
+                        },
+                        config={
+                            "callbacks": [getattr(self, "_langfuse_handler", None)]
+                            if getattr(self, "_langfuse_handler", None)
+                            else [],
+                            "tags": [
+                                "component:extraction",
+                                "component:extraction.results",
+                                f"paper:{state['paper_id']}",
+                            ],
+                            "metadata": {
+                                "paper_id": state["paper_id"],
+                                "intervention_idx": intervention.idx,
+                            },
+                            "run_name": "extraction.results",
+                        },
                     )
 
                     extraction = ResultsExtraction(**result)
@@ -269,7 +330,19 @@ class ExtractionWorkflow:
                 {
                     "full_text": state["full_text"],
                     "interventions_json": interventions_json,
-                }
+                },
+                config={
+                    "callbacks": [getattr(self, "_langfuse_handler", None)]
+                    if getattr(self, "_langfuse_handler", None)
+                    else [],
+                    "tags": [
+                        "component:extraction",
+                        "component:extraction.conclusions",
+                        f"paper:{state['paper_id']}",
+                    ],
+                    "metadata": {"paper_id": state["paper_id"]},
+                    "run_name": "extraction.conclusions",
+                },
             )
 
             extraction = ConclusionsExtraction(**result)

--- a/backend/app/services/analysis/workflow_langchain.py
+++ b/backend/app/services/analysis/workflow_langchain.py
@@ -5,7 +5,7 @@ Implements: Issues → Interventions → Mapping → Results (per intervention l
 
 import json
 import logging
-from typing import Any, Dict, List, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict
 from datetime import datetime
 
 from langchain_core.output_parsers import JsonOutputParser
@@ -13,7 +13,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 
 from app.core.config import settings
-from app.utils.llm.llm_utils import get_langfuse_handler
+from app.utils.llm.llm_utils import get_langfuse_handler, build_langfuse_metadata
 from .prompts import (
     ISSUES_PROMPT,
     INTERVENTIONS_PROMPT,
@@ -54,7 +54,14 @@ class WorkflowState(TypedDict):
 class ExtractionWorkflow:
     """LangGraph workflow for document extraction."""
 
-    def __init__(self, model: str = "gpt-4o-mini", temperature: float = 0.0):
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.0,
+        *,
+        policy_project_id: Optional[str] = None,
+        policy_user_id: Optional[str] = None,
+    ):
         if not settings.OPENAI_API_KEY:
             raise ValueError("OPENAI_API_KEY is required for LangChain workflow")
         self.llm = ChatOpenAI(
@@ -65,6 +72,9 @@ class ExtractionWorkflow:
         )
         self.json_parser = JsonOutputParser()
         self.workflow = self._build_workflow()
+        self.policy_project_id = policy_project_id
+        self.policy_user_id = policy_user_id
+        self._langfuse_session_id: Optional[str] = None
 
     def _build_workflow(self) -> StateGraph:
         """Build the LangGraph workflow."""
@@ -93,6 +103,7 @@ class ExtractionWorkflow:
         """Run the complete extraction workflow."""
         # Create a per-run Langfuse session and propagate handler via closure
         session_id = f"extraction:{paper_id}:{datetime.utcnow().isoformat()}"
+        self._langfuse_session_id = session_id
         self._langfuse_handler = get_langfuse_handler(session_id=session_id)
 
         initial_state = WorkflowState(
@@ -141,22 +152,36 @@ class ExtractionWorkflow:
                 conclusion=None,
             )
 
+    def _build_metadata(
+        self, tags: List[str], extra: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        return build_langfuse_metadata(
+            tags=tags,
+            session_id=self._langfuse_session_id,
+            user_id=self.policy_user_id,
+            project_id=self.policy_project_id,
+            extra=extra,
+        )
+
     async def _extract_issues(self, state: WorkflowState) -> Dict[str, Any]:
         """Stage A: Extract issues."""
         try:
             chain = ISSUES_PROMPT | self.llm | self.json_parser
+            tags = [
+                "component:extraction",
+                "component:extraction.issues",
+                f"paper:{state['paper_id']}",
+            ]
             result = await chain.ainvoke(
                 {"full_text": state["full_text"]},
                 config={
                     "callbacks": [getattr(self, "_langfuse_handler", None)]
                     if getattr(self, "_langfuse_handler", None)
                     else [],
-                    "tags": [
-                        "component:extraction",
-                        "component:extraction.issues",
-                        f"paper:{state['paper_id']}",
-                    ],
-                    "metadata": {"paper_id": state["paper_id"]},
+                    "tags": tags,
+                    "metadata": self._build_metadata(
+                        tags, extra={"paper_id": state["paper_id"]}
+                    ),
                     "run_name": "extraction.issues",
                 },
             )
@@ -174,18 +199,21 @@ class ExtractionWorkflow:
         """Stage B: Extract interventions."""
         try:
             chain = INTERVENTIONS_PROMPT | self.llm | self.json_parser
+            tags = [
+                "component:extraction",
+                "component:extraction.interventions",
+                f"paper:{state['paper_id']}",
+            ]
             result = await chain.ainvoke(
                 {"full_text": state["full_text"]},
                 config={
                     "callbacks": [getattr(self, "_langfuse_handler", None)]
                     if getattr(self, "_langfuse_handler", None)
                     else [],
-                    "tags": [
-                        "component:extraction",
-                        "component:extraction.interventions",
-                        f"paper:{state['paper_id']}",
-                    ],
-                    "metadata": {"paper_id": state["paper_id"]},
+                    "tags": tags,
+                    "metadata": self._build_metadata(
+                        tags, extra={"paper_id": state["paper_id"]}
+                    ),
                     "run_name": "extraction.interventions",
                 },
             )
@@ -221,6 +249,11 @@ class ExtractionWorkflow:
             )
 
             chain = MAPPING_PROMPT | self.llm | self.json_parser
+            tags = [
+                "component:extraction",
+                "component:extraction.mappings",
+                f"paper:{state['paper_id']}",
+            ]
             result = await chain.ainvoke(
                 {
                     "full_text": state["full_text"],
@@ -231,12 +264,10 @@ class ExtractionWorkflow:
                     "callbacks": [getattr(self, "_langfuse_handler", None)]
                     if getattr(self, "_langfuse_handler", None)
                     else [],
-                    "tags": [
-                        "component:extraction",
-                        "component:extraction.mappings",
-                        f"paper:{state['paper_id']}",
-                    ],
-                    "metadata": {"paper_id": state["paper_id"]},
+                    "tags": tags,
+                    "metadata": self._build_metadata(
+                        tags, extra={"paper_id": state["paper_id"]}
+                    ),
                     "run_name": "extraction.mappings",
                 },
             )
@@ -263,6 +294,11 @@ class ExtractionWorkflow:
             for intervention in state["interventions"]:
                 try:
                     one_intervention_json = json.dumps(intervention.model_dump())
+                    tags = [
+                        "component:extraction",
+                        "component:extraction.results",
+                        f"paper:{state['paper_id']}",
+                    ]
 
                     result = await chain.ainvoke(
                         {
@@ -273,15 +309,14 @@ class ExtractionWorkflow:
                             "callbacks": [getattr(self, "_langfuse_handler", None)]
                             if getattr(self, "_langfuse_handler", None)
                             else [],
-                            "tags": [
-                                "component:extraction",
-                                "component:extraction.results",
-                                f"paper:{state['paper_id']}",
-                            ],
-                            "metadata": {
-                                "paper_id": state["paper_id"],
-                                "intervention_idx": intervention.idx,
-                            },
+                            "tags": tags,
+                            "metadata": self._build_metadata(
+                                tags,
+                                extra={
+                                    "paper_id": state["paper_id"],
+                                    "intervention_idx": intervention.idx,
+                                },
+                            ),
                             "run_name": "extraction.results",
                         },
                     )
@@ -326,6 +361,11 @@ class ExtractionWorkflow:
             )
 
             chain = CONCLUSIONS_PROMPT | self.llm | self.json_parser
+            tags = [
+                "component:extraction",
+                "component:extraction.conclusions",
+                f"paper:{state['paper_id']}",
+            ]
             result = await chain.ainvoke(
                 {
                     "full_text": state["full_text"],
@@ -335,12 +375,10 @@ class ExtractionWorkflow:
                     "callbacks": [getattr(self, "_langfuse_handler", None)]
                     if getattr(self, "_langfuse_handler", None)
                     else [],
-                    "tags": [
-                        "component:extraction",
-                        "component:extraction.conclusions",
-                        f"paper:{state['paper_id']}",
-                    ],
-                    "metadata": {"paper_id": state["paper_id"]},
+                    "tags": tags,
+                    "metadata": self._build_metadata(
+                        tags, extra={"paper_id": state["paper_id"]}
+                    ),
                     "run_name": "extraction.conclusions",
                 },
             )

--- a/backend/app/services/screening.py
+++ b/backend/app/services/screening.py
@@ -159,6 +159,7 @@ class ScreeningService:
             system_message=self.system_message,
             session_name=session_name,
             output_fields=self.fields,
+            run_name="screening.batch_check",
         )
 
         # Run screening

--- a/backend/app/services/simplified_conversation_manager.py
+++ b/backend/app/services/simplified_conversation_manager.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import Dict, List, Optional, Tuple
 from enum import Enum
+from datetime import datetime
 
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -14,7 +15,7 @@ from langchain_core.output_parsers import JsonOutputParser
 from pydantic import BaseModel, Field
 
 from app.core.config import settings
-from app.utils.llm.llm_utils import get_langfuse_handler
+from app.utils.llm.llm_utils import get_langfuse_handler, build_langfuse_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -63,10 +64,7 @@ class SimplifiedConversationManager:
                 max_tokens=settings.LLM_MAX_TOKENS,
                 openai_api_key=settings.OPENAI_API_KEY,
             )
-            # Langfuse handler for chat sessions
-            self.langfuse_handler = get_langfuse_handler(
-                session_id=f"chat:{settings.PROJECT_NAME}"
-            )
+            self.langfuse_handler = get_langfuse_handler()
             self._setup_analyzer()
 
     def _setup_analyzer(self):
@@ -115,7 +113,14 @@ Respond with this JSON format:
         json_parser = JsonOutputParser(pydantic_object=ConversationAnalysis)
         self.analyzer = analysis_prompt | self.llm | json_parser
 
-    async def analyze_conversation(self, messages: List[Dict]) -> ConversationAnalysis:
+    async def analyze_conversation(
+        self,
+        messages: List[Dict],
+        *,
+        session_id: Optional[str] = None,
+        policy_project_id: Optional[str] = None,
+        policy_user_id: Optional[str] = None,
+    ) -> ConversationAnalysis:
         """Analyze conversation using AI self-assessment"""
 
         try:
@@ -133,14 +138,21 @@ Respond with this JSON format:
                         )
 
                 try:
+                    analyze_tags = ["component:chat", "component:chat.analyze"]
                     result = await self.analyzer.ainvoke(
                         {"messages": langchain_messages},
                         config={
                             "callbacks": [self.langfuse_handler]
                             if self.langfuse_handler
                             else [],
-                            "tags": ["component:chat", "component:chat.analyze"],
-                            "metadata": {},
+                            "tags": analyze_tags,
+                            "metadata": build_langfuse_metadata(
+                                tags=analyze_tags,
+                                session_id=session_id
+                                or f"chat-analyze:{datetime.utcnow().isoformat()}",
+                                user_id=policy_user_id,
+                                project_id=policy_project_id,
+                            ),
                             "run_name": "chat.analyze",
                         },
                     )
@@ -231,18 +243,35 @@ Respond with this JSON format:
         )
 
     async def generate_response(
-        self, messages: List[Dict], user_message: str
+        self,
+        messages: List[Dict],
+        user_message: str,
+        *,
+        policy_project_id: Optional[str] = None,
+        policy_user_id: Optional[str] = None,
     ) -> Tuple[str, ConversationAnalysis]:
         """Generate response with conversation analysis"""
+
+        session_id = f"chat:{policy_project_id or 'global'}:{policy_user_id or 'anonymous'}:{datetime.utcnow().isoformat()}"
 
         try:
             # First analyze the conversation (including new message)
             analysis_messages = messages + [{"role": "user", "content": user_message}]
-            analysis = await self.analyze_conversation(analysis_messages)
+            analysis = await self.analyze_conversation(
+                analysis_messages,
+                session_id=session_id,
+                policy_project_id=policy_project_id,
+                policy_user_id=policy_user_id,
+            )
 
             if self.llm and not settings.MOCK_OPENAI:
                 return await self._generate_ai_response(
-                    messages, user_message, analysis
+                    messages,
+                    user_message,
+                    analysis,
+                    session_id=session_id,
+                    policy_project_id=policy_project_id,
+                    policy_user_id=policy_user_id,
                 )
             else:
                 return await self._generate_mock_response(user_message, analysis)
@@ -256,7 +285,14 @@ Respond with this JSON format:
             return await self._generate_mock_response(user_message, analysis)
 
     async def _generate_ai_response(
-        self, messages: List[Dict], user_message: str, analysis: ConversationAnalysis
+        self,
+        messages: List[Dict],
+        user_message: str,
+        analysis: ConversationAnalysis,
+        *,
+        session_id: str,
+        policy_project_id: Optional[str],
+        policy_user_id: Optional[str],
     ) -> Tuple[str, ConversationAnalysis]:
         """Generate AI response using LangChain"""
 
@@ -302,12 +338,18 @@ Continue to help them refine their thinking, answer questions, or prepare for ev
         langchain_messages.append(HumanMessage(content=user_message))
 
         # Generate response
+        respond_tags = ["component:chat", "component:chat.respond"]
         response = await self.llm.ainvoke(
             langchain_messages,
             config={
                 "callbacks": [self.langfuse_handler] if self.langfuse_handler else [],
-                "tags": ["component:chat", "component:chat.respond"],
-                "metadata": {},
+                "tags": respond_tags,
+                "metadata": build_langfuse_metadata(
+                    tags=respond_tags,
+                    session_id=session_id,
+                    user_id=policy_user_id,
+                    project_id=policy_project_id,
+                ),
                 "run_name": "chat.respond",
             },
         )

--- a/backend/app/services/simplified_conversation_manager.py
+++ b/backend/app/services/simplified_conversation_manager.py
@@ -138,7 +138,11 @@ Respond with this JSON format:
                         )
 
                 try:
-                    analyze_tags = ["component:chat", "component:chat.analyze"]
+                    analyze_tags = [
+                        "component:chat",
+                        "component:chat.analyze",
+                        f"model:{settings.LLM_MODEL}",
+                    ]
                     result = await self.analyzer.ainvoke(
                         {"messages": langchain_messages},
                         config={
@@ -338,7 +342,11 @@ Continue to help them refine their thinking, answer questions, or prepare for ev
         langchain_messages.append(HumanMessage(content=user_message))
 
         # Generate response
-        respond_tags = ["component:chat", "component:chat.respond"]
+        respond_tags = [
+            "component:chat",
+            "component:chat.respond",
+            f"model:{settings.LLM_MODEL}",
+        ]
         response = await self.llm.ainvoke(
             langchain_messages,
             config={

--- a/backend/app/services/simplified_conversation_manager.py
+++ b/backend/app/services/simplified_conversation_manager.py
@@ -14,6 +14,7 @@ from langchain_core.output_parsers import JsonOutputParser
 from pydantic import BaseModel, Field
 
 from app.core.config import settings
+from app.utils.llm.llm_utils import get_langfuse_handler
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,7 @@ class SimplifiedConversationManager:
     def __init__(self):
         self.llm = None
         self.analyzer = None
+        self.langfuse_handler = None
 
         if settings.OPENAI_API_KEY and not settings.MOCK_OPENAI:
             self.llm = ChatOpenAI(
@@ -60,6 +62,10 @@ class SimplifiedConversationManager:
                 temperature=settings.LLM_TEMPERATURE,
                 max_tokens=settings.LLM_MAX_TOKENS,
                 openai_api_key=settings.OPENAI_API_KEY,
+            )
+            # Langfuse handler for chat sessions
+            self.langfuse_handler = get_langfuse_handler(
+                session_id=f"chat:{settings.PROJECT_NAME}"
             )
             self._setup_analyzer()
 
@@ -128,7 +134,15 @@ Respond with this JSON format:
 
                 try:
                     result = await self.analyzer.ainvoke(
-                        {"messages": langchain_messages}
+                        {"messages": langchain_messages},
+                        config={
+                            "callbacks": [self.langfuse_handler]
+                            if self.langfuse_handler
+                            else [],
+                            "tags": ["component:chat", "component:chat.analyze"],
+                            "metadata": {},
+                            "run_name": "chat.analyze",
+                        },
                     )
 
                     # Handle string response
@@ -288,7 +302,15 @@ Continue to help them refine their thinking, answer questions, or prepare for ev
         langchain_messages.append(HumanMessage(content=user_message))
 
         # Generate response
-        response = await self.llm.ainvoke(langchain_messages)
+        response = await self.llm.ainvoke(
+            langchain_messages,
+            config={
+                "callbacks": [self.langfuse_handler] if self.langfuse_handler else [],
+                "tags": ["component:chat", "component:chat.respond"],
+                "metadata": {},
+                "run_name": "chat.respond",
+            },
+        )
 
         return response.content, analysis
 

--- a/backend/app/services/synthesis/agent.py
+++ b/backend/app/services/synthesis/agent.py
@@ -7,8 +7,11 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 from langgraph.graph import StateGraph, END
 from app.services.vectorization import vectorization_service
-from app.utils.llm.llm_utils import get_llm
-from app.utils.llm.llm_utils import get_langfuse_handler
+from app.utils.llm.llm_utils import (
+    get_llm,
+    get_langfuse_handler,
+    build_langfuse_metadata,
+)
 from app.services.synthesis.schemas import KeyIssue, PolicyIntervention
 from app.services.synthesis.prompts import (
     build_discover_themes_prompt,
@@ -37,6 +40,26 @@ CRITIQUE_ITERATIONS = 1
 def _escape_braces(text: str) -> str:
     """Escape braces to avoid ChatPromptTemplate .format() interpreting them as variables."""
     return (text or "").replace("{", "{{").replace("}", "}}")
+
+
+def _langfuse_config(
+    state: SynthesisState,
+    tags: List[str],
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    handler = state.get("langfuse_handler")
+    metadata = build_langfuse_metadata(
+        tags=tags,
+        session_id=state.get("langfuse_session_id"),
+        user_id=state.get("policy_user_id"),
+        project_id=state.get("project_id"),
+        extra=extra,
+    )
+    return {
+        "callbacks": [handler] if handler else [],
+        "tags": tags,
+        "metadata": metadata,
+    }
 
 
 class DiscoveredTheme(BaseModel):
@@ -78,6 +101,8 @@ class SynthesisState(TypedDict):
     aggregated_interventions: List[PolicyIntervention]
     # Langfuse handler for tracing (injected at runtime)
     langfuse_handler: Any
+    langfuse_session_id: str
+    policy_user_id: Optional[str]
 
 
 class ThemesOut(BaseModel):
@@ -219,39 +244,50 @@ async def create_canonical_concepts(state: SynthesisState) -> SynthesisState:
 
 
 async def define_issue_themes(state: SynthesisState) -> SynthesisState:
+    tags = [
+        "component:synthesis",
+        "component:synthesis.discover_themes",
+        "branch:issues",
+        f"project:{state.get('project_id','')}",
+    ]
     themes = await _discover_themes_for_concepts(
         state.get("issue_concepts", []) or [],
         state.get("issue_theme_critique"),
         str(state.get("research_question") or "Not specified"),
         handler=state.get("langfuse_handler"),
-        tags=[
-            "component:synthesis",
-            "component:synthesis.discover_themes",
-            "branch:issues",
-            f"project:{state.get('project_id','')}",
-        ],
-        metadata={"project_id": state.get("project_id", ""), "branch": "issues"},
+        tags=tags,
+        metadata=build_langfuse_metadata(
+            tags=tags,
+            session_id=state.get("langfuse_session_id"),
+            user_id=state.get("policy_user_id"),
+            project_id=state.get("project_id"),
+            extra={"branch": "issues"},
+        ),
         run_name="synthesis.discover_themes",
     )
     return {"discovered_issue_themes": themes}
 
 
 async def define_intervention_themes(state: SynthesisState) -> SynthesisState:
+    tags = [
+        "component:synthesis",
+        "component:synthesis.discover_themes",
+        "branch:interventions",
+        f"project:{state.get('project_id','')}",
+    ]
     themes = await _discover_themes_for_concepts(
         state.get("intervention_concepts", []) or [],
         state.get("intervention_theme_critique"),
         str(state.get("research_question") or "Not specified"),
         handler=state.get("langfuse_handler"),
-        tags=[
-            "component:synthesis",
-            "component:synthesis.discover_themes",
-            "branch:interventions",
-            f"project:{state.get('project_id','')}",
-        ],
-        metadata={
-            "project_id": state.get("project_id", ""),
-            "branch": "interventions",
-        },
+        tags=tags,
+        metadata=build_langfuse_metadata(
+            tags=tags,
+            session_id=state.get("langfuse_session_id"),
+            user_id=state.get("policy_user_id"),
+            project_id=state.get("project_id"),
+            extra={"branch": "interventions"},
+        ),
         run_name="synthesis.discover_themes",
     )
     return {"discovered_intervention_themes": themes}
@@ -264,22 +300,23 @@ async def critique_issue_themes(state: SynthesisState) -> SynthesisState:
     )
     prompt = build_theme_critique_prompt("issue")
     llm = get_llm(THEME_MODEL, temperature=0.0)
+    tags = [
+        "component:synthesis",
+        "component:synthesis.critique",
+        "branch:issues",
+        f"project:{state.get('project_id','')}",
+    ]
     resp = await llm.ainvoke(
         prompt.format(
             rq=_escape_braces(str(state.get("research_question") or "Not specified")),
             themes=themes_payload,
         ),
         config={
-            "callbacks": [state.get("langfuse_handler")]
-            if state.get("langfuse_handler")
-            else [],
-            "tags": [
-                "component:synthesis",
-                "component:synthesis.critique",
-                "branch:issues",
-                f"project:{state.get('project_id','')}",
-            ],
-            "metadata": {"project_id": state.get("project_id", ""), "branch": "issues"},
+            **_langfuse_config(
+                state,
+                tags,
+                extra={"branch": "issues"},
+            ),
             "run_name": "synthesis.critique",
         },
     )
@@ -298,25 +335,23 @@ async def critique_intervention_themes(state: SynthesisState) -> SynthesisState:
     )
     prompt = build_theme_critique_prompt("intervention")
     llm = get_llm(THEME_MODEL, temperature=0.0)
+    tags = [
+        "component:synthesis",
+        "component:synthesis.critique",
+        "branch:interventions",
+        f"project:{state.get('project_id','')}",
+    ]
     resp = await llm.ainvoke(
         prompt.format(
             rq=_escape_braces(str(state.get("research_question") or "Not specified")),
             themes=themes_payload,
         ),
         config={
-            "callbacks": [state.get("langfuse_handler")]
-            if state.get("langfuse_handler")
-            else [],
-            "tags": [
-                "component:synthesis",
-                "component:synthesis.critique",
-                "branch:interventions",
-                f"project:{state.get('project_id','')}",
-            ],
-            "metadata": {
-                "project_id": state.get("project_id", ""),
-                "branch": "interventions",
-            },
+            **_langfuse_config(
+                state,
+                tags,
+                extra={"branch": "interventions"},
+            ),
             "run_name": "synthesis.critique",
         },
     )
@@ -398,17 +433,24 @@ async def _map_concepts(
 
 async def map_issue_concepts_to_final_themes(state: SynthesisState) -> SynthesisState:
     print("--- Mapping Issue Concepts to Final Themes ---")
+    tags = [
+        "component:synthesis",
+        "component:synthesis.map_concepts",
+        "branch:issues",
+        f"project:{state.get('project_id','')}",
+    ]
     finals = await _map_concepts(
         state.get("issue_concepts", []) or [],
         state.get("discovered_issue_themes", []) or [],
         handler=state.get("langfuse_handler"),
-        tags=[
-            "component:synthesis",
-            "component:synthesis.map_concepts",
-            "branch:issues",
-            f"project:{state.get('project_id','')}",
-        ],
-        metadata={"project_id": state.get("project_id", ""), "branch": "issues"},
+        tags=tags,
+        metadata=build_langfuse_metadata(
+            tags=tags,
+            session_id=state.get("langfuse_session_id"),
+            user_id=state.get("policy_user_id"),
+            project_id=state.get("project_id"),
+            extra={"branch": "issues"},
+        ),
         run_name="synthesis.map_concepts",
     )
     return {"final_issue_themes": finals}
@@ -418,20 +460,24 @@ async def map_intervention_concepts_to_final_themes(
     state: SynthesisState
 ) -> SynthesisState:
     print("--- Mapping Intervention Concepts to Final Themes ---")
+    tags = [
+        "component:synthesis",
+        "component:synthesis.map_concepts",
+        "branch:interventions",
+        f"project:{state.get('project_id','')}",
+    ]
     finals = await _map_concepts(
         state.get("intervention_concepts", []) or [],
         state.get("discovered_intervention_themes", []) or [],
         handler=state.get("langfuse_handler"),
-        tags=[
-            "component:synthesis",
-            "component:synthesis.map_concepts",
-            "branch:interventions",
-            f"project:{state.get('project_id','')}",
-        ],
-        metadata={
-            "project_id": state.get("project_id", ""),
-            "branch": "interventions",
-        },
+        tags=tags,
+        metadata=build_langfuse_metadata(
+            tags=tags,
+            session_id=state.get("langfuse_session_id"),
+            user_id=state.get("policy_user_id"),
+            project_id=state.get("project_id"),
+            extra={"branch": "interventions"},
+        ),
         run_name="synthesis.map_concepts",
     )
     return {"final_intervention_themes": finals}
@@ -504,18 +550,18 @@ async def build_aggregated_tables(state: SynthesisState) -> SynthesisState:
             llm = get_llm(MAPPING_MODEL, temperature=0)
             sample = "\n".join([f"- {s}" for s in concept_texts[:8]])
             prompt = build_impact_summary_prompt()
+            tags = [
+                "component:synthesis",
+                "component:synthesis.impact_summary",
+                f"project:{state.get('project_id','')}",
+            ]
             resp = await llm.ainvoke(
                 prompt.format(name=name, sample=_escape_braces(sample)),
                 config={
-                    "callbacks": [state.get("langfuse_handler")]
-                    if state.get("langfuse_handler")
-                    else [],
-                    "tags": [
-                        "component:synthesis",
-                        "component:synthesis.impact_summary",
-                        f"project:{state.get('project_id','')}",
-                    ],
-                    "metadata": {"project_id": state.get("project_id", "")},
+                    **_langfuse_config(
+                        state,
+                        tags,
+                    ),
                     "run_name": "synthesis.impact_summary",
                 },
             )
@@ -607,21 +653,21 @@ async def synthesize_executive_briefing(state: SynthesisState) -> SynthesisState
     prompt = build_executive_briefing_prompt()
     llm = get_llm(BRIEFING_MODEL, temperature=0)
     try:
+        tags = [
+            "component:synthesis",
+            "component:synthesis.executive_brief",
+            f"project:{state.get('project_id','')}",
+        ]
         resp = await llm.ainvoke(
             prompt.format(
                 rq=rq,
                 payload=_escape_braces(json.dumps(payload)),
             ),
             config={
-                "callbacks": [state.get("langfuse_handler")]
-                if state.get("langfuse_handler")
-                else [],
-                "tags": [
-                    "component:synthesis",
-                    "component:synthesis.executive_brief",
-                    f"project:{state.get('project_id','')}",
-                ],
-                "metadata": {"project_id": state.get("project_id", "")},
+                **_langfuse_config(
+                    state,
+                    tags,
+                ),
                 "run_name": "synthesis.executive_brief",
             },
         )
@@ -704,13 +750,33 @@ class SynthesisAgent:
     def __init__(self) -> None:
         self.workflow = create_synthesis_workflow()
 
-    async def run(self, project_id: str) -> SynthesisState:
+    async def run(
+        self, project_id: str, user_id: Optional[str] = None
+    ) -> SynthesisState:
         # Create a per-run Langfuse session and propagate handler through state
         session_id = f"synthesis:{project_id}:{datetime.utcnow().isoformat()}"
         handler = get_langfuse_handler(session_id=session_id)
+        resolved_user = user_id or self._resolve_project_user(project_id)
         initial_state: SynthesisState = {  # type: ignore[assignment]
             "project_id": project_id,
             "langfuse_handler": handler,
+            "langfuse_session_id": session_id,
+            "policy_user_id": resolved_user,
         }
         final_state: SynthesisState = await self.workflow.ainvoke(initial_state)
         return final_state
+
+    @staticmethod
+    def _resolve_project_user(project_id: str) -> Optional[str]:
+        try:
+            result = (
+                vectorization_service.supabase.table("analysis_projects")
+                .select("created_by_user_id")
+                .eq("id", project_id)
+                .execute()
+            )
+            if result.data:
+                return result.data[0].get("created_by_user_id")
+        except Exception:
+            return None
+        return None

--- a/backend/app/services/synthesis/agent.py
+++ b/backend/app/services/synthesis/agent.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import List, Dict, TypedDict, Optional, Any
-from datetime import datetime
 from pydantic import BaseModel, Field
 from langgraph.graph import StateGraph, END
 from app.services.vectorization import vectorization_service
@@ -11,6 +10,7 @@ from app.utils.llm.llm_utils import (
     get_llm,
     get_langfuse_handler,
     build_langfuse_metadata,
+    resolve_langfuse_session_id,
 )
 from app.services.synthesis.schemas import KeyIssue, PolicyIntervention
 from app.services.synthesis.prompts import (
@@ -248,7 +248,7 @@ async def define_issue_themes(state: SynthesisState) -> SynthesisState:
         "component:synthesis",
         "component:synthesis.discover_themes",
         "branch:issues",
-        f"project:{state.get('project_id','')}",
+        f"model:{THEME_MODEL}",
     ]
     themes = await _discover_themes_for_concepts(
         state.get("issue_concepts", []) or [],
@@ -273,7 +273,7 @@ async def define_intervention_themes(state: SynthesisState) -> SynthesisState:
         "component:synthesis",
         "component:synthesis.discover_themes",
         "branch:interventions",
-        f"project:{state.get('project_id','')}",
+        f"model:{THEME_MODEL}",
     ]
     themes = await _discover_themes_for_concepts(
         state.get("intervention_concepts", []) or [],
@@ -304,7 +304,7 @@ async def critique_issue_themes(state: SynthesisState) -> SynthesisState:
         "component:synthesis",
         "component:synthesis.critique",
         "branch:issues",
-        f"project:{state.get('project_id','')}",
+        f"model:{THEME_MODEL}",
     ]
     resp = await llm.ainvoke(
         prompt.format(
@@ -339,7 +339,7 @@ async def critique_intervention_themes(state: SynthesisState) -> SynthesisState:
         "component:synthesis",
         "component:synthesis.critique",
         "branch:interventions",
-        f"project:{state.get('project_id','')}",
+        f"model:{THEME_MODEL}",
     ]
     resp = await llm.ainvoke(
         prompt.format(
@@ -437,7 +437,7 @@ async def map_issue_concepts_to_final_themes(state: SynthesisState) -> Synthesis
         "component:synthesis",
         "component:synthesis.map_concepts",
         "branch:issues",
-        f"project:{state.get('project_id','')}",
+        f"model:{MAPPING_MODEL}",
     ]
     finals = await _map_concepts(
         state.get("issue_concepts", []) or [],
@@ -464,7 +464,7 @@ async def map_intervention_concepts_to_final_themes(
         "component:synthesis",
         "component:synthesis.map_concepts",
         "branch:interventions",
-        f"project:{state.get('project_id','')}",
+        f"model:{MAPPING_MODEL}",
     ]
     finals = await _map_concepts(
         state.get("intervention_concepts", []) or [],
@@ -553,7 +553,7 @@ async def build_aggregated_tables(state: SynthesisState) -> SynthesisState:
             tags = [
                 "component:synthesis",
                 "component:synthesis.impact_summary",
-                f"project:{state.get('project_id','')}",
+                f"model:{MAPPING_MODEL}",
             ]
             resp = await llm.ainvoke(
                 prompt.format(name=name, sample=_escape_braces(sample)),
@@ -656,7 +656,7 @@ async def synthesize_executive_briefing(state: SynthesisState) -> SynthesisState
         tags = [
             "component:synthesis",
             "component:synthesis.executive_brief",
-            f"project:{state.get('project_id','')}",
+            f"model:{BRIEFING_MODEL}",
         ]
         resp = await llm.ainvoke(
             prompt.format(
@@ -754,7 +754,7 @@ class SynthesisAgent:
         self, project_id: str, user_id: Optional[str] = None
     ) -> SynthesisState:
         # Create a per-run Langfuse session and propagate handler through state
-        session_id = f"synthesis:{project_id}:{datetime.utcnow().isoformat()}"
+        session_id = resolve_langfuse_session_id(project_id)
         handler = get_langfuse_handler(session_id=session_id)
         resolved_user = user_id or self._resolve_project_user(project_id)
         initial_state: SynthesisState = {  # type: ignore[assignment]

--- a/backend/app/services/synthesis/agent.py
+++ b/backend/app/services/synthesis/agent.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import List, Dict, TypedDict, Optional, Any
+from datetime import datetime
 from pydantic import BaseModel, Field
 from langgraph.graph import StateGraph, END
 from app.services.vectorization import vectorization_service
 from app.utils.llm.llm_utils import get_llm
+from app.utils.llm.llm_utils import get_langfuse_handler
 from app.services.synthesis.schemas import KeyIssue, PolicyIntervention
 from app.services.synthesis.prompts import (
     build_discover_themes_prompt,
@@ -74,6 +76,8 @@ class SynthesisState(TypedDict):
     executive_briefing: str
     aggregated_issues: List[KeyIssue]
     aggregated_interventions: List[PolicyIntervention]
+    # Langfuse handler for tracing (injected at runtime)
+    langfuse_handler: Any
 
 
 class ThemesOut(BaseModel):
@@ -83,7 +87,14 @@ class ThemesOut(BaseModel):
 
 
 async def _discover_themes_for_concepts(
-    concepts: List[Concept], critique: Optional[str], rq: str
+    concepts: List[Concept],
+    critique: Optional[str],
+    rq: str,
+    *,
+    handler: Any = None,
+    tags: Optional[List[str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    run_name: Optional[str] = None,
 ) -> List[DiscoveredTheme]:
     """Generic helper to discover themes for a given concept set (structured output)."""
     if not concepts:
@@ -98,7 +109,13 @@ async def _discover_themes_for_concepts(
                 critique_instruction=instructions,
                 rq=_escape_braces(rq),
                 concepts=_escape_braces(json.dumps([c.dict() for c in concepts])),
-            )
+            ),
+            config={
+                "callbacks": [handler] if handler else [],
+                "tags": tags or [],
+                "metadata": metadata or {},
+                "run_name": run_name or "synthesis.discover_themes",
+            },
         )
         return out.themes or []
     except Exception:
@@ -206,6 +223,15 @@ async def define_issue_themes(state: SynthesisState) -> SynthesisState:
         state.get("issue_concepts", []) or [],
         state.get("issue_theme_critique"),
         str(state.get("research_question") or "Not specified"),
+        handler=state.get("langfuse_handler"),
+        tags=[
+            "component:synthesis",
+            "component:synthesis.discover_themes",
+            "branch:issues",
+            f"project:{state.get('project_id','')}",
+        ],
+        metadata={"project_id": state.get("project_id", ""), "branch": "issues"},
+        run_name="synthesis.discover_themes",
     )
     return {"discovered_issue_themes": themes}
 
@@ -215,6 +241,18 @@ async def define_intervention_themes(state: SynthesisState) -> SynthesisState:
         state.get("intervention_concepts", []) or [],
         state.get("intervention_theme_critique"),
         str(state.get("research_question") or "Not specified"),
+        handler=state.get("langfuse_handler"),
+        tags=[
+            "component:synthesis",
+            "component:synthesis.discover_themes",
+            "branch:interventions",
+            f"project:{state.get('project_id','')}",
+        ],
+        metadata={
+            "project_id": state.get("project_id", ""),
+            "branch": "interventions",
+        },
+        run_name="synthesis.discover_themes",
     )
     return {"discovered_intervention_themes": themes}
 
@@ -230,7 +268,20 @@ async def critique_issue_themes(state: SynthesisState) -> SynthesisState:
         prompt.format(
             rq=_escape_braces(str(state.get("research_question") or "Not specified")),
             themes=themes_payload,
-        )
+        ),
+        config={
+            "callbacks": [state.get("langfuse_handler")]
+            if state.get("langfuse_handler")
+            else [],
+            "tags": [
+                "component:synthesis",
+                "component:synthesis.critique",
+                "branch:issues",
+                f"project:{state.get('project_id','')}",
+            ],
+            "metadata": {"project_id": state.get("project_id", ""), "branch": "issues"},
+            "run_name": "synthesis.critique",
+        },
     )
     critique = (resp.content if hasattr(resp, "content") else str(resp)).strip()
     next_iter = int(state.get("issue_theme_iteration") or 0) + 1
@@ -251,7 +302,23 @@ async def critique_intervention_themes(state: SynthesisState) -> SynthesisState:
         prompt.format(
             rq=_escape_braces(str(state.get("research_question") or "Not specified")),
             themes=themes_payload,
-        )
+        ),
+        config={
+            "callbacks": [state.get("langfuse_handler")]
+            if state.get("langfuse_handler")
+            else [],
+            "tags": [
+                "component:synthesis",
+                "component:synthesis.critique",
+                "branch:interventions",
+                f"project:{state.get('project_id','')}",
+            ],
+            "metadata": {
+                "project_id": state.get("project_id", ""),
+                "branch": "interventions",
+            },
+            "run_name": "synthesis.critique",
+        },
     )
     critique = (resp.content if hasattr(resp, "content") else str(resp)).strip()
     next_iter = int(state.get("intervention_theme_iteration") or 0) + 1
@@ -262,7 +329,13 @@ async def critique_intervention_themes(state: SynthesisState) -> SynthesisState:
 
 
 async def _map_concepts(
-    concepts: List[Concept], themes: List[DiscoveredTheme]
+    concepts: List[Concept],
+    themes: List[DiscoveredTheme],
+    *,
+    handler: Any = None,
+    tags: Optional[List[str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    run_name: Optional[str] = None,
 ) -> List[FinalTheme]:
     if not concepts or not themes:
         return []
@@ -283,7 +356,13 @@ async def _map_concepts(
                     prompt.format(
                         themes=_escape_braces(json.dumps(theme_defs)),
                         concept=_escape_braces(json.dumps(concept.dict())),
-                    )
+                    ),
+                    config={
+                        "callbacks": [handler] if handler else [],
+                        "tags": tags or [],
+                        "metadata": metadata or {},
+                        "run_name": run_name or "synthesis.map_concepts",
+                    },
                 )
                 raw = (r.content if hasattr(r, "content") else str(r)).strip()
                 # Parse integer index directly
@@ -322,6 +401,15 @@ async def map_issue_concepts_to_final_themes(state: SynthesisState) -> Synthesis
     finals = await _map_concepts(
         state.get("issue_concepts", []) or [],
         state.get("discovered_issue_themes", []) or [],
+        handler=state.get("langfuse_handler"),
+        tags=[
+            "component:synthesis",
+            "component:synthesis.map_concepts",
+            "branch:issues",
+            f"project:{state.get('project_id','')}",
+        ],
+        metadata={"project_id": state.get("project_id", ""), "branch": "issues"},
+        run_name="synthesis.map_concepts",
     )
     return {"final_issue_themes": finals}
 
@@ -333,6 +421,18 @@ async def map_intervention_concepts_to_final_themes(
     finals = await _map_concepts(
         state.get("intervention_concepts", []) or [],
         state.get("discovered_intervention_themes", []) or [],
+        handler=state.get("langfuse_handler"),
+        tags=[
+            "component:synthesis",
+            "component:synthesis.map_concepts",
+            "branch:interventions",
+            f"project:{state.get('project_id','')}",
+        ],
+        metadata={
+            "project_id": state.get("project_id", ""),
+            "branch": "interventions",
+        },
+        run_name="synthesis.map_concepts",
     )
     return {"final_intervention_themes": finals}
 
@@ -405,7 +505,19 @@ async def build_aggregated_tables(state: SynthesisState) -> SynthesisState:
             sample = "\n".join([f"- {s}" for s in concept_texts[:8]])
             prompt = build_impact_summary_prompt()
             resp = await llm.ainvoke(
-                prompt.format(name=name, sample=_escape_braces(sample))
+                prompt.format(name=name, sample=_escape_braces(sample)),
+                config={
+                    "callbacks": [state.get("langfuse_handler")]
+                    if state.get("langfuse_handler")
+                    else [],
+                    "tags": [
+                        "component:synthesis",
+                        "component:synthesis.impact_summary",
+                        f"project:{state.get('project_id','')}",
+                    ],
+                    "metadata": {"project_id": state.get("project_id", "")},
+                    "run_name": "synthesis.impact_summary",
+                },
             )
             return (resp.content if hasattr(resp, "content") else str(resp)).strip()
         except Exception:
@@ -499,7 +611,19 @@ async def synthesize_executive_briefing(state: SynthesisState) -> SynthesisState
             prompt.format(
                 rq=rq,
                 payload=_escape_braces(json.dumps(payload)),
-            )
+            ),
+            config={
+                "callbacks": [state.get("langfuse_handler")]
+                if state.get("langfuse_handler")
+                else [],
+                "tags": [
+                    "component:synthesis",
+                    "component:synthesis.executive_brief",
+                    f"project:{state.get('project_id','')}",
+                ],
+                "metadata": {"project_id": state.get("project_id", "")},
+                "run_name": "synthesis.executive_brief",
+            },
         )
         text = (resp.content if hasattr(resp, "content") else str(resp)).strip()
         if text.startswith("```"):
@@ -581,6 +705,12 @@ class SynthesisAgent:
         self.workflow = create_synthesis_workflow()
 
     async def run(self, project_id: str) -> SynthesisState:
-        initial_state: SynthesisState = {"project_id": project_id}  # type: ignore[assignment]
+        # Create a per-run Langfuse session and propagate handler through state
+        session_id = f"synthesis:{project_id}:{datetime.utcnow().isoformat()}"
+        handler = get_langfuse_handler(session_id=session_id)
+        initial_state: SynthesisState = {  # type: ignore[assignment]
+            "project_id": project_id,
+            "langfuse_handler": handler,
+        }
         final_state: SynthesisState = await self.workflow.ainvoke(initial_state)
         return final_state

--- a/backend/app/utils/llm/batch_check.py
+++ b/backend/app/utils/llm/batch_check.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import create_model
 
-# from app.utils.llm.llm_utils import get_langfuse_handler
+from app.utils.llm.llm_utils import get_langfuse_handler
 from app.utils.llm.llm_utils import get_llm
 
 
@@ -56,9 +56,9 @@ class LLMProcessor:
         else:
             session_name = f"{session_name}_"
 
-        # self.langfuse_handler = get_langfuse_handler(
-        #     session_id=f"{session_name}{datetime.today().isoformat()}"
-        # )
+        self.langfuse_handler = get_langfuse_handler(
+            session_id=f"{session_name}{datetime.today().isoformat()}"
+        )
         self.output_path = Path(output_path)
         self.model_name = model_name
         self.temperature = temperature
@@ -117,7 +117,19 @@ class LLMProcessor:
         structured_llm = self.llm.with_structured_output(self.schema)
         response = await structured_llm.ainvoke(
             input_text,
-            # config={"callbacks": [self.langfuse_handler]}
+            config={
+                "callbacks": [self.langfuse_handler] if self.langfuse_handler else [],
+                "tags": [
+                    "component:batch_check",
+                    "component:batch_check.invoke",
+                    f"model:{self.model_name}",
+                ],
+                "metadata": {
+                    "model": self.model_name,
+                    "temperature": self.temperature,
+                },
+                "run_name": "batch_check.invoke",
+            },
         )
         response = response.dict()
         response["id"] = _id

--- a/backend/app/utils/llm/batch_check.py
+++ b/backend/app/utils/llm/batch_check.py
@@ -28,7 +28,11 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import create_model
 
-from app.utils.llm.llm_utils import get_langfuse_handler, build_langfuse_metadata
+from app.utils.llm.llm_utils import (
+    get_langfuse_handler,
+    build_langfuse_metadata,
+    resolve_langfuse_session_id,
+)
 from app.utils.llm.llm_utils import get_llm
 
 
@@ -55,12 +59,9 @@ class LLMProcessor:
         run_name: str = "batch_check.process",
     ) -> None:
         self.llm = get_llm(model_name=model_name, temperature=temperature)
-        if session_name is None:
-            session_name = ""
-        else:
-            session_name = f"{session_name}_"
-
-        self.langfuse_session_id = f"{session_name}{datetime.today().isoformat()}"
+        self.langfuse_session_id = resolve_langfuse_session_id(
+            policy_project_id, session_name
+        )
         self.langfuse_handler = get_langfuse_handler(
             session_id=self.langfuse_session_id
         )
@@ -125,9 +126,11 @@ class LLMProcessor:
         start_time = datetime.now(tz=timezone.utc).isoformat()
         structured_llm = self.llm.with_structured_output(self.schema)
         tags = self.component_tags + [
-            "component:batch_check.invoke",
+            "component:batch_check.process",
             f"model:{self.model_name}",
         ]
+        if self.policy_project_id:
+            tags.append(f"project:{self.policy_project_id}")
         response = await structured_llm.ainvoke(
             input_text,
             config={

--- a/backend/app/utils/llm/batch_check.py
+++ b/backend/app/utils/llm/batch_check.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import create_model
 
-from app.utils.llm.llm_utils import get_langfuse_handler
+from app.utils.llm.llm_utils import get_langfuse_handler, build_langfuse_metadata
 from app.utils.llm.llm_utils import get_llm
 
 
@@ -49,6 +49,10 @@ class LLMProcessor:
         system_message: Optional[str] = None,
         output_fields: Optional[List[Dict[str, str]]] = None,
         session_name: Optional[str] = None,
+        component_tags: Optional[List[str]] = None,
+        policy_project_id: Optional[str] = None,
+        policy_user_id: Optional[str] = None,
+        run_name: str = "batch_check.process",
     ) -> None:
         self.llm = get_llm(model_name=model_name, temperature=temperature)
         if session_name is None:
@@ -56,12 +60,17 @@ class LLMProcessor:
         else:
             session_name = f"{session_name}_"
 
+        self.langfuse_session_id = f"{session_name}{datetime.today().isoformat()}"
         self.langfuse_handler = get_langfuse_handler(
-            session_id=f"{session_name}{datetime.today().isoformat()}"
+            session_id=self.langfuse_session_id
         )
         self.output_path = Path(output_path)
         self.model_name = model_name
         self.temperature = temperature
+        self.component_tags = component_tags or ["component:batch_check"]
+        self.policy_project_id = policy_project_id
+        self.policy_user_id = policy_user_id
+        self.run_name = run_name
 
         self.output_fields = output_fields or [
             {
@@ -115,20 +124,26 @@ class LLMProcessor:
     async def _invoke_llm(self, input_text: str, _id: str) -> Dict:
         start_time = datetime.now(tz=timezone.utc).isoformat()
         structured_llm = self.llm.with_structured_output(self.schema)
+        tags = self.component_tags + [
+            "component:batch_check.invoke",
+            f"model:{self.model_name}",
+        ]
         response = await structured_llm.ainvoke(
             input_text,
             config={
                 "callbacks": [self.langfuse_handler] if self.langfuse_handler else [],
-                "tags": [
-                    "component:batch_check",
-                    "component:batch_check.invoke",
-                    f"model:{self.model_name}",
-                ],
-                "metadata": {
-                    "model": self.model_name,
-                    "temperature": self.temperature,
-                },
-                "run_name": "batch_check.invoke",
+                "tags": tags,
+                "metadata": build_langfuse_metadata(
+                    tags=tags,
+                    session_id=self.langfuse_session_id,
+                    user_id=self.policy_user_id,
+                    project_id=self.policy_project_id,
+                    extra={
+                        "model": self.model_name,
+                        "temperature": self.temperature,
+                    },
+                ),
+                "run_name": self.run_name,
             },
         )
         response = response.dict()

--- a/backend/app/utils/llm/llm_utils.py
+++ b/backend/app/utils/llm/llm_utils.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 
 
 import tiktoken
@@ -7,7 +8,17 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import AzureChatOpenAI
 from langchain_openai import ChatOpenAI
 
-# from langfuse.langchain import CallbackHandler
+from typing import Any
+
+try:
+    # Langfuse >=3 import path
+    from langfuse.langchain import CallbackHandler  # type: ignore
+except Exception:  # pragma: no cover - fallback for Langfuse <3
+    try:
+        # Langfuse <3 import path
+        from langfuse.callback import CallbackHandler  # type: ignore
+    except Exception:
+        CallbackHandler = None  # type: ignore
 from pydantic import BaseModel
 
 import logging
@@ -21,18 +32,16 @@ except KeyError:
     LLM_SERVICE = "OpenAI"
 
 
-# def get_langfuse_handler(session_id: str = None) -> CallbackHandler:
-#     """Initialise a Langfuse callback handler"""
-#     if session_id is None:
-#         session_id = f"{datetime.today().isoformat()}"
+def get_langfuse_handler(session_id: str = None) -> Any:
+    """Initialise a Langfuse callback handler"""
+    if session_id is None:
+        session_id = f"{datetime.today().isoformat()}"
 
-#     return CallbackHandler(
-#         user_id=os.environ.get("USER_EMAIL"),
-#         session_id=session_id,
-#         secret_key=os.environ.get("LANGFUSE_SECRET_KEY"),
-#         public_key=os.environ.get("LANGFUSE_PUBLIC_KEY"),
-#         host=os.environ.get("LANGFUSE_HOST"),
-#     )
+    # The Langfuse LangChain CallbackHandler reads configuration from environment variables.
+    # It does not accept user/session/keys as init kwargs.
+    if CallbackHandler is None:
+        return None
+    return CallbackHandler()
 
 
 def get_llm(model_name: str = None, temperature: float = None) -> ChatOpenAI:

--- a/backend/app/utils/llm/llm_utils.py
+++ b/backend/app/utils/llm/llm_utils.py
@@ -30,6 +30,17 @@ def get_langfuse_handler(session_id: str = None) -> CallbackHandler:
     return CallbackHandler()
 
 
+def resolve_langfuse_session_id(
+    project_id: Optional[str] = None, session_name: Optional[str] = None
+) -> str:
+    """Return a canonical Langfuse session id for the given project."""
+    if session_name:
+        return session_name
+    if project_id:
+        return f"project:{project_id}"
+    return "project:global"
+
+
 def build_langfuse_metadata(
     *,
     tags: Optional[List[str]] = None,
@@ -47,8 +58,9 @@ def build_langfuse_metadata(
     if tags:
         metadata["langfuse_tags"] = tags
 
-    if session_id:
-        metadata["langfuse_session_id"] = session_id
+    resolved_session = session_id or resolve_langfuse_session_id(project_id)
+    if resolved_session:
+        metadata["langfuse_session_id"] = resolved_session
 
     if user_id:
         metadata["langfuse_user_id"] = user_id

--- a/backend/app/utils/llm/llm_utils.py
+++ b/backend/app/utils/llm/llm_utils.py
@@ -1,24 +1,12 @@
 import os
 from datetime import datetime
-
+from typing import Any, Dict, List, Optional
 
 import tiktoken
-
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import AzureChatOpenAI
 from langchain_openai import ChatOpenAI
-
-from typing import Any
-
-try:
-    # Langfuse >=3 import path
-    from langfuse.langchain import CallbackHandler  # type: ignore
-except Exception:  # pragma: no cover - fallback for Langfuse <3
-    try:
-        # Langfuse <3 import path
-        from langfuse.callback import CallbackHandler  # type: ignore
-    except Exception:
-        CallbackHandler = None  # type: ignore
+from langfuse.langchain import CallbackHandler
 from pydantic import BaseModel
 
 import logging
@@ -32,16 +20,44 @@ except KeyError:
     LLM_SERVICE = "OpenAI"
 
 
-def get_langfuse_handler(session_id: str = None) -> Any:
+def get_langfuse_handler(session_id: str = None) -> CallbackHandler:
     """Initialise a Langfuse callback handler"""
     if session_id is None:
         session_id = f"{datetime.today().isoformat()}"
 
     # The Langfuse LangChain CallbackHandler reads configuration from environment variables.
     # It does not accept user/session/keys as init kwargs.
-    if CallbackHandler is None:
-        return None
     return CallbackHandler()
+
+
+def build_langfuse_metadata(
+    *,
+    tags: Optional[List[str]] = None,
+    session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Compose metadata payload that Langfuse understands for tags/user/session."""
+
+    metadata: Dict[str, Any] = {}
+    if extra:
+        metadata.update(extra)
+
+    if tags:
+        metadata["langfuse_tags"] = tags
+
+    if session_id:
+        metadata["langfuse_session_id"] = session_id
+
+    if user_id:
+        metadata["langfuse_user_id"] = user_id
+        metadata["policy_user_id"] = user_id
+
+    if project_id:
+        metadata["policy_project_id"] = project_id
+
+    return metadata
 
 
 def get_llm(model_name: str = None, temperature: float = None) -> ChatOpenAI:


### PR DESCRIPTION
Add traces for tracking LLM calls on langfuse.

- Sessions are linked to projects
- Policy atlas user ids are fed forward to langfuse user ids
- Tags for components and subcomponent tracking

Closes #13 