### PR TITLE
Fix polling to only run for projects that are actually in progress

### DIFF
--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -447,10 +447,22 @@ export default function ProjectResultsPage() {
     }
   }, [analysisComplete])
 
-  // Start polling when project ID is available
+  // Start polling when project ID is available and project is in a running state
   useEffect(() => {
     if (!projectId) {
       console.log('No project ID, skipping polling setup')
+      return
+    }
+
+    // Only poll if we're viewing a project that is actually running
+    // Check the activeProject from store - if it's for a different project or not running, skip polling
+    const currentProjectStatus = activeProject?.id === projectId ? activeProject.status : null
+    const isProjectRunning = currentProjectStatus === 'running' || currentProjectStatus === 'synthesising'
+    
+    // If we know the project is not running (completed, failed, created), don't start polling
+    if (currentProjectStatus && !isProjectRunning) {
+      console.log(`Project ${projectId} status is '${currentProjectStatus}', no polling needed`)
+      setAnalysisComplete(currentProjectStatus === 'completed' || currentProjectStatus === 'created')
       return
     }
 
@@ -566,7 +578,7 @@ export default function ProjectResultsPage() {
       }
       hasStartedPollingRef.current = null
     }
-  }, [projectId, analysisComplete]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [projectId, analysisComplete, activeProject?.id, activeProject?.status]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load data when navigating to a project
   useEffect(() => {


### PR DESCRIPTION
### Problem

When a user was viewing a project that had an analysis running, the polling logic would check for updates every 20 seconds. However, if the user navigated to browse a different project (e.g., one that was already completed), the polling would still trigger API calls and data refreshes, causing loading states to appear and disrupting the user's browsing experience.

### Cause

The polling effect would always start and make an API call to `checkProjectStatus()` whenever the `projectId` changed, regardless of whether the project actually needed polling. Only *after* making these calls would it determine if polling was needed. This caused unnecessary API calls and visible loading states even for completed projects.

### Solution

Added an early check at the start of the polling effect that examines the `activeProject` status from the Zustand store. If the project being viewed is already `completed`, `created`, or `failed`, the polling setup is skipped entirely - no API calls, no loading states, no disruption.

Polling now only starts if the project is actually in a `running` or `synthesising` state, or if the status is unknown (which triggers an API check as a fallback).

### Changes

- `frontend/app/(main)/projects/[projectId]/page.tsx`: Added early return in polling effect based on known project status from store