### PR TITLE
Adding OpenAlex API key support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,6 @@
 # OpenAlex asks for email for polite use (optional but recommended)
 OPENALEX_EMAIL=
-
-# MediaCloud
-MEDIACLOUD_API_KEY=
+OPENALEX_API_KEY=
 
 # Overton API key
 OVERTON_API_KEY=
@@ -15,6 +13,8 @@ OPENAI_API_KEY=
 CLERK_SECRET_KEY=
 CLERK_PUBLISHABLE_KEY=
 CLERK_JWT_ISSUER=
+# Organisation whose projects are visible to all
+DEMO_ORG_ID=
 
 # Database
 SUPABASE_URL=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -89,6 +89,7 @@ class Settings(BaseSettings):
 
     # OpenAlex Configuration
     OPENALEX_EMAIL: Optional[str] = None
+    OPENALEX_API_KEY: Optional[str] = None
 
     # MediaCloud Configuration
     MEDIACLOUD_API_KEY: Optional[str] = None

--- a/backend/app/services/analysis/references.py
+++ b/backend/app/services/analysis/references.py
@@ -556,17 +556,18 @@ class ReferencesService:
                 task_meta.append(("openalex_search", query_variant))
 
                 # Also collect raw responses for first query only (to avoid too much data)
-                if idx == 0:
-                    tasks.append(
-                        openalex_service.fetch_raw(
-                            query=query_str,
-                            max_results=limit,
-                            min_citations=settings.DEFAULT_MIN_CITATIONS,
-                            date_from=df_val,
-                            date_to=dt_val,
-                        )
-                    )
-                    task_meta.append(("openalex_raw", query_variant))
+                # DISABLED: Commented out to save credits (10 credits per fetch_raw call)
+                # if idx == 0:
+                #     tasks.append(
+                #         openalex_service.fetch_raw(
+                #             query=query_str,
+                #             max_results=limit,
+                #             min_citations=settings.DEFAULT_MIN_CITATIONS,
+                #             date_from=df_val,
+                #             date_to=dt_val,
+                #         )
+                #     )
+                #     task_meta.append(("openalex_raw", query_variant))
 
         if overton_service:
             # Determine source_country parameter from geography_filter
@@ -661,6 +662,10 @@ class ReferencesService:
                     raw_overton = g
                 elif isinstance(g, pd.DataFrame):
                     results.append(g)
+
+        # Check OpenAlex rate limit once after all queries complete
+        if openalex_service:
+            await openalex_service.check_rate_limit()
 
         if not results:
             df = pd.DataFrame(

--- a/backend/app/services/openalex.py
+++ b/backend/app/services/openalex.py
@@ -6,6 +6,8 @@ from openai import AsyncOpenAI
 from app.core.config import settings
 import logging
 import asyncio
+import httpx
+import math
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +47,17 @@ class OpenAlexService:
             config.email = settings.OPENALEX_EMAIL
         config.max_retries = 3
         config.retry_backoff_factor = 0.5
+
+        # Configure API key for OpenAlex (PyAlex has built-in support)
+        if settings.OPENALEX_API_KEY:
+            config.api_key = settings.OPENALEX_API_KEY
+            self._api_key = settings.OPENALEX_API_KEY
+            logger.info("OpenAlex API key configured")
+        else:
+            self._api_key = None
+            logger.warning(
+                "OpenAlex API key not configured - limited to 100 credits per day"
+            )
 
         # Initialize OpenAI client for boolean query generation
         if settings.OPENAI_API_KEY:
@@ -420,6 +433,46 @@ class OpenAlexService:
         """Format papers for LLM screening"""
         # Create dictionary with title and content
         return df.set_index("id")[["title", "content"]].to_dict("index")
+
+    async def check_rate_limit(self) -> Optional[Dict]:
+        """Check current OpenAlex rate limit status.
+
+        Returns:
+            Dict with rate limit information, or None if API key is not configured
+        """
+        if not self._api_key:
+            logger.warning("Cannot check rate limit: API key not configured")
+            return None
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    "https://api.openalex.org/rate-limit",
+                    params={"api_key": self._api_key},
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                rate_limit_info = data.get("rate_limit", {})
+                credits_limit = rate_limit_info.get("credits_limit", 0)
+                credits_used = rate_limit_info.get("credits_used", 0)
+                credits_remaining = rate_limit_info.get("credits_remaining", 0)
+                resets_in_seconds = rate_limit_info.get("resets_in_seconds", 0)
+                resets_in_hours = math.ceil(resets_in_seconds / 3600)
+
+                logger.info(
+                    "📊 OpenAlex Rate Limit: %d/%d credits used, %d remaining (resets in %dh)",
+                    credits_used,
+                    credits_limit,
+                    credits_remaining,
+                    resets_in_hours,
+                )
+
+                return rate_limit_info
+        except Exception as e:
+            logger.error("Failed to check OpenAlex rate limit: %s", e)
+            return None
 
     async def fetch_raw(
         self,

--- a/backend/test/test_openalex.py
+++ b/backend/test/test_openalex.py
@@ -1,0 +1,129 @@
+"""Integration tests for OpenAlex API service."""
+
+import pytest
+import pandas as pd
+
+from app.services.openalex import OpenAlexService, sanitize_openalex_query
+from app.core.config import settings
+
+
+class TestSanitizeOpenAlexQuery:
+    """Tests for query sanitization function."""
+
+    def test_removes_commas_inside_quotes(self):
+        query = '"climate change, adaptation" OR "global warming"'
+        result = sanitize_openalex_query(query)
+        assert result == '"climate change adaptation" OR "global warming"'
+
+    def test_preserves_commas_outside_quotes(self):
+        query = "climate, change, adaptation"
+        result = sanitize_openalex_query(query)
+        assert result == "climate, change, adaptation"
+
+    def test_handles_empty_string(self):
+        result = sanitize_openalex_query("")
+        assert result == ""
+
+    def test_handles_no_quotes(self):
+        query = "climate change adaptation"
+        result = sanitize_openalex_query(query)
+        assert result == "climate change adaptation"
+
+
+@pytest.mark.skipif(
+    not settings.OPENALEX_API_KEY, reason="OPENALEX_API_KEY not configured"
+)
+class TestOpenAlexServiceIntegration:
+    """Integration tests that make real API calls to OpenAlex."""
+
+    @pytest.fixture
+    def service(self):
+        return OpenAlexService()
+
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, service):
+        """Test that search returns a DataFrame with expected columns."""
+        df = await service.search(
+            query="machine learning",
+            max_results=10,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) <= 10
+        assert len(df) > 0
+
+        expected_columns = ["id", "title", "abstract", "doi", "authors"]
+        for col in expected_columns:
+            assert col in df.columns, f"Missing column: {col}"
+
+    @pytest.mark.asyncio
+    async def test_search_with_return_total(self, service):
+        """Test that search can return total count."""
+        df, total = await service.search(
+            query="climate change",
+            max_results=5,
+            return_n_total=True,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) <= 5
+        assert isinstance(total, int)
+        assert total > 0
+
+    @pytest.mark.asyncio
+    async def test_search_minimal_returns_limited_fields(self, service):
+        """Test that minimal search returns only essential fields."""
+        df = await service.search_minimal(
+            query="renewable energy",
+            max_results=10,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) <= 10
+
+        expected_columns = ["id", "doi", "title", "cited_by_count", "relevance_score"]
+        assert list(df.columns) == expected_columns
+
+    @pytest.mark.asyncio
+    async def test_search_minimal_count_only(self, service):
+        """Test that count_only returns just an integer."""
+        count = await service.search_minimal(
+            query="artificial intelligence",
+            count_only=True,
+        )
+
+        assert isinstance(count, int)
+        assert count > 0
+
+    @pytest.mark.asyncio
+    async def test_check_rate_limit(self, service):
+        """Test that rate limit check returns expected structure."""
+        rate_limit = await service.check_rate_limit()
+
+        assert rate_limit is not None
+        assert "credits_limit" in rate_limit
+        assert "credits_used" in rate_limit
+        assert "credits_remaining" in rate_limit
+        assert "resets_in_seconds" in rate_limit
+
+        assert isinstance(rate_limit["credits_limit"], int)
+        assert rate_limit["credits_limit"] > 0
+        assert rate_limit["credits_remaining"] >= 0
+
+
+@pytest.mark.skipif(
+    settings.OPENALEX_API_KEY is not None,
+    reason="Test only runs when API key is NOT configured",
+)
+class TestOpenAlexServiceWithoutApiKey:
+    """Tests for behavior when API key is not configured."""
+
+    @pytest.fixture
+    def service(self):
+        return OpenAlexService()
+
+    @pytest.mark.asyncio
+    async def test_check_rate_limit_returns_none(self, service):
+        """Test that rate limit check returns None without API key."""
+        result = await service.check_rate_limit()
+        assert result is None


### PR DESCRIPTION
Adds API key authentication for OpenAlex API calls (required starting Feb 13, 2026) and implements credit usage monitoring.

### Changes

**Configuration**
- Added `OPENALEX_API_KEY` to backend settings (`config.py`)
- PyAlex uses native `config.api_key` for authentication

**Rate Limit Monitoring**
- Added `check_rate_limit()` method to query OpenAlex `/rate-limit` endpoint
- Logs credit usage after search operations: `📊 OpenAlex Rate Limit: X/100000 credits used, Y remaining (resets in Zh)`

**Cost Optimisation**
- Disabled `fetch_raw` debug calls (saves 10 credits per search)

**Tests**
- Added `test_openalex.py` with unit tests for query sanitisation and integration tests for API calls

### Credit Usage Estimate
- ~150 credits per search (15 queries × 10 credits each)
- Daily capacity: ~666 searches/day with free API key (100,000 credits/day)

### Usage
Add your api_key to `.env`: