### PR TITLE
Supabase MCP

### DIFF
--- a/mcp/supabase/README.md
+++ b/mcp/supabase/README.md
@@ -1,0 +1,104 @@
+# Supabase MCP Server
+
+Read-only MCP server for querying the Policy Atlas Supabase database.
+
+## Tools
+
+### Basic Operations
+
+| Tool | Description |
+|------|-------------|
+| `list_tables` | List all tables in the database |
+| `describe_table` | Get column types and sample values for a table |
+| `count_rows` | Count rows, optionally grouped by column |
+
+### Query Operations
+
+| Tool | Description |
+|------|-------------|
+| `sample_rows` | Get rows with filtering, ordering, and column selection |
+| `run_query` | Execute arbitrary SELECT queries (requires DB function) |
+| `get_row_by_id` | Fetch a single row by primary key |
+
+### Relationship Operations
+
+| Tool | Description |
+|------|-------------|
+| `get_related` | Get related rows via foreign key relationships |
+| `explain_schema` | Show foreign key relationships between tables |
+
+## Usage Examples
+
+### sample_rows with filters
+
+```json
+{
+  "table_name": "synthesis_runs",
+  "where": "status=completed",
+  "order_by": "-created_at",
+  "limit": 10
+}
+```
+
+### get_related
+
+```json
+{
+  "from_table": "synthesis_runs",
+  "id": "abc-123",
+  "to_table": "synthesis_citations"
+}
+```
+
+### explain_schema
+
+```json
+{
+  "table_name": "synthesis_citations"
+}
+```
+
+Output:
+```
+Schema for 'synthesis_citations':
+
+  Primary Key: id
+
+  Belongs To:
+    → synthesis_runs (via synthesis_run_id)
+    → analysis_documents (via analysis_document_id)
+```
+
+## Filter Syntax
+
+The `where` parameter supports:
+
+- Equality: `status=completed`
+- Inequality: `status!=pending`
+- Comparison: `count>10`, `created_at<2024-01-01`
+- LIKE/ILIKE: `title ILIKE %obesity%`
+- Multiple conditions: `status=completed AND version>1`
+
+## Setup
+
+1. Ensure `backend/.env` contains `SUPABASE_URL` and `SUPABASE_KEY`
+2. Run `npm install` in this directory
+3. Add to Cursor MCP config:
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "node",
+      "args": ["/path/to/mcp/supabase/index.js"]
+    }
+  }
+}
+```
+
+## Note on run_query
+
+The `run_query` tool requires a database function for arbitrary SQL. Without it, use `sample_rows` with filters for most queries.
+
+
+

--- a/mcp/supabase/index.js
+++ b/mcp/supabase/index.js
@@ -1,0 +1,582 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { createClient } from "@supabase/supabase-js";
+import { config } from "dotenv";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// Load .env from backend folder (two levels up from mcp/supabase/)
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: resolve(__dirname, "../../backend/.env") });
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error("Missing SUPABASE_URL or SUPABASE_KEY in backend/.env");
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// Schema relationships for explain_schema and get_related
+const SCHEMA_RELATIONSHIPS = {
+  analysis_projects: {
+    primary_key: "id",
+    has_many: [
+      { table: "analysis_documents", foreign_key: "analysis_project_id" },
+      { table: "synthesis_runs", foreign_key: "analysis_project_id" }
+    ]
+  },
+  analysis_documents: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "analysis_projects", foreign_key: "analysis_project_id" }
+    ],
+    has_many: [
+      { table: "analysis_extractions", foreign_key: "analysis_document_id" },
+      { table: "document_chunks", foreign_key: "analysis_document_id" },
+      { table: "synthesis_citations", foreign_key: "analysis_document_id" }
+    ]
+  },
+  analysis_extractions: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "analysis_documents", foreign_key: "analysis_document_id" }
+    ]
+  },
+  synthesis_runs: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "analysis_projects", foreign_key: "analysis_project_id" }
+    ],
+    has_many: [
+      { table: "synthesis_citations", foreign_key: "synthesis_run_id" },
+      { table: "synthesis_themes", foreign_key: "synthesis_run_id" },
+      { table: "synthesis_outcome_themes", foreign_key: "synthesis_run_id" }
+    ]
+  },
+  synthesis_citations: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "synthesis_runs", foreign_key: "synthesis_run_id" },
+      { table: "analysis_documents", foreign_key: "analysis_document_id" }
+    ]
+  },
+  synthesis_themes: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "synthesis_runs", foreign_key: "synthesis_run_id" }
+    ]
+  },
+  synthesis_outcome_themes: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "synthesis_runs", foreign_key: "synthesis_run_id" }
+    ],
+    has_many: [
+      { table: "outcome_theme_assignments", foreign_key: "outcome_theme_id" }
+    ]
+  },
+  outcome_theme_assignments: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "synthesis_outcome_themes", foreign_key: "outcome_theme_id" }
+    ]
+  },
+  document_chunks: {
+    primary_key: "id",
+    belongs_to: [
+      { table: "analysis_documents", foreign_key: "analysis_document_id" }
+    ]
+  }
+};
+
+const server = new Server(
+  { name: "mcp-supabase", version: "2.0.0" },
+  { capabilities: { tools: {} } }
+);
+
+// List available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "list_tables",
+      description: "List all tables in the Supabase database",
+      inputSchema: { type: "object", properties: {} }
+    },
+    {
+      name: "describe_table",
+      description: "Get column information for a specific table",
+      inputSchema: {
+        type: "object",
+        properties: {
+          table_name: { type: "string", description: "Name of the table to describe" }
+        },
+        required: ["table_name"]
+      }
+    },
+    {
+      name: "sample_rows",
+      description: "Get sample rows from a table with optional filtering",
+      inputSchema: {
+        type: "object",
+        properties: {
+          table_name: { type: "string", description: "Name of the table" },
+          limit: { type: "number", description: "Number of rows to return (default 5, max 100)" },
+          columns: { type: "string", description: "Comma-separated list of columns to select (default: all)" },
+          where: { type: "string", description: "Filter condition, e.g. 'status=completed' or 'id=abc-123'" },
+          order_by: { type: "string", description: "Column to order by (prefix with - for descending, e.g. '-created_at')" }
+        },
+        required: ["table_name"]
+      }
+    },
+    {
+      name: "count_rows",
+      description: "Count rows in a table, optionally grouped by a column",
+      inputSchema: {
+        type: "object",
+        properties: {
+          table_name: { type: "string", description: "Name of the table" },
+          column: { type: "string", description: "Column to group by (optional)" },
+          where: { type: "string", description: "Filter condition (optional)" }
+        },
+        required: ["table_name"]
+      }
+    },
+    {
+      name: "run_query",
+      description: "Execute a read-only SQL SELECT query. Only SELECT statements are allowed.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { 
+            type: "string", 
+            description: "SQL SELECT query to execute. Must start with SELECT. Example: SELECT c.*, d.title FROM synthesis_citations c JOIN analysis_documents d ON c.analysis_document_id = d.id WHERE c.synthesis_run_id = 'xxx' LIMIT 10" 
+          }
+        },
+        required: ["query"]
+      }
+    },
+    {
+      name: "get_row_by_id",
+      description: "Fetch a single row by its primary key",
+      inputSchema: {
+        type: "object",
+        properties: {
+          table_name: { type: "string", description: "Name of the table" },
+          id: { type: "string", description: "Primary key value (usually UUID)" },
+          columns: { type: "string", description: "Comma-separated columns to return (default: all)" }
+        },
+        required: ["table_name", "id"]
+      }
+    },
+    {
+      name: "get_related",
+      description: "Get related rows from another table via foreign key relationship",
+      inputSchema: {
+        type: "object",
+        properties: {
+          from_table: { type: "string", description: "Source table name" },
+          id: { type: "string", description: "ID of the source row" },
+          to_table: { type: "string", description: "Related table to fetch from" },
+          limit: { type: "number", description: "Max rows to return (default 20)" }
+        },
+        required: ["from_table", "id", "to_table"]
+      }
+    },
+    {
+      name: "explain_schema",
+      description: "Show foreign key relationships between tables",
+      inputSchema: {
+        type: "object",
+        properties: {
+          table_name: { type: "string", description: "Specific table to explain (optional, shows all if omitted)" }
+        }
+      }
+    }
+  ]
+}));
+
+// Parse simple where conditions like "status=completed" or "id=abc-123"
+function parseWhere(whereStr) {
+  if (!whereStr) return null;
+  
+  const conditions = [];
+  const parts = whereStr.split(/\s+AND\s+/i);
+  
+  for (const part of parts) {
+    const match = part.match(/^(\w+)\s*(=|!=|>|<|>=|<=|LIKE|ILIKE)\s*(.+)$/i);
+    if (match) {
+      let [, column, operator, value] = match;
+      value = value.trim().replace(/^['"]|['"]$/g, ''); // Remove quotes
+      conditions.push({ column, operator: operator.toLowerCase(), value });
+    }
+  }
+  
+  return conditions.length > 0 ? conditions : null;
+}
+
+// Apply where conditions to a Supabase query
+function applyWhere(query, conditions) {
+  if (!conditions) return query;
+  
+  for (const { column, operator, value } of conditions) {
+    switch (operator) {
+      case '=':
+        query = query.eq(column, value);
+        break;
+      case '!=':
+        query = query.neq(column, value);
+        break;
+      case '>':
+        query = query.gt(column, value);
+        break;
+      case '<':
+        query = query.lt(column, value);
+        break;
+      case '>=':
+        query = query.gte(column, value);
+        break;
+      case '<=':
+        query = query.lte(column, value);
+        break;
+      case 'like':
+        query = query.like(column, value);
+        break;
+      case 'ilike':
+        query = query.ilike(column, value);
+        break;
+    }
+  }
+  return query;
+}
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case "list_tables": {
+        const tables = Object.keys(SCHEMA_RELATIONSHIPS);
+        return {
+          content: [{ type: "text", text: `Available tables:\n${tables.join("\n")}` }]
+        };
+      }
+
+      case "describe_table": {
+        const tableName = args.table_name;
+        
+        const { data, error } = await supabase
+          .from(tableName)
+          .select("*")
+          .limit(1);
+        
+        if (error) {
+          return { content: [{ type: "text", text: `Error: ${error.message}` }] };
+        }
+        
+        if (!data || data.length === 0) {
+          return { content: [{ type: "text", text: `Table '${tableName}' is empty or doesn't exist` }] };
+        }
+        
+        const columns = Object.keys(data[0]);
+        const sample = data[0];
+        
+        const description = columns.map(col => {
+          const val = sample[col];
+          const type = val === null ? "null" : Array.isArray(val) ? "array" : typeof val;
+          const preview = val === null ? "null" : 
+            typeof val === "object" ? JSON.stringify(val).slice(0, 60) :
+            String(val).slice(0, 60);
+          return `  ${col}: ${type} = ${preview}`;
+        }).join("\n");
+        
+        return { content: [{ type: "text", text: `Columns in '${tableName}':\n\n${description}` }] };
+      }
+
+      case "sample_rows": {
+        const tableName = args.table_name;
+        const limit = Math.min(args.limit || 5, 100);
+        const columns = args.columns || "*";
+        const orderBy = args.order_by;
+        
+        let query = supabase.from(tableName).select(columns);
+        
+        // Apply where conditions
+        const conditions = parseWhere(args.where);
+        query = applyWhere(query, conditions);
+        
+        // Apply ordering
+        if (orderBy) {
+          const desc = orderBy.startsWith('-');
+          const col = desc ? orderBy.slice(1) : orderBy;
+          query = query.order(col, { ascending: !desc });
+        }
+        
+        query = query.limit(limit);
+        
+        const { data, error } = await query;
+        
+        if (error) {
+          return { content: [{ type: "text", text: `Error: ${error.message}` }] };
+        }
+        
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }]
+        };
+      }
+
+      case "count_rows": {
+        const tableName = args.table_name;
+        const column = args.column;
+        const conditions = parseWhere(args.where);
+        
+        if (column) {
+          let query = supabase.from(tableName).select(column);
+          query = applyWhere(query, conditions);
+          
+          const { data, error } = await query;
+          
+          if (error) {
+            return { content: [{ type: "text", text: `Error: ${error.message}` }] };
+          }
+          
+          const counts = {};
+          for (const row of data || []) {
+            const val = row[column] ?? "(null)";
+            counts[val] = (counts[val] || 0) + 1;
+          }
+          
+          const sorted = Object.entries(counts)
+            .sort((a, b) => b[1] - a[1])
+            .map(([val, count]) => `  ${val}: ${count}`)
+            .join("\n");
+          
+          return { content: [{ type: "text", text: `Counts by '${column}' in '${tableName}':\n\n${sorted}` }] };
+        } else {
+          let query = supabase.from(tableName).select("*", { count: "exact", head: true });
+          query = applyWhere(query, conditions);
+          
+          const { count, error } = await query;
+          
+          if (error) {
+            return { content: [{ type: "text", text: `Error: ${error.message}` }] };
+          }
+          
+          return { content: [{ type: "text", text: `Total rows in '${tableName}': ${count}` }] };
+        }
+      }
+
+      case "run_query": {
+        const query = args.query?.trim();
+        
+        // Security: only allow SELECT queries
+        if (!query || !query.toUpperCase().startsWith('SELECT')) {
+          return { 
+            content: [{ type: "text", text: "Error: Only SELECT queries are allowed. Query must start with SELECT." }] 
+          };
+        }
+        
+        // Block dangerous keywords
+        const dangerous = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'TRUNCATE', 'ALTER', 'CREATE', 'GRANT', 'REVOKE'];
+        const upperQuery = query.toUpperCase();
+        for (const keyword of dangerous) {
+          if (upperQuery.includes(keyword)) {
+            return { 
+              content: [{ type: "text", text: `Error: Query contains forbidden keyword: ${keyword}` }] 
+            };
+          }
+        }
+        
+        const { data, error } = await supabase.rpc('run_readonly_query', { query_text: query });
+        
+        if (error) {
+          // If RPC doesn't exist, try raw query via postgrest (limited)
+          return { 
+            content: [{ 
+              type: "text", 
+              text: `Error: ${error.message}\n\nNote: run_query requires a database function. Use sample_rows with filters for basic queries, or create the function:\n\nCREATE OR REPLACE FUNCTION run_readonly_query(query_text TEXT)\nRETURNS JSON AS $$\nBEGIN\n  RETURN (SELECT json_agg(row_to_json(t)) FROM (SELECT * FROM (SELECT query_text) AS subq) t);\nEND;\n$$ LANGUAGE plpgsql SECURITY DEFINER;`
+            }] 
+          };
+        }
+        
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }]
+        };
+      }
+
+      case "get_row_by_id": {
+        const tableName = args.table_name;
+        const id = args.id;
+        const columns = args.columns || "*";
+        
+        const pk = SCHEMA_RELATIONSHIPS[tableName]?.primary_key || "id";
+        
+        const { data, error } = await supabase
+          .from(tableName)
+          .select(columns)
+          .eq(pk, id)
+          .single();
+        
+        if (error) {
+          return { content: [{ type: "text", text: `Error: ${error.message}` }] };
+        }
+        
+        return {
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }]
+        };
+      }
+
+      case "get_related": {
+        const fromTable = args.from_table;
+        const id = args.id;
+        const toTable = args.to_table;
+        const limit = Math.min(args.limit || 20, 100);
+        
+        const schema = SCHEMA_RELATIONSHIPS[fromTable];
+        if (!schema) {
+          return { content: [{ type: "text", text: `Unknown table: ${fromTable}` }] };
+        }
+        
+        // Find the relationship
+        let foreignKey = null;
+        let direction = null;
+        
+        // Check has_many relationships
+        const hasMany = schema.has_many?.find(r => r.table === toTable);
+        if (hasMany) {
+          foreignKey = hasMany.foreign_key;
+          direction = 'has_many';
+        }
+        
+        // Check belongs_to relationships (reverse lookup)
+        const belongsTo = schema.belongs_to?.find(r => r.table === toTable);
+        if (belongsTo) {
+          // For belongs_to, we need to get the FK value from source row first
+          const pk = schema.primary_key || "id";
+          const { data: sourceRow, error: sourceError } = await supabase
+            .from(fromTable)
+            .select(belongsTo.foreign_key)
+            .eq(pk, id)
+            .single();
+          
+          if (sourceError || !sourceRow) {
+            return { content: [{ type: "text", text: `Error finding source row: ${sourceError?.message}` }] };
+          }
+          
+          const relatedId = sourceRow[belongsTo.foreign_key];
+          const targetPk = SCHEMA_RELATIONSHIPS[toTable]?.primary_key || "id";
+          
+          const { data, error } = await supabase
+            .from(toTable)
+            .select("*")
+            .eq(targetPk, relatedId)
+            .limit(1);
+          
+          if (error) {
+            return { content: [{ type: "text", text: `Error: ${error.message}` }] };
+          }
+          
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }]
+          };
+        }
+        
+        if (!foreignKey) {
+          return { 
+            content: [{ 
+              type: "text", 
+              text: `No relationship found from '${fromTable}' to '${toTable}'. Use explain_schema to see available relationships.` 
+            }] 
+          };
+        }
+        
+        // For has_many, query the related table
+        const { data, error } = await supabase
+          .from(toTable)
+          .select("*")
+          .eq(foreignKey, id)
+          .limit(limit);
+        
+        if (error) {
+          return { content: [{ type: "text", text: `Error: ${error.message}` }] };
+        }
+        
+        return {
+          content: [{ 
+            type: "text", 
+            text: `Found ${data.length} related rows in '${toTable}' (via ${foreignKey}):\n\n${JSON.stringify(data, null, 2)}` 
+          }]
+        };
+      }
+
+      case "explain_schema": {
+        const tableName = args.table_name;
+        
+        if (tableName) {
+          const schema = SCHEMA_RELATIONSHIPS[tableName];
+          if (!schema) {
+            return { content: [{ type: "text", text: `Unknown table: ${tableName}` }] };
+          }
+          
+          let output = `Schema for '${tableName}':\n\n`;
+          output += `  Primary Key: ${schema.primary_key || 'id'}\n`;
+          
+          if (schema.belongs_to?.length) {
+            output += `\n  Belongs To:\n`;
+            for (const rel of schema.belongs_to) {
+              output += `    → ${rel.table} (via ${rel.foreign_key})\n`;
+            }
+          }
+          
+          if (schema.has_many?.length) {
+            output += `\n  Has Many:\n`;
+            for (const rel of schema.has_many) {
+              output += `    ← ${rel.table} (via ${rel.foreign_key})\n`;
+            }
+          }
+          
+          return { content: [{ type: "text", text: output }] };
+        }
+        
+        // Show all relationships
+        let output = "Database Schema Relationships:\n\n";
+        
+        for (const [table, schema] of Object.entries(SCHEMA_RELATIONSHIPS)) {
+          output += `${table}:\n`;
+          
+          if (schema.belongs_to?.length) {
+            for (const rel of schema.belongs_to) {
+              output += `  → ${rel.table} (${rel.foreign_key})\n`;
+            }
+          }
+          if (schema.has_many?.length) {
+            for (const rel of schema.has_many) {
+              output += `  ← ${rel.table} (${rel.foreign_key})\n`;
+            }
+          }
+          output += "\n";
+        }
+        
+        return { content: [{ type: "text", text: output }] };
+      }
+
+      default:
+        return { content: [{ type: "text", text: `Unknown tool: ${name}` }] };
+    }
+  } catch (err) {
+    return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+  }
+});
+
+// Start server
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/supabase/index.js
+++ b/mcp/supabase/index.js
@@ -340,8 +340,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const conditions = parseWhere(args.where);
         
         if (column) {
-          let query = supabase.from(tableName).select(column);
+          let query = supabase.from(tableName).select(`${column}, count`);
           query = applyWhere(query, conditions);
+          query = query.order('count', { ascending: false });
           
           const { data, error } = await query;
           
@@ -349,15 +350,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             return { content: [{ type: "text", text: `Error: ${error.message}` }] };
           }
           
-          const counts = {};
-          for (const row of data || []) {
-            const val = row[column] ?? "(null)";
-            counts[val] = (counts[val] || 0) + 1;
-          }
-          
-          const sorted = Object.entries(counts)
-            .sort((a, b) => b[1] - a[1])
-            .map(([val, count]) => `  ${val}: ${count}`)
+          const sorted = (data || [])
+            .map((row) => `  ${row[column] ?? "(null)"}: ${row.count}`)
             .join("\n");
           
           return { content: [{ type: "text", text: `Counts by '${column}' in '${tableName}':\n\n${sorted}` }] };

--- a/mcp/supabase/package-lock.json
+++ b/mcp/supabase/package-lock.json
@@ -1,0 +1,318 @@
+{
+  "name": "mcp-supabase",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-supabase",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^0.5.0",
+        "@supabase/supabase-js": "^2.39.0",
+        "dotenv": "^16.3.1"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.86.0.tgz",
+      "integrity": "sha512-3xPqMvBWC6Haqpr6hEWmSUqDq+6SA1BAEdbiaHdAZM9QjZ5uiQJ+6iD9pZOzOa6MVXZh4GmwjhC9ObIG0K1NcA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.86.0.tgz",
+      "integrity": "sha512-AlOoVfeaq9XGlBFIyXTmb+y+CZzxNO4wWbfgRM6iPpNU5WCXKawtQYSnhivi3UVxS7GA0rWovY4d6cIAxZAojA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.86.0.tgz",
+      "integrity": "sha512-QVf+wIXILcZJ7IhWhWn+ozdf8B+oO0Ulizh2AAPxD/6nQL+x3r9lJ47a+fpc/jvAOGXMbkeW534Kw6jz7e8iIA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.86.0.tgz",
+      "integrity": "sha512-dyS8bFoP29R/sj5zLi0AP3JfgG8ar1nuImcz5jxSx7UIW7fbFsXhUCVrSY2Ofo0+Ev6wiATiSdBOzBfWaiFyPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.86.0.tgz",
+      "integrity": "sha512-PM47jX/Mfobdtx7NNpoj9EvlrkapAVTQBZgGGslEXD6NS70EcGjhgRPBItwHdxZPM5GwqQ0cGMN06uhjeY2mHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.86.0.tgz",
+      "integrity": "sha512-BaC9sv5+HGNy1ulZwY8/Ev7EjfYYmWD4fOMw9bDBqTawEj6JHAiOHeTwXLRzVaeSay4p17xYLN2NSCoGgXMQnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.86.0",
+        "@supabase/functions-js": "2.86.0",
+        "@supabase/postgrest-js": "2.86.0",
+        "@supabase/realtime-js": "2.86.0",
+        "@supabase/storage-js": "2.86.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.0.tgz",
+      "integrity": "sha512-kmgmea2nguZEvRqW79gDqNXyxA3OS5WIgMVffrHpqXV4F/J4UmNIw2vstixioLTNSkd5rFB8G0s3Lwzogm6OFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/mcp/supabase/package.json
+++ b/mcp/supabase/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mcp-supabase",
+  "version": "1.0.0",
+  "description": "MCP server for Supabase read-only queries",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@supabase/supabase-js": "^2.39.0",
+    "dotenv": "^16.3.1"
+  }
+}


### PR DESCRIPTION
Adds an MCP to allow coding agents read-only access to the supabase tables for development.

# Setup

1. Run `npm install` in `mcp/`
3. Add to Cursor MCP config:

```json
{
  "mcpServers": {
    "supabase": {
      "command": "node",
      "args": ["/path/to/mcp/supabase/index.js"]
    }
  }
}
```