### PR TITLE
[83] Implementing organisations

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends, Query
 from fastapi.responses import JSONResponse
 import logging
+import os
 from datetime import datetime
 import uuid
 from typing import Optional, List
@@ -35,6 +36,85 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/analysis-projects", tags=["analysis-projects"])
 
+# Organization slug that has access to all projects (dev/admin org)
+ADMIN_ORG_SLUG = "nesta-dev"
+
+
+def can_access_all_projects(user: CurrentUser) -> bool:
+    """Check if user belongs to an admin org that can see all projects."""
+    return user.organization_slug == ADMIN_ORG_SLUG
+
+
+def can_access_project(
+    user: CurrentUser, project_org_id: str | None, project_created_by: str | None = None
+) -> bool:
+    """Check if user can access a specific project based on organization.
+
+    Args:
+        user: Current authenticated user
+        project_org_id: Organization ID of the project
+        project_created_by: User ID who created the project
+    """
+    # Admin org can access everything
+    if can_access_all_projects(user):
+        return True
+
+    # Creators can always access their own projects (regardless of org assignment)
+    if project_created_by == user.user_id:
+        return True
+
+    # Everyone can access demo org projects
+    demo_org_id = os.getenv("DEMO_ORG_ID")
+    if demo_org_id and project_org_id == demo_org_id:
+        return True
+
+    # User can access projects from their own org
+    if user.organization_id and user.organization_id == project_org_id:
+        return True
+
+    return False
+
+
+def get_project_with_auth_check(
+    project_id: str, user: CurrentUser, select: str = "*"
+) -> dict:
+    """Fetch a project and verify the user has access to it.
+
+    Args:
+        project_id: The project UUID
+        user: The current authenticated user
+        select: Columns to select (default: all)
+
+    Returns:
+        The project data dict
+
+    Raises:
+        HTTPException: 404 if not found, 403 if access denied
+    """
+    # Always need organization_id and created_by_user_id for auth check
+    auth_fields = "organization_id, created_by_user_id"
+    if select != "*" and "organization_id" not in select:
+        select = f"{select}, {auth_fields}"
+
+    result = (
+        vectorization_service.supabase.table("analysis_projects")
+        .select(select)
+        .eq("id", project_id)
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    project = result.data[0]
+
+    if not can_access_project(
+        user, project.get("organization_id"), project.get("created_by_user_id")
+    ):
+        raise HTTPException(status_code=403, detail="Access denied to this project")
+
+    return project
+
 
 # END-I - INFO REGION END
 
@@ -62,18 +142,11 @@ async def get_synthesis_summary(
     try:
         from app.services.synthesis.logbook import get_synthesis_status
 
-        # Check project status first
-        project_result = (
-            vectorization_service.supabase.table("analysis_projects")
-            .select("status")
-            .eq("id", project_id)
-            .execute()
+        # Check project exists and user has access
+        project = get_project_with_auth_check(
+            project_id, current_user, "status, organization_id"
         )
-
-        if not project_result.data:
-            raise HTTPException(status_code=404, detail="Project not found")
-
-        project_status = project_result.data[0].get("status")
+        project_status = project.get("status")
 
         # Check if synthesis is already cached
         cached = await read_cached_summary(project_id)
@@ -142,14 +215,19 @@ async def get_synthesis_summary(
 @router.get("")
 @router.get("/")
 async def get_analysis_projects(current_user: CurrentUser = Depends(get_current_user)):
-    """Get all analysis projects"""
+    """Get analysis projects filtered by user's organization."""
     try:
-        result = (
-            vectorization_service.supabase.table("analysis_projects")
-            .select("*")
-            .order("created_at", desc=True)
-            .execute()
-        )
+        # Use database function for filtering (centralizes authorization logic)
+        result = vectorization_service.supabase.rpc(
+            "get_user_projects",
+            {
+                "p_user_id": current_user.user_id,
+                "p_organization_id": current_user.organization_id,
+                "p_organization_slug": current_user.organization_slug,
+                "p_demo_org_id": os.getenv("DEMO_ORG_ID"),
+                "p_admin_org_slug": ADMIN_ORG_SLUG,
+            },
+        ).execute()
 
         projects = []
         for project_data in result.data:
@@ -243,18 +321,8 @@ async def get_analysis_project(
 ):
     """Get a specific analysis project with documents and extractions"""
     try:
-        # Get project
-        project_result = (
-            vectorization_service.supabase.table("analysis_projects")
-            .select("*")
-            .eq("id", project_id)
-            .execute()
-        )
-
-        if not project_result.data:
-            raise HTTPException(status_code=404, detail="Project not found")
-
-        project = project_result.data[0]
+        # Get project with authorization check
+        project = get_project_with_auth_check(project_id, current_user)
 
         # Get documents
         docs_result = (
@@ -318,6 +386,9 @@ async def update_analysis_project(
 ):
     """Update an analysis project"""
     try:
+        # Check authorization first
+        get_project_with_auth_check(project_id, current_user, "id, organization_id")
+
         # Build update data
         update_data = {}
 
@@ -378,16 +449,8 @@ async def delete_analysis_project(
 ):
     """Delete an analysis project and all its data"""
     try:
-        # Check if project exists
-        project_result = (
-            vectorization_service.supabase.table("analysis_projects")
-            .select("id")
-            .eq("id", project_id)
-            .execute()
-        )
-
-        if not project_result.data:
-            raise HTTPException(status_code=404, detail="Project not found")
+        # Check authorization (also verifies project exists)
+        get_project_with_auth_check(project_id, current_user, "id, organization_id")
 
         # Clean up chunks that reference analysis_documents from this project
         try:
@@ -551,16 +614,8 @@ async def run_analysis_for_project(
         from app.services.analysis.schemas import RunConfig
         from app.core.config import settings
 
-        # Check if project exists
-        project_result = (
-            vectorization_service.supabase.table("analysis_projects")
-            .select("*")
-            .eq("id", project_id)
-            .execute()
-        )
-
-        if not project_result.data:
-            raise HTTPException(status_code=404, detail="Project not found")
+        # Check authorization (also verifies project exists)
+        get_project_with_auth_check(project_id, current_user, "id, organization_id")
 
         # Build run config from request (query comes from search, not from project)
         query = request.get("query", "").strip()
@@ -732,6 +787,9 @@ async def get_project_documents(
 ):
     """Get all documents for an analysis project"""
     try:
+        # Check authorization
+        get_project_with_auth_check(project_id, current_user, "id, organization_id")
+
         docs_result = (
             vectorization_service.supabase.table("analysis_documents")
             .select("*")
@@ -1328,17 +1386,8 @@ async def chat_with_project(
 ) -> ChatResponse:
     """Chat with the analysis project using RAG over collected evidence."""
     try:
-        # Verify project exists and user has access
-        project_result = (
-            vectorization_service.supabase.table("analysis_projects")
-            .select("id")
-            .eq("id", project_id)
-            .single()
-            .execute()
-        )
-
-        if not project_result.data:
-            raise HTTPException(status_code=404, detail="Project not found")
+        # Check authorization
+        get_project_with_auth_check(project_id, current_user, "id, organization_id")
 
         # Generate chat response using the chatbot service
         response = await chatbot_service.chat(project_id, request)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -166,6 +166,7 @@ async def get_analysis_projects(current_user: CurrentUser = Depends(get_current_
                     "created_at": project_data["created_at"],
                     "created_by_user_id": project_data.get("created_by_user_id"),
                     "created_by_name": project_data.get("created_by_name"),
+                    "organization_id": project_data.get("organization_id"),
                 }
             )
 
@@ -200,6 +201,7 @@ async def create_analysis_project(
             "created_at": datetime.utcnow().isoformat(),
             "created_by_user_id": current_user.user_id,
             "created_by_name": current_user.name,
+            "organization_id": current_user.organization_id,
         }
 
         result = (
@@ -225,6 +227,7 @@ async def create_analysis_project(
             "created_at": created_project["created_at"],
             "created_by_user_id": created_project.get("created_by_user_id"),
             "created_by_name": created_project.get("created_by_name"),
+            "organization_id": created_project.get("organization_id"),
         }
 
     except HTTPException:
@@ -291,6 +294,7 @@ async def get_analysis_project(
                 "created_at": project["created_at"],
                 "created_by_user_id": project.get("created_by_user_id"),
                 "created_by_name": project.get("created_by_name"),
+                "organization_id": project.get("organization_id"),
                 "search_query": project.get("search_query"),
             },
             "documents": documents,
@@ -358,6 +362,7 @@ async def update_analysis_project(
             "created_at": updated_project["created_at"],
             "created_by_user_id": updated_project.get("created_by_user_id"),
             "created_by_name": updated_project.get("created_by_name"),
+            "organization_id": updated_project.get("organization_id"),
         }
 
     except HTTPException:

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,4 +1,5 @@
 import os
+import time
 from dotenv import load_dotenv
 from typing import Optional
 from fastapi import HTTPException, Depends
@@ -23,18 +24,41 @@ if not CLERK_SECRET_KEY:
 JWKS_URL = f"{CLERK_JWT_ISSUER}/.well-known/jwks.json"
 jwks_client = PyJWKClient(JWKS_URL)
 
+# Simple in-memory cache for user details (fallback if not in JWT)
+# Format: {user_id: (email, name, timestamp)}
+_user_cache: dict[str, tuple[Optional[str], Optional[str], float]] = {}
+_CACHE_TTL_SECONDS = 3600  # 1 hour
+
 
 class CurrentUser:
     def __init__(
-        self, user_id: str, email: Optional[str] = None, name: Optional[str] = None
+        self,
+        user_id: str,
+        email: Optional[str] = None,
+        name: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        organization_slug: Optional[str] = None,
+        organization_role: Optional[str] = None,
     ):
         self.user_id = user_id
         self.email = email
         self.name = name
+        self.organization_id = organization_id
+        self.organization_slug = organization_slug
+        self.organization_role = organization_role
 
 
-async def fetch_user_from_clerk(user_id: str) -> tuple[Optional[str], Optional[str]]:
-    """Fetch user details from Clerk API"""
+async def fetch_user_from_clerk_cached(
+    user_id: str
+) -> tuple[Optional[str], Optional[str]]:
+    """Fetch user details from Clerk API with caching."""
+    # Check cache first
+    if user_id in _user_cache:
+        email, name, timestamp = _user_cache[user_id]
+        if time.time() - timestamp < _CACHE_TTL_SECONDS:
+            return email, name
+
+    # Fetch from API
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(
@@ -52,7 +76,6 @@ async def fetch_user_from_clerk(user_id: str) -> tuple[Optional[str], Optional[s
                 email_addresses = user_data.get("email_addresses", [])
                 email = None
                 if email_addresses:
-                    # Get the primary email or first email
                     primary_email = next(
                         (
                             addr
@@ -70,23 +93,18 @@ async def fetch_user_from_clerk(user_id: str) -> tuple[Optional[str], Optional[s
 
                 name = None
                 if first_name or last_name:
-                    name_parts = []
-                    if first_name:
-                        name_parts.append(first_name)
-                    if last_name:
-                        name_parts.append(last_name)
+                    name_parts = [n for n in [first_name, last_name] if n]
                     name = " ".join(name_parts) if name_parts else None
                 elif email:
-                    # Fallback to email prefix
                     name = email.split("@")[0]
 
+                # Cache the result
+                _user_cache[user_id] = (email, name, time.time())
                 return email, name
             else:
-                print(f"Failed to fetch user from Clerk API: {response.status_code}")
                 return None, None
 
-    except Exception as e:
-        print(f"Error fetching user from Clerk API: {e}")
+    except Exception:
         return None, None
 
 
@@ -135,21 +153,48 @@ async def get_current_user(
             # Fallback to email if no name is available
             name = email.split("@")[0]  # Use email prefix as display name
 
-        # If we don't have email or name from JWT, fetch from Clerk API
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Invalid token: no user ID")
+
+        # If we don't have email or name from JWT, fetch from Clerk API (cached)
         if not email or not name:
-            print(
-                f"JWT missing user details, fetching from Clerk API for user: {user_id}"
-            )
-            api_email, api_name = await fetch_user_from_clerk(user_id)
+            api_email, api_name = await fetch_user_from_clerk_cached(user_id)
             if not email and api_email:
                 email = api_email
             if not name and api_name:
                 name = api_name
 
-        if not user_id:
-            raise HTTPException(status_code=401, detail="Invalid token: no user ID")
+        # Extract organization info from JWT (Clerk Organizations)
+        # Clerk may put org info in 'o' claim as nested object, or as top-level org_id/org_slug/org_role
+        organization_id = payload.get("org_id")
+        organization_slug = payload.get("org_slug")
+        organization_role = payload.get("org_role")
 
-        return CurrentUser(user_id=user_id, email=email, name=name)
+        # Check for nested 'o' claim (Clerk's default org structure)
+        org_claim = payload.get("o")
+        if org_claim and isinstance(org_claim, dict):
+            organization_id = organization_id or org_claim.get("id")
+            organization_slug = (
+                organization_slug or org_claim.get("slg") or org_claim.get("slug")
+            )
+            organization_role = (
+                organization_role or org_claim.get("rol") or org_claim.get("role")
+            )
+
+        # Only warn if org is missing (don't log every successful request)
+        if not organization_id:
+            print(
+                f"WARNING: No org_id in JWT for user {user_id}. User may not have an active organization."
+            )
+
+        return CurrentUser(
+            user_id=user_id,
+            email=email,
+            name=name,
+            organization_id=organization_id,
+            organization_slug=organization_slug,
+            organization_role=organization_role,
+        )
 
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token has expired")

--- a/backend/supabase/migrations/20260107000001_add_organization_id.sql
+++ b/backend/supabase/migrations/20260107000001_add_organization_id.sql
@@ -1,0 +1,13 @@
+-- Add organization_id to analysis_projects for multi-tenancy
+-- Projects belong to the organization that was active when they were created
+
+ALTER TABLE analysis_projects 
+ADD COLUMN IF NOT EXISTS organization_id TEXT;
+
+-- Index for efficient filtering by organization
+CREATE INDEX IF NOT EXISTS idx_analysis_projects_organization 
+ON analysis_projects(organization_id);
+
+-- Note: Existing projects will have NULL organization_id
+-- These should be backfilled manually or via a script once orgs are set up
+

--- a/backend/supabase/migrations/20260107000002_add_get_user_projects_function.sql
+++ b/backend/supabase/migrations/20260107000002_add_get_user_projects_function.sql
@@ -1,0 +1,52 @@
+-- Function to get projects filtered by organization access rules
+-- This centralizes the authorization logic in the database
+
+CREATE OR REPLACE FUNCTION get_user_projects(
+    p_user_id TEXT,
+    p_organization_id TEXT DEFAULT NULL,
+    p_organization_slug TEXT DEFAULT NULL,
+    p_demo_org_id TEXT DEFAULT NULL,
+    p_admin_org_slug TEXT DEFAULT 'nesta-dev'
+)
+RETURNS SETOF analysis_projects
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    -- Admin org sees everything
+    IF p_organization_slug = p_admin_org_slug THEN
+        RETURN QUERY
+        SELECT * FROM analysis_projects
+        ORDER BY created_at DESC;
+        RETURN;
+    END IF;
+
+    -- User with an organization
+    IF p_organization_id IS NOT NULL THEN
+        RETURN QUERY
+        SELECT * FROM analysis_projects
+        WHERE 
+            -- Projects from user's organization
+            organization_id = p_organization_id
+            -- Demo org projects (if demo org is configured)
+            OR (p_demo_org_id IS NOT NULL AND organization_id = p_demo_org_id)
+            -- User's own projects (regardless of org assignment - handles backfill edge case)
+            OR created_by_user_id = p_user_id
+        ORDER BY created_at DESC;
+        RETURN;
+    END IF;
+
+    -- User without an organization
+    RETURN QUERY
+    SELECT * FROM analysis_projects
+    WHERE 
+        -- User's own projects (any org or no org)
+        created_by_user_id = p_user_id
+        -- Demo org projects (if demo org is configured)
+        OR (p_demo_org_id IS NOT NULL AND organization_id = p_demo_org_id)
+    ORDER BY created_at DESC;
+END;
+$$;
+
+COMMENT ON FUNCTION get_user_projects IS 'Returns projects filtered by organization access rules. Admin org sees all, regular users see their org + demo + their own projects (regardless of org assignment).';
+

--- a/docs/backend/user-management.md
+++ b/docs/backend/user-management.md
@@ -1,0 +1,70 @@
+# User Management
+
+Policy Atlas uses [Clerk](https://clerk.com/) for authentication and organization management. Project access is controlled based on the user's organization membership.
+
+## Architecture
+
+- **Clerk**: Handles user authentication, passwords, and organization assignments
+- **Supabase**: Stores project data with `organization_id` for multi-tenancy
+- **JWT Claims**: Organization info (`org_id`, `org_slug`) is passed from Clerk to the backend via JWT tokens
+
+## Project access rules
+
+Access is evaluated in priority order—first matching rule wins:
+
+| Priority | Condition | Access |
+|----------|-----------|--------|
+| 1 | Admin org (`nesta-dev`) | ✅ See all projects |
+| 2 | Project creator | ✅ Always see own projects |
+| 3 | Demo org project | ✅ Everyone can see |
+| 4 | Same org project | ✅ See org's projects |
+| - | Otherwise | ❌ No access |
+
+The filtering logic is implemented in the PostgreSQL function `get_user_projects` (see `migrations/20260107000002_add_get_user_projects_function.sql`).
+
+## User experience
+
+### Users with an organization
+
+- Organization name displayed in sidebar under user avatar
+- "Show all org projects" toggle available on projects page, to see colleagues' searches
+- Default view shows only their created projects
+
+### Users without an organization
+
+- No organization shown in sidebar
+- No toggle on projects page
+- Only see their own created projects and demo projects
+
+## Configuration
+
+Environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `DEMO_ORG_ID` | Clerk organization ID for demo projects (visible to all users) |
+
+The admin org slug (`nesta-dev`) is hardcoded in `backend/app/api/projects.py`.
+
+## Clerk JWT Setup
+
+Ensure Clerk session tokens include these claims (configure in Clerk Dashboard, Configure → Sessions):
+
+```json
+{
+  "org_id": "{{org.id}}",
+  "org_slug": "{{org.slug}}",
+  "org_role": "{{org.role}}",
+  "email": "{{user.primary_email_address}}",
+  "first_name": "{{user.first_name}}",
+  "last_name": "{{user.last_name}}"
+}
+```
+
+## Assigning users to organizations
+
+Currently done manually via Clerk Dashboard:
+
+1. Go to Clerk Dashboard → Organizations
+2. Select or create an organization
+3. Add users as members

--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -115,9 +115,6 @@ export default function AgentLayout({
           </div>
         </div>
 
-        {/* Organization */}
-        <OrganizationManager />
-
         {/* Active Project */}
         <div className="px-6 pb-4">
           <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
@@ -216,7 +213,7 @@ export default function AgentLayout({
 
         {/* User */}
         <div className="p-4 border-t border-slate-100">
-          <div className="flex items-center gap-3">
+          <div className="flex items-start gap-3">
             <div className="flex-shrink-0">
               <UserButton 
                 appearance={{
@@ -229,10 +226,11 @@ export default function AgentLayout({
                 }}
               />
             </div>
-            <div className="flex-1 min-w-0 flex items-center">
+            <div className="flex-1 min-w-0 flex flex-col gap-0.5">
               <p className="text-sm font-medium text-slate-900 truncate leading-none">
                 {user?.firstName || user?.emailAddresses?.[0]?.emailAddress || 'User'}
               </p>
+              <OrganizationManager />
             </div>
           </div>
         </div>

--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -11,6 +11,7 @@ import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
 import { FeedbackButton } from '@/components/ui/feedback-button'
 import { FeedbackModal } from '@/components/ui/feedback-modal'
 import { useFeedbackStore, fetchProjectFeedback, saveProjectFeedback } from '@/lib/feedbackStore'
+import { OrganizationManager } from '@/components/OrganizationManager'
 
 const sidebarItems = [
   { name: 'Projects', href: '/projects', icon: FolderOpen },
@@ -113,6 +114,9 @@ export default function AgentLayout({
             </div>
           </div>
         </div>
+
+        {/* Organization */}
+        <OrganizationManager />
 
         {/* Active Project */}
         <div className="px-6 pb-4">

--- a/frontend/app/(main)/projects/page.tsx
+++ b/frontend/app/(main)/projects/page.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'next/navigation'
 import { useAPI } from '@/lib/api'
 import { useAnalysisProjectStore, AnalysisProject } from '@/lib/analysisProjectStore'
 import { Switch } from '@/components/ui/switch'
-import { useUser } from '@clerk/nextjs'
+import { useUser, useOrganization } from '@clerk/nextjs'
 
 export default function ProjectsPage() {
   const router = useRouter()
@@ -33,6 +33,7 @@ export default function ProjectsPage() {
     setError
   } = useAnalysisProjectStore()
   const { user } = useUser()
+  const { organization } = useOrganization()
 
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showInfoDialog, setShowInfoDialog] = useState(false)
@@ -40,7 +41,7 @@ export default function ProjectsPage() {
   const [isCreating, setIsCreating] = useState(false)
   const [editProjectDialog, setEditProjectDialog] = useState<AnalysisProject | null>(null)
   const [editForm, setEditForm] = useState({ title: '', description: '' })
-  const [showMyProjectsOnly, setShowMyProjectsOnly] = useState(false)
+  const [showAllOrgProjects, setShowAllOrgProjects] = useState(false)
 
   useEffect(() => {
     loadProjects()
@@ -134,25 +135,28 @@ export default function ProjectsPage() {
     }
   }
 
-  // Determine the user's full name, email, and email username for filtering
+  // Get current user ID for filtering
+  const currentUserId = user?.id || ''
   const currentUserFullName = user?.fullName || ''
   const currentUserEmail = user?.emailAddresses?.[0]?.emailAddress || ''
   const currentUserEmailUsername = currentUserEmail.split('@')[0] || ''
 
-  // Filter projects if toggle is on (match by full name, email, or email username)
-  const displayedProjects = showMyProjectsOnly
-    ? projects.filter(
-        p =>
-          p.created_by_name === currentUserFullName ||
-          p.created_by_name === currentUserEmail ||
-          p.created_by_name === currentUserEmailUsername
+  // Default: show only user's own projects. When toggled, show all org projects.
+  const displayedProjects = showAllOrgProjects
+    ? projects
+    : projects.filter(p => 
+        // Match by user ID (preferred) or fallback to name matching
+        p.created_by_user_id === currentUserId ||
+        p.created_by_name === currentUserFullName ||
+        p.created_by_name === currentUserEmail ||
+        p.created_by_name === currentUserEmailUsername
       )
-    : projects
 
-  // Helper: can the current user delete this project?
-  const canDeleteProject = (project: AnalysisProject) => {
-    if (currentUserFullName === 'Karlis Kanders') return true
+  // Helper: can the current user edit/delete this project?
+  const canModifyProject = (project: AnalysisProject) => {
+    // Match by user ID (preferred) or fallback to name matching
     return (
+      project.created_by_user_id === currentUserId ||
       project.created_by_name === currentUserFullName ||
       project.created_by_name === currentUserEmail ||
       project.created_by_name === currentUserEmailUsername
@@ -173,16 +177,18 @@ export default function ProjectsPage() {
           <div className="flex items-center justify-between mb-8">
             <h2 className="text-xl font-semibold text-slate-900"></h2>
             <div className="flex gap-2 items-center">
-              <div className="flex items-center gap-2 mr-2">
-                <Switch
-                  checked={showMyProjectsOnly}
-                  onCheckedChange={setShowMyProjectsOnly}
-                  id="show-my-projects-switch"
-                />
-                <label htmlFor="show-my-projects-switch" className="text-sm text-slate-700 select-none cursor-pointer">
-                  Show my projects
-                </label>
-              </div>
+              {organization && (
+                <div className="flex items-center gap-2 mr-2">
+                  <Switch
+                    checked={showAllOrgProjects}
+                    onCheckedChange={setShowAllOrgProjects}
+                    id="show-all-org-projects-switch"
+                  />
+                  <label htmlFor="show-all-org-projects-switch" className="text-sm text-slate-700 select-none cursor-pointer">
+                    Show all org projects
+                  </label>
+                </div>
+              )}
               <Button 
                 onClick={() => setShowInfoDialog(true)}
                 variant="outline"
@@ -231,7 +237,7 @@ export default function ProjectsPage() {
                         <span className="truncate max-w-[180px]">{project.title}</span>
                       </div>
                       <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
-                        {canDeleteProject(project) && (
+                        {canModifyProject(project) && (
                           <Button 
                             variant="ghost" 
                             size="sm"
@@ -240,7 +246,7 @@ export default function ProjectsPage() {
                             <Edit className="h-3 w-3" />
                           </Button>
                         )}
-                        {canDeleteProject(project) && (
+                        {canModifyProject(project) && (
                           <Button 
                             variant="ghost" 
                             size="sm"

--- a/frontend/components/OrganizationManager.tsx
+++ b/frontend/components/OrganizationManager.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import { useOrganization, useOrganizationList, useSession } from '@clerk/nextjs'
-import { Building2 } from 'lucide-react'
+import { Home } from 'lucide-react'
 
 /**
  * Handles organization auto-selection and displays current org.
@@ -40,39 +40,26 @@ export function OrganizationManager() {
     return null
   }
 
-  // If user has no organizations, show nothing (or a message)
+  // If user has no organizations, show nothing
   if (!organization && (!userMemberships?.data || userMemberships.data.length === 0)) {
-    return (
-      <div className="px-6 pb-4">
-        <div className="bg-amber-50 rounded-lg p-3 border border-amber-200">
-          <div className="flex items-center gap-2">
-            <Building2 className="h-4 w-4 text-amber-600" />
-            <p className="text-xs text-amber-700">No organization assigned</p>
-          </div>
-        </div>
-      </div>
-    )
+    return null
   }
 
   // Show current organization
   if (organization) {
     return (
-      <div className="px-6 pb-2">
-        <div className="flex items-center gap-2 text-slate-500">
-          <Building2 className="h-3.5 w-3.5" />
-          <p className="text-xs font-medium truncate">{organization.name}</p>
-        </div>
+      <div className="flex items-center gap-1.5 text-slate-500">
+        <Home className="h-3 w-3 flex-shrink-0" />
+        <span className="text-xs truncate">{organization.name}</span>
       </div>
     )
   }
 
   // Still loading/selecting
   return (
-    <div className="px-6 pb-2">
-      <div className="flex items-center gap-2 text-slate-400">
-        <Building2 className="h-3.5 w-3.5" />
-        <p className="text-xs">Loading organization...</p>
-      </div>
+    <div className="flex items-center gap-1.5 text-slate-400">
+      <Home className="h-3 w-3 flex-shrink-0" />
+      <span className="text-xs">Loading...</span>
     </div>
   )
 }

--- a/frontend/components/OrganizationManager.tsx
+++ b/frontend/components/OrganizationManager.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useOrganization, useOrganizationList, useSession } from '@clerk/nextjs'
+import { Building2 } from 'lucide-react'
+
+/**
+ * Handles organization auto-selection and displays current org.
+ * 
+ * - If user has no active org but belongs to orgs, auto-selects the first one
+ * - Shows the current organization name in the sidebar
+ * - For users with multiple orgs, they can use Clerk's UserButton to switch
+ */
+export function OrganizationManager() {
+  const { organization, isLoaded: orgLoaded } = useOrganization()
+  const { userMemberships, isLoaded: listLoaded, setActive } = useOrganizationList({
+    userMemberships: { infinite: true }
+  })
+  const { session } = useSession()
+
+  // Auto-select organization if user has orgs but none is active
+  useEffect(() => {
+    if (!orgLoaded || !listLoaded) return
+    
+    // If no active org but user has memberships, auto-select the first one
+    if (!organization && userMemberships?.data && userMemberships.data.length > 0) {
+      const firstOrg = userMemberships.data[0].organization
+      console.log(`Auto-selecting organization: ${firstOrg.name}`)
+      setActive?.({ organization: firstOrg.id })
+        .then(() => {
+          // Force token refresh to include new org claims
+          session?.getToken({ skipCache: true })
+          console.log('Organization set, token refreshed')
+        })
+    }
+  }, [organization, userMemberships, orgLoaded, listLoaded, setActive, session])
+
+  // Don't render anything until loaded
+  if (!orgLoaded || !listLoaded) {
+    return null
+  }
+
+  // If user has no organizations, show nothing (or a message)
+  if (!organization && (!userMemberships?.data || userMemberships.data.length === 0)) {
+    return (
+      <div className="px-6 pb-4">
+        <div className="bg-amber-50 rounded-lg p-3 border border-amber-200">
+          <div className="flex items-center gap-2">
+            <Building2 className="h-4 w-4 text-amber-600" />
+            <p className="text-xs text-amber-700">No organization assigned</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Show current organization
+  if (organization) {
+    return (
+      <div className="px-6 pb-2">
+        <div className="flex items-center gap-2 text-slate-500">
+          <Building2 className="h-3.5 w-3.5" />
+          <p className="text-xs font-medium truncate">{organization.name}</p>
+        </div>
+      </div>
+    )
+  }
+
+  // Still loading/selecting
+  return (
+    <div className="px-6 pb-2">
+      <div className="flex items-center gap-2 text-slate-400">
+        <Building2 className="h-3.5 w-3.5" />
+        <p className="text-xs">Loading organization...</p>
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/lib/analysisProjectStore.ts
+++ b/frontend/lib/analysisProjectStore.ts
@@ -13,6 +13,7 @@ export interface AnalysisProject {
   created_at: string
   created_by_user_id?: string
   created_by_name?: string
+  organization_id?: string
   search_query?: {
     original_query?: string
     boolean_query?: string

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
     - Overview: backend/overview.md
     - API documentation: backend/api.md
     - Database: backend/database.md
+    - User Management: backend/user-management.md
   - Frontend:
     - Overview: frontend/overview.md
 


### PR DESCRIPTION
Adds organisation-based project access control (Closes #83 )

Implements organisation management using Clerk Organizations, allowing users to be assigned to organisations and see only their organisation's projects.

**Backend**
- Added `organization_id` column to `analysis_projects` table in Supabase (as a migration; not pushed yet)
- New projects automatically inherit the creator's organisation
- Created `get_user_projects` PostgreSQL function for efficient project filtering with SQL (rather than fetching *all* projects and then filtering in the backend)
- Updated `can_access_project` in projects.py to enforce access rules
- Adjusted JWT token from Clerk to also show user name and organisation details

**Frontend**
- Added OrganizationManager component for auto-selecting user's org and displaying it in sidebar
- Added "Show all org projects" toggle on projects page (hidden for users without org)
- Projects list defaults to showing only user's own projects

See also the documentation page user-management.md for more details.

Also, reduced clutter in logs, by removing the numerous (too many!) calls to Clerk API 

NB: Once this PR is approved, I'll need to backfill the organisations for the existing projects before deploying these changes.