### PR TITLE
Improve search wizard UX

### DIFF
--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -14,6 +14,7 @@ import { FeedbackModal } from '@/components/ui/feedback-modal'
 import { useFeedbackStore, fetchProjectFeedback, saveProjectFeedback } from '@/lib/feedbackStore'
 import { fetchEvidenceCategories } from '@/lib/evidenceCategories'
 import { OrganizationManager } from '@/components/OrganizationManager'
+import { Footer } from '@/components/Footer'
 
 const getResultsHref = (activeProjectId?: string) =>
   activeProjectId ? `/projects/${activeProjectId}` : '/projects'
@@ -261,8 +262,15 @@ export default function AgentLayout({
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col ml-64">
-        {children}
+      <div className="flex-1 flex flex-col ml-64 min-h-0">
+        <div className="flex-1 min-h-0 overflow-auto">
+          <div className="min-h-full flex flex-col bg-white">
+            <div className="min-h-0">
+              {children}
+            </div>
+            <Footer />
+          </div>
+        </div>
       </div>
 
       {/* Feedback Modal */}

--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -265,7 +265,7 @@ export default function AgentLayout({
       <div className="flex-1 flex flex-col ml-64 min-h-0">
         <div className="flex-1 min-h-0 overflow-auto">
           <div className="min-h-full flex flex-col bg-white">
-            <div className="min-h-0">
+            <div className="flex-1 min-h-0 flex flex-col">
               {children}
             </div>
             <Footer />

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -177,8 +177,12 @@ export default function ProjectResultsPage() {
         return
       }
       
-      // If we already have this project in store, no need to fetch
-      if (activeProject?.id === projectId) return
+      // If we already have this project in store with full payload, no need to fetch.
+      // The projects list endpoint omits search_query, so we must refetch when that field is missing.
+      const hasSearchQueryField =
+        !!activeProject &&
+        Object.prototype.hasOwnProperty.call(activeProject, 'search_query')
+      if (activeProject?.id === projectId && hasSearchQueryField) return
       
       setProjectLoading(true)
       setError(null)

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -868,7 +868,7 @@ export default function ProjectResultsPage() {
   }
 
   return (
-    <div className="flex-1 flex flex-col">
+    <div className="flex flex-col">
       {/* Header */}
       <div className="border-b border-slate-200 bg-white px-8 py-6">
         <div className="flex items-center justify-between">
@@ -907,7 +907,7 @@ export default function ProjectResultsPage() {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 bg-slate-50">
+      <div className="bg-slate-50">
 
         {/* Show error state */}
         {error && (
@@ -939,7 +939,7 @@ export default function ProjectResultsPage() {
 
         {/* Show empty state if no project */}
         {!projectId && !error && (
-          <div className="flex items-center justify-center h-full">
+          <div className="flex items-center justify-center min-h-[200px] py-12">
             <div className="text-center p-8">
               <FileText className="h-16 w-16 text-slate-400 mx-auto mb-4" />
               <h3 className="text-lg font-medium text-slate-900 mb-2">No Project Selected</h3>
@@ -962,7 +962,7 @@ export default function ProjectResultsPage() {
 
         {/* Show results tabs */}
         {projectId && !error && (
-          <Tabs value={urlTab} onValueChange={handleTabChange} className="h-full flex flex-col">
+          <Tabs value={urlTab} onValueChange={handleTabChange} className="flex flex-col">
             <div className="px-6 pt-4">
               <TabsList className="!grid w-full grid-cols-3">
                 <TabsTrigger value="summary" className="flex items-center gap-2">
@@ -980,7 +980,7 @@ export default function ProjectResultsPage() {
               </TabsList>
             </div>
 
-            <div className="flex-1 overflow-auto">
+            <div>
               <TabsContent value="summary" className="p-6 m-0">
                 <div className="max-w-6xl mx-auto">
                   {/* Stat Cards Row */}

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -868,7 +868,7 @@ export default function ProjectResultsPage() {
   }
 
   return (
-    <div className="flex flex-col">
+    <div className="flex-1 flex flex-col bg-slate-50">
       {/* Header */}
       <div className="border-b border-slate-200 bg-white px-8 py-6">
         <div className="flex items-center justify-between">
@@ -907,7 +907,7 @@ export default function ProjectResultsPage() {
       </div>
 
       {/* Main Content */}
-      <div className="bg-slate-50">
+      <div className="flex-1">
 
         {/* Show error state */}
         {error && (

--- a/frontend/app/(main)/results/ExecutiveBriefing.tsx
+++ b/frontend/app/(main)/results/ExecutiveBriefing.tsx
@@ -21,6 +21,7 @@ import {
   getEvidenceCategoryShortName,
   getEvidenceCategoryRank
 } from "@/lib/evidenceCategories";
+import { FOOTER_DISCLAIMER_TEXT } from "@/components/Footer";
 
 interface ExecutiveBriefingProps {
   briefing: string;
@@ -891,11 +892,13 @@ export function ExecutiveBriefing({
             .pill { text-decoration:none; background:#e0f2fe; color:#1d4ed8; }
             .pill-inline { text-decoration:none; color:#1d4ed8; font-weight:600; }
             .question-text { font-size:14px; color:#0f172a; font-weight:600; }
+            .pdf-footer { margin-top:24px; padding:16px; border-top:1px solid #e2e8f0; background:#f8fafc; font-size:11px; color:#64748b; text-align:center; line-height:1.5; max-width:42rem; margin-left:auto; margin-right:auto; }
           </style>
         </head>
         <body>
           <h1>Executive Summary</h1>
           ${structuredHtml}
+          <footer class="pdf-footer">${FOOTER_DISCLAIMER_TEXT}</footer>
         </body>
       </html>
     `;

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -45,6 +45,9 @@ export default function SearchPage() {
           case "LAST_YEAR":
             dateFrom = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate()).toISOString().split('T')[0];
             break;
+          case "LAST_2_YEARS":
+            dateFrom = new Date(now.getFullYear() - 2, now.getMonth(), now.getDate()).toISOString().split('T')[0];
+            break;
           case "LAST_5_YEARS":
             dateFrom = new Date(now.getFullYear() - 5, now.getMonth(), now.getDate()).toISOString().split('T')[0];
             break;

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -79,9 +79,9 @@ export default function SearchPage() {
 
       const searchContext = {
         research_question: context.researchQuestion,
-        population: context.population.selected,
+        population: context.population,
         inner_setting: context.innerSetting,
-        outcome: context.outcome.selected,
+        outcome: context.outcome,
         screening_factors: context.screeningFactors,
         sources: context.parameters.sources,
         geography: context.parameters.geography,

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -43,6 +43,10 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
+html {
+  font-size: 78%;
+}
+
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -44,7 +44,7 @@
 }
 
 html {
-  font-size: 78%;
+  font-size: 85%;
 }
 
 :root {

--- a/frontend/app/login/layout.tsx
+++ b/frontend/app/login/layout.tsx
@@ -1,7 +1,14 @@
+import { Footer } from '@/components/Footer'
+
 export default function LoginLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <div className="flex flex-col min-h-screen">
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </div>
+  )
 } 

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,0 +1,16 @@
+export const FOOTER_DISCLAIMER_TEXT =
+  'Policy Atlas is powered by AI and may make mistakes. The outputs are ' +
+  'a synthesis of third-party evidence from academic and grey literature, they ' +
+  'do not necessarily reflect the official views of Nesta. They are intended ' +
+  'for informational purposes only and should be cross-referenced with ' +
+  'primary sources before being used for decision-making.'
+
+export function Footer({ className = '' }: { className?: string }) {
+  return (
+    <footer className={`flex-shrink-0 mt-auto border-t border-slate-200 bg-slate-50 px-4 py-4 ${className}`.trim()}>
+      <p className="text-xs text-slate-600 max-w-4xl mx-auto text-center leading-relaxed">
+        {FOOTER_DISCLAIMER_TEXT}
+      </p>
+    </footer>
+  )
+}

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -7,7 +7,7 @@ export const FOOTER_DISCLAIMER_TEXT =
 
 export function Footer({ className = '' }: { className?: string }) {
   return (
-    <footer className={`flex-shrink-0 mt-auto border-t border-slate-200 bg-slate-50 px-4 py-4 ${className}`.trim()}>
+    <footer className={`flex-shrink-0 border-t border-slate-200 bg-slate-50 px-4 py-4 ${className}`.trim()}>
       <p className="text-xs text-slate-600 max-w-4xl mx-auto text-center leading-relaxed">
         {FOOTER_DISCLAIMER_TEXT}
       </p>

--- a/frontend/components/results/SearchPlanModal.tsx
+++ b/frontend/components/results/SearchPlanModal.tsx
@@ -21,6 +21,7 @@ const SOURCE_LABELS: Record<string, string> = {
 
 const TIME_PRESET_LABELS: Record<string, string> = {
   LAST_YEAR: 'Last year',
+  LAST_2_YEARS: 'Last 2 years',
   LAST_5_YEARS: 'Last 5 years',
   LAST_10_YEARS: 'Last 10 years',
   SINCE_2000: 'Since 2000',

--- a/frontend/components/results/SearchPlanModal.tsx
+++ b/frontend/components/results/SearchPlanModal.tsx
@@ -276,6 +276,15 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
               </div>
             </div>
             <div>
+              <span className="font-medium text-sm">Retrieval limit</span>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <span className={chipClassName}>{maxResults || 'Not specified'} per source</span>
+                <span className="text-xs text-gray-500">
+                  {searchQuery.sources?.length || 0} source{(searchQuery.sources?.length || 0) === 1 ? '' : 's'} selected
+                </span>
+              </div>
+            </div>
+            <div>
               <span className="font-medium text-sm">Time window</span>
               <div className="mt-2 flex flex-wrap gap-2">
                 <span className={chipClassName}>
@@ -301,16 +310,6 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
                   <span className="text-sm text-gray-500">Not specified</span>
                 )}
               </div>
-            </div>
-          </div>
-
-          <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-3">
-            <div className="text-xs uppercase tracking-wide text-blue-700 mb-1">Retrieval limit</div>
-            <p className="text-sm text-gray-700">Maximum number of results retrieved from each selected source.</p>
-            <div className="mt-2 text-sm">
-              <span className="font-medium">Max results per source: </span>
-              <span className="font-semibold text-gray-900">{maxResults || 'Not specified'}</span>
-              <span className="text-gray-500"> ({searchQuery.sources?.length || 0} source{(searchQuery.sources?.length || 0) === 1 ? '' : 's'} selected)</span>
             </div>
           </div>
 

--- a/frontend/components/results/SearchPlanModal.tsx
+++ b/frontend/components/results/SearchPlanModal.tsx
@@ -29,6 +29,11 @@ const TIME_PRESET_LABELS: Record<string, string> = {
   CUSTOM: 'Custom range',
 }
 
+const GEO_LABELS: Record<string, string> = {
+  All: 'Anywhere',
+  'All but UK': 'Anywhere but UK',
+}
+
 type SearchQueryExtended = {
   research_question?: string
   original_query?: string
@@ -36,6 +41,7 @@ type SearchQueryExtended = {
   boolean_queries?: string[]
   boolean_query?: string
   population?: string[]
+  inner_setting?: string[]
   outcome?: string[]
   geography?: string[]
   geography_filter?: string[]
@@ -51,6 +57,11 @@ type SearchQueryExtended = {
   sub_questions?: string[]
   additional_questions?: string[]
   screening_factors?: string[]
+  implementation_constraints?: {
+    cost?: string
+    staffing?: string
+    implementation_complexity?: string
+  } | null
   scope?: string[]
   custom_focus?: string[]
   excludes?: string[]
@@ -70,12 +81,30 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
   const semanticQuery = searchQuery.semantic_query
   const booleanQueries = searchQuery.boolean_queries || (searchQuery.boolean_query ? [searchQuery.boolean_query] : [])
   const population = searchQuery.population || []
+  const innerSetting = searchQuery.inner_setting || []
   const outcome = searchQuery.outcome || []
   const geography = searchQuery.geography || searchQuery.geography_filter || []
   const timePreset = searchQuery.time_preset
   const timeFrom = searchQuery.time_from
   const timeTo = searchQuery.time_to
   const maxResults = searchQuery.max_results || searchQuery.limit
+  const implementationConstraints = searchQuery.implementation_constraints
+  const hasImplementationConstraints = !!implementationConstraints && [
+    implementationConstraints.cost,
+    implementationConstraints.staffing,
+    implementationConstraints.implementation_complexity,
+  ].some((value) => value && value.toLowerCase() !== 'any')
+  const hasCustomTimeRange = timePreset === 'CUSTOM' || !!(timeFrom || timeTo)
+  const chipClassName = 'inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800'
+  const formatConstraintValue = (value?: string) => {
+    if (!value) return null
+    const normalised = value.trim()
+    if (!normalised || normalised.toLowerCase() === 'any') return null
+    return normalised.charAt(0).toUpperCase() + normalised.slice(1)
+  }
+  const constraintCost = formatConstraintValue(implementationConstraints?.cost)
+  const constraintStaffing = formatConstraintValue(implementationConstraints?.staffing)
+  const constraintComplexity = formatConstraintValue(implementationConstraints?.implementation_complexity)
 
   const copyBooleanQuery = async (query: string) => {
     if (!query) return
@@ -100,7 +129,7 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="flex items-center gap-2">
           <Settings className="h-4 w-4" />
-          Search Settings
+          View search settings
         </Button>
       </DialogTrigger>
       
@@ -171,94 +200,117 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
             </div>
           )}
 
-          {/* Key Parameters */}
-          <div className="grid grid-cols-2 gap-3 text-xs">
-            {searchQuery.sources && searchQuery.sources.length > 0 && (
-              <div>
-                <span className="font-medium">Sources:</span>
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {searchQuery.sources.map((source: string) => (
-                    <Badge key={source} variant="outline">
-                      {SOURCE_LABELS[source] || source}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {timePreset && (
-              <div>
-                <span className="font-medium">Time window:</span>
-                <div className="mt-1">
-                  <Badge variant="outline">
-                    {TIME_PRESET_LABELS[timePreset] || timePreset.replaceAll('_', ' ')}
-                  </Badge>
-                  {(timePreset === 'CUSTOM' || (timeFrom && timeTo)) && (
-                    <div className="text-xs text-gray-600 mt-1">
-                      {timeFrom && new Date(timeFrom).toLocaleDateString()} - {timeTo && new Date(timeTo).toLocaleDateString()}
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {geography.length > 0 && (
-              <div>
-                <span className="font-medium">Geography:</span>
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {geography.map((geo: string) => (
-                    <Badge key={geo} variant="outline">
-                      {geo}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {maxResults && (
-              <div>
-                <span className="font-medium">Max results:</span>
-                <div className="mt-1">{maxResults}</div>
-              </div>
-            )}
-
-            {searchQuery.mode && (
-              <div>
-                <span className="font-medium">Search mode:</span>
-                <div className="mt-1">
-                  <Badge variant="outline">{searchQuery.mode}</Badge>
-                </div>
-              </div>
-            )}
+          <div className="grid gap-3">
+            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-3">
+              <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Population</div>
+              {population.length > 0 ? (
+                <p className="text-sm text-gray-900">{population.join(', ')}</p>
+              ) : (
+                <p className="text-sm text-gray-500">Not specified</p>
+              )}
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-3">
+              <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Setting</div>
+              {innerSetting.length > 0 ? (
+                <p className="text-sm text-gray-900">{innerSetting.join(', ')}</p>
+              ) : (
+                <p className="text-sm text-gray-500">No preference</p>
+              )}
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-3">
+              <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Outcome</div>
+              {outcome.length > 0 ? (
+                <p className="text-sm text-gray-900">{outcome.join(', ')}</p>
+              ) : (
+                <p className="text-sm text-gray-500">Not specified</p>
+              )}
+            </div>
           </div>
 
-          {/* Population */}
-          {population.length > 0 && (
+          <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Filters</div>
             <div>
-              <h4 className="font-medium mb-1 text-xs">Population</h4>
-              <div className="flex flex-wrap gap-1">
-                {population.map((item: string, idx: number) => (
-                  <Badge key={idx} variant="outline" className="text-xs py-0">
-                    {item}
-                  </Badge>
-                ))}
+              <span className="font-medium text-sm">Search sources</span>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {searchQuery.sources && searchQuery.sources.length > 0 ? (
+                  searchQuery.sources.map((source: string) => (
+                    <span key={source} className={chipClassName}>
+                      {SOURCE_LABELS[source] || source}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-sm text-gray-500">Not specified</span>
+                )}
               </div>
             </div>
-          )}
+            <div>
+              <span className="font-medium text-sm">Time window</span>
+              <div className="mt-2 flex flex-wrap gap-2">
+                <span className={chipClassName}>
+                  {timePreset ? (TIME_PRESET_LABELS[timePreset] || timePreset.replaceAll('_', ' ')) : 'Not specified'}
+                </span>
+                {hasCustomTimeRange && (
+                  <span className={chipClassName}>
+                    {timeFrom || 'No start date'} to {timeTo || 'No end date'}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div>
+              <span className="font-medium text-sm">Geography</span>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {geography.length > 0 ? (
+                  geography.map((geo: string) => (
+                    <span key={geo} className={chipClassName}>
+                      {GEO_LABELS[geo] || geo}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-sm text-gray-500">Not specified</span>
+                )}
+              </div>
+            </div>
+          </div>
 
-          {/* Outcome */}
-          {outcome.length > 0 && (
+          <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Prioritisation</div>
             <div>
-              <h4 className="font-medium mb-1 text-xs">Outcome</h4>
-              <div className="flex flex-wrap gap-1">
-                {outcome.map((item: string, idx: number) => (
-                  <Badge key={idx} variant="outline" className="text-xs py-0">
-                    {item}
-                  </Badge>
-                ))}
-              </div>
+              <span className="font-medium text-sm">Implementation constraints</span>
+              {hasImplementationConstraints ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {constraintCost && <span className={chipClassName}>Cost: {constraintCost}</span>}
+                  {constraintStaffing && <span className={chipClassName}>Staffing: {constraintStaffing}</span>}
+                  {constraintComplexity && <span className={chipClassName}>Complexity: {constraintComplexity}</span>}
+                </div>
+              ) : (
+                <div className="mt-2 text-sm text-gray-500">Not specified</div>
+              )}
             </div>
-          )}
+            <div>
+              <span className="font-medium text-sm">Screening factors</span>
+              {searchQuery.screening_factors && searchQuery.screening_factors.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {searchQuery.screening_factors.map((item, idx) => (
+                    <span key={`${item}-${idx}`} className={chipClassName}>
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-2 text-sm text-gray-500">None added</div>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-3">
+            <div className="text-xs uppercase tracking-wide text-blue-700 mb-1">Retrieval limit</div>
+            <p className="text-sm text-gray-700">Maximum number of results retrieved from each selected source.</p>
+            <div className="mt-2 text-sm">
+              <span className="font-medium">Max results per source: </span>
+              <span className="font-semibold text-gray-900">{maxResults || 'Not specified'}</span>
+              <span className="text-gray-500"> ({searchQuery.sources?.length || 0} source{(searchQuery.sources?.length || 0) === 1 ? '' : 's'} selected)</span>
+            </div>
+          </div>
 
           {/* Sub Questions */}
           {searchQuery.sub_questions && searchQuery.sub_questions.length > 0 && (
@@ -272,35 +324,12 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
             </div>
           )}
 
-          {/* Additional Questions */}
-          {searchQuery.additional_questions && searchQuery.additional_questions.length > 0 && (
-            <div>
-              <h4 className="font-medium mb-1 text-xs">Additional questions</h4>
-              <ul className="text-xs text-gray-700 space-y-0.5 list-disc list-inside">
-                {searchQuery.additional_questions.map((q, idx) => (
-                  <li key={idx}>{q}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {/* Screening Factors */}
-          {searchQuery.screening_factors && searchQuery.screening_factors.length > 0 && (
-            <div>
-              <h4 className="font-medium mb-1 text-xs">Screening factors</h4>
-              <div className="flex flex-wrap gap-1">
-                {searchQuery.screening_factors.map((item, idx) => (
-                  <Badge key={idx} variant="outline" className="text-xs py-0">
-                    {item}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Scope */}
-          {searchQuery.scope && searchQuery.scope.length > 0 && (
-            <div>
+          {/* Advanced options */}
+          {(searchQuery.scope?.length || searchQuery.custom_focus?.length || searchQuery.excludes?.length) ? (
+            <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
+              <div className="text-xs uppercase tracking-wide text-gray-500">Advanced options</div>
+              {searchQuery.scope && searchQuery.scope.length > 0 && (
+                <div>
               <h4 className="font-medium mb-1 text-xs">Scope</h4>
               <div className="flex flex-wrap gap-1">
                 {searchQuery.scope.map((item) => (
@@ -309,12 +338,11 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
                   </Badge>
                 ))}
               </div>
-            </div>
-          )}
+                </div>
+              )}
 
-          {/* Custom Focus */}
-          {searchQuery.custom_focus && searchQuery.custom_focus.length > 0 && (
-            <div>
+              {searchQuery.custom_focus && searchQuery.custom_focus.length > 0 && (
+                <div>
               <h4 className="font-medium mb-1 text-xs">Custom focus</h4>
               <div className="flex flex-wrap gap-1">
                 {searchQuery.custom_focus.map((item) => (
@@ -323,12 +351,11 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
                   </Badge>
                 ))}
               </div>
-            </div>
-          )}
+                </div>
+              )}
 
-          {/* Excludes */}
-          {searchQuery.excludes && searchQuery.excludes.length > 0 && (
-            <div>
+              {searchQuery.excludes && searchQuery.excludes.length > 0 && (
+                <div>
               <h4 className="font-medium mb-1 text-xs">Exclusions</h4>
               <div className="flex flex-wrap gap-1">
                 {searchQuery.excludes.map((item) => (
@@ -337,8 +364,10 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
                   </Badge>
                 ))}
               </div>
+                </div>
+              )}
             </div>
-          )}
+          ) : null}
 
           {/* Start New Search Button */}
           <div className="pt-2 border-t">

--- a/frontend/components/results/SearchPlanModal.tsx
+++ b/frontend/components/results/SearchPlanModal.tsx
@@ -230,6 +230,36 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
           </div>
 
           <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Refinement</div>
+            <div>
+              <span className="font-medium text-sm">Implementation constraints</span>
+              {hasImplementationConstraints ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {constraintCost && <span className={chipClassName}>Cost: {constraintCost}</span>}
+                  {constraintStaffing && <span className={chipClassName}>Staffing: {constraintStaffing}</span>}
+                  {constraintComplexity && <span className={chipClassName}>Complexity: {constraintComplexity}</span>}
+                </div>
+              ) : (
+                <div className="mt-2 text-sm text-gray-500">Not specified</div>
+              )}
+            </div>
+            <div>
+              <span className="font-medium text-sm">Screening factors</span>
+              {searchQuery.screening_factors && searchQuery.screening_factors.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {searchQuery.screening_factors.map((item, idx) => (
+                    <span key={`${item}-${idx}`} className={chipClassName}>
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-2 text-sm text-gray-500">None added</div>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
             <div className="text-xs uppercase tracking-wide text-gray-500">Filters</div>
             <div>
               <span className="font-medium text-sm">Search sources</span>
@@ -271,36 +301,6 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
                   <span className="text-sm text-gray-500">Not specified</span>
                 )}
               </div>
-            </div>
-          </div>
-
-          <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
-            <div className="text-xs uppercase tracking-wide text-gray-500">Prioritisation</div>
-            <div>
-              <span className="font-medium text-sm">Implementation constraints</span>
-              {hasImplementationConstraints ? (
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {constraintCost && <span className={chipClassName}>Cost: {constraintCost}</span>}
-                  {constraintStaffing && <span className={chipClassName}>Staffing: {constraintStaffing}</span>}
-                  {constraintComplexity && <span className={chipClassName}>Complexity: {constraintComplexity}</span>}
-                </div>
-              ) : (
-                <div className="mt-2 text-sm text-gray-500">Not specified</div>
-              )}
-            </div>
-            <div>
-              <span className="font-medium text-sm">Screening factors</span>
-              {searchQuery.screening_factors && searchQuery.screening_factors.length > 0 ? (
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {searchQuery.screening_factors.map((item, idx) => (
-                    <span key={`${item}-${idx}`} className={chipClassName}>
-                      {item}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <div className="mt-2 text-sm text-gray-500">None added</div>
-              )}
             </div>
           </div>
 

--- a/frontend/components/results/SearchPlanModal.tsx
+++ b/frontend/components/results/SearchPlanModal.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Settings, Search, Copy, CheckCircle, Info } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import type { AnalysisProject } from '@/lib/analysisProjectStore'
+import { useWizard } from '@/components/search/SearchWizard'
 
 interface SearchPlanModalProps {
   project: AnalysisProject
@@ -118,6 +119,7 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
   }
 
   const startNewSearch = () => {
+    useWizard.getState().reset()
     setIsOpen(false)
     router.push('/search')
   }

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -160,6 +160,7 @@ interface WizardState {
   additionalQuestions: string[];
   maxResults: number;
   set: (p: Partial<WizardState>) => void;
+  reset: () => void;
   next: () => void;
   back: () => void;
   buildContext: () => SearchContext;
@@ -193,6 +194,35 @@ export const useWizard = create<WizardState>((set, get) => ({
   additionalQuestions: [],
   maxResults: 30,
   set: (p) => set(p),
+  reset: () =>
+    set({
+      step: "ASK",
+      researchQuestion: "",
+      population: { selected: [], keepBroad: false },
+      innerSetting: { selected: [], noPreference: true },
+      outcome: { selected: [], keepBroad: false },
+      implementationConstraints: {
+        cost: "Any",
+        staffing: "Any",
+        implementationComplexity: "Any",
+      },
+      generatedPopulationOptions: [],
+      generatedInnerSettingOptions: [],
+      generatedOutcomeOptions: [],
+      generatedAdditionalQuestions: [],
+      isGeneratingOptions: false,
+      parameters: {
+        sources: [],
+        access: { academic: true, policy: true },
+        geography: [ANYWHERE_VALUE],
+        timePreset: "LAST_10_YEARS",
+        customFrom: undefined,
+        customTo: undefined,
+      },
+      screeningFactors: [],
+      additionalQuestions: [],
+      maxResults: 30,
+    }),
   next: () => {
     const s = get();
     // Skip ADDITIONAL_QUESTIONS step - go directly from SCREENING to SUMMARY
@@ -1195,7 +1225,10 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
       {/* Navigation at top */}
       <div className="flex justify-between items-center">
-        <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
+          <Button variant="ghost" onClick={() => s.reset()} disabled={isRunning}>Start new search</Button>
+        </div>
         <Button onClick={() => onRunAnalysis(context)} disabled={isRunning}>
           {isRunning ? 'Starting up...' : 'Run Analysis'}
         </Button>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -35,8 +35,17 @@ const Chip = ({ active, children, onClick }: { active?: boolean; children: React
 
 // ---------------- TYPES & CONSTANTS ----------------
 type Step = "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "PARAMETERS" | "SCREENING" | "ADDITIONAL_QUESTIONS" | "SUMMARY";
-type TimePreset = "LAST_YEAR" | "LAST_5_YEARS" | "LAST_10_YEARS" | "SINCE_2000" | "ANY" | "CUSTOM";
+type TimePreset = "LAST_YEAR" | "LAST_2_YEARS" | "LAST_5_YEARS" | "LAST_10_YEARS" | "SINCE_2000" | "ANY" | "CUSTOM";
 type Access = { academic: boolean; policy: boolean };
+const TIME_PRESET_LABELS: Record<TimePreset, string> = {
+  LAST_YEAR: "Last year",
+  LAST_2_YEARS: "Last 2 years",
+  LAST_5_YEARS: "Last 5 years",
+  LAST_10_YEARS: "Last 10 years",
+  SINCE_2000: "Since 2000",
+  ANY: "Any time",
+  CUSTOM: "Custom range",
+};
 const SOURCE_LABELS: Record<"openalex" | "overton", string> = {
   openalex: "Academic literature",
   overton: "Grey literature",
@@ -777,33 +786,36 @@ function ScreenParameters() {
         <div className="space-y-4">
           <h3 className="font-semibold text-lg">When should the evidence be published?</h3>
           <div className="flex flex-wrap gap-3">
-            {["LAST_YEAR", "LAST_5_YEARS", "LAST_10_YEARS", "SINCE_2000", "ANY", "CUSTOM"].map((p) => (
+            {["LAST_YEAR", "LAST_2_YEARS", "LAST_5_YEARS", "LAST_10_YEARS", "SINCE_2000", "ANY", "CUSTOM"].map((p) => (
               <Chip
                 key={p}
                 active={s.parameters.timePreset === p}
                 onClick={() => s.set({ parameters: { ...s.parameters, timePreset: p as TimePreset } })}
               >
-                {p.replaceAll("_", " ")}
+                {TIME_PRESET_LABELS[p as TimePreset]}
               </Chip>
             ))}
           </div>
           {s.parameters.timePreset === "CUSTOM" && (
-            <div className="flex gap-3 max-w-lg">
-              <div className="flex-1">
-                <div className="text-xs text-gray-500 mb-2">From</div>
-                <Input
-                  type="date"
-                  value={s.parameters.customFrom || ""}
-                  onChange={(e) => s.set({ parameters: { ...s.parameters, customFrom: e.target.value } })}
-                />
-              </div>
-              <div className="flex-1">
-                <div className="text-xs text-gray-500 mb-2">To</div>
-                <Input
-                  type="date"
-                  value={s.parameters.customTo || ""}
-                  onChange={(e) => s.set({ parameters: { ...s.parameters, customTo: e.target.value } })}
-                />
+            <div className="max-w-3xl rounded-2xl border border-blue-100 bg-blue-50/40 p-4 space-y-3">
+              <p className="text-sm text-gray-600">Select a start and end date for your custom range.</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="flex-1">
+                  <div className="text-xs text-gray-500 mb-2">From</div>
+                  <Input
+                    type="date"
+                    value={s.parameters.customFrom || ""}
+                    onChange={(e) => s.set({ parameters: { ...s.parameters, customFrom: e.target.value } })}
+                  />
+                </div>
+                <div className="flex-1">
+                  <div className="text-xs text-gray-500 mb-2">To</div>
+                  <Input
+                    type="date"
+                    value={s.parameters.customTo || ""}
+                    onChange={(e) => s.set({ parameters: { ...s.parameters, customTo: e.target.value } })}
+                  />
+                </div>
               </div>
             </div>
           )}
@@ -865,82 +877,93 @@ function ScreenParameters() {
         </div>
 
         {/* Implementation constraints (optional) */}
-        <div className="max-w-2xl">
-          <details className="rounded-xl border border-gray-200 bg-gray-50/40 p-4">
-            <summary className="cursor-pointer text-sm font-medium text-gray-800">
-              Implementation constraints (optional)
-            </summary>
-            <div className="mt-4 space-y-4">
-              <p className="text-sm text-gray-600">
-                Share resource or complexity limits if relevant. Leave as “Any” to skip matching.
-              </p>
-              <div className="grid gap-4 sm:grid-cols-3">
-                <div className="space-y-2">
-                  <div className="text-xs text-gray-500">Cost tolerance</div>
-                  <select
-                    className="w-full px-3 py-2 border border-gray-300 rounded-xl text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                    value={s.implementationConstraints.cost}
-                    onChange={(e) =>
-                      s.set({
-                        implementationConstraints: {
-                          ...s.implementationConstraints,
-                          cost: e.target.value,
-                        },
-                      })
-                    }
-                  >
-                    {constraintOptions.map((opt) => (
-                      <option key={opt} value={opt}>
-                        {opt}
-                      </option>
-                    ))}
-                  </select>
+        <div className="space-y-4 max-w-2xl">
+          <h3 className="font-semibold text-lg">Do you have implementation constraints we should consider?</h3>
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <span>Optional. Leave as “Any” if you do not want to filter by implementation feasibility.</span>
+            <Tooltip
+              content={
+                <div className="max-w-xs text-sm space-y-1">
+                  <p><span className="font-medium">Low</span>: minimal resources or operational effort required.</p>
+                  <p><span className="font-medium">Moderate</span>: manageable resources and coordination needed.</p>
+                  <p><span className="font-medium">High</span>: substantial resources, staffing, or delivery complexity.</p>
                 </div>
-                <div className="space-y-2">
-                  <div className="text-xs text-gray-500">Staffing capacity</div>
-                  <select
-                    className="w-full px-3 py-2 border border-gray-300 rounded-xl text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                    value={s.implementationConstraints.staffing}
-                    onChange={(e) =>
-                      s.set({
-                        implementationConstraints: {
-                          ...s.implementationConstraints,
-                          staffing: e.target.value,
-                        },
-                      })
-                    }
-                  >
-                    {constraintOptions.map((opt) => (
-                      <option key={opt} value={opt}>
-                        {opt}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="space-y-2">
-                  <div className="text-xs text-gray-500">Complexity tolerance</div>
-                  <select
-                    className="w-full px-3 py-2 border border-gray-300 rounded-xl text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                    value={s.implementationConstraints.implementationComplexity}
-                    onChange={(e) =>
-                      s.set({
-                        implementationConstraints: {
-                          ...s.implementationConstraints,
-                          implementationComplexity: e.target.value,
-                        },
-                      })
-                    }
-                  >
-                    {constraintOptions.map((opt) => (
-                      <option key={opt} value={opt}>
-                        {opt}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
+              }
+            >
+              <button
+                type="button"
+                className="inline-flex items-center justify-center h-5 w-5 rounded-full border border-gray-300 text-xs text-gray-600 hover:bg-gray-50"
+                aria-label="How level values are interpreted"
+              >
+                ?
+              </button>
+            </Tooltip>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <div className="text-xs text-gray-500">Cost tolerance</div>
+              <select
+                className="w-full px-3 py-2 border border-gray-300 rounded-xl text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                value={s.implementationConstraints.cost}
+                onChange={(e) =>
+                  s.set({
+                    implementationConstraints: {
+                      ...s.implementationConstraints,
+                      cost: e.target.value,
+                    },
+                  })
+                }
+              >
+                {constraintOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
             </div>
-          </details>
+            <div className="space-y-2">
+              <div className="text-xs text-gray-500">Staffing capacity</div>
+              <select
+                className="w-full px-3 py-2 border border-gray-300 rounded-xl text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                value={s.implementationConstraints.staffing}
+                onChange={(e) =>
+                  s.set({
+                    implementationConstraints: {
+                      ...s.implementationConstraints,
+                      staffing: e.target.value,
+                    },
+                  })
+                }
+              >
+                {constraintOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <div className="text-xs text-gray-500">Complexity tolerance</div>
+              <select
+                className="w-full px-3 py-2 border border-gray-300 rounded-xl text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                value={s.implementationConstraints.implementationComplexity}
+                onChange={(e) =>
+                  s.set({
+                    implementationConstraints: {
+                      ...s.implementationConstraints,
+                      implementationComplexity: e.target.value,
+                    },
+                  })
+                }
+              >
+                {constraintOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
         </div>
 
       </div>
@@ -1163,6 +1186,10 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
     context.implementationConstraints.staffing,
     context.implementationConstraints.implementationComplexity,
   ].some((value) => value && value !== "Any");
+  const hasCustomDateRange =
+    context.parameters.timePreset === "CUSTOM" &&
+    (context.parameters.customFrom || context.parameters.customTo);
+  const timeWindowLabel = TIME_PRESET_LABELS[context.parameters.timePreset];
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
@@ -1191,90 +1218,147 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
         <CardHeader>
           <CardTitle>Search parameters</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div>
-            <span className="font-medium">Population: </span>
-            {context.population.selected.length > 0 ? (
-              <span>{context.population.selected.join(", ")}</span>
-            ) : (
-              <span className="text-gray-500">Not specified</span>
-            )}
+        <CardContent className="space-y-6">
+          <div className="grid gap-4">
+            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Population</div>
+              {context.population.selected.length > 0 ? (
+                <p className="text-gray-900">{context.population.selected.join(", ")}</p>
+              ) : (
+                <p className="text-gray-500">Not specified</p>
+              )}
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Setting</div>
+              {context.innerSetting.length > 0 ? (
+                <p className="text-gray-900">{context.innerSetting.join(", ")}</p>
+              ) : (
+                <p className="text-gray-500">No preference</p>
+              )}
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Outcome</div>
+              {context.outcome.selected.length > 0 ? (
+                <p className="text-gray-900">{context.outcome.selected.join(", ")}</p>
+              ) : (
+                <p className="text-gray-500">Not specified</p>
+              )}
+            </div>
           </div>
-          <div>
-            <span className="font-medium">Outcome: </span>
-            {context.outcome.selected.length > 0 ? (
-              <span>{context.outcome.selected.join(", ")}</span>
-            ) : (
-              <span className="text-gray-500">Not specified</span>
-            )}
+
+          <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-4">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Filters</div>
+            <div className="space-y-3">
+              <div>
+                <span className="font-medium">Search sources</span>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {context.parameters.sources.length > 0 ? (
+                    context.parameters.sources.map((src) => (
+                      <span key={src} className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                        {SOURCE_LABELS[src] ?? src}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-gray-500">Not specified</span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <span className="font-medium">Time window</span>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    {timeWindowLabel}
+                  </span>
+                  {hasCustomDateRange && (
+                    <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                      {context.parameters.customFrom || "No start date"} to{" "}
+                      {context.parameters.customTo || "No end date"}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <span className="font-medium">Geography</span>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {context.parameters.geography.length > 0 ? (
+                    context.parameters.geography.map((geo) => (
+                      <span key={geo} className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                        {GEO_LABELS[geo] || geo}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-gray-500">Not specified</span>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
-          <div>
-            <span className="font-medium">Sources: </span>
-            <span>
-              {context.parameters.sources.length > 0
-                ? context.parameters.sources.map((src) => SOURCE_LABELS[src] ?? src).join(", ")
-                : "Not specified"}
-            </span>
-          </div>
-          {context.parameters.geography.length > 0 && (
+
+          <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Prioritisation</div>
             <div>
-              <span className="font-medium">Where should we look for evidence? (options): </span>
-              <span>{context.parameters.geography.join(", ")}</span>
+              <span className="font-medium">Implementation constraints</span>
+              {hasImplementationConstraints ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    Cost: {context.implementationConstraints.cost}
+                  </span>
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    Staffing: {context.implementationConstraints.staffing}
+                  </span>
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    Complexity: {context.implementationConstraints.implementationComplexity}
+                  </span>
+                </div>
+              ) : (
+                <div className="mt-2 text-gray-500">Not specified</div>
+              )}
             </div>
-          )}
-          <div>
-            <span className="font-medium">Implementation constraints: </span>
-            {hasImplementationConstraints ? (
-              <span>
-                Cost: {context.implementationConstraints.cost}, Staffing:{" "}
-                {context.implementationConstraints.staffing}, Complexity:{" "}
-                {context.implementationConstraints.implementationComplexity}
-              </span>
-            ) : (
-              <span className="text-gray-500">Not specified</span>
-            )}
-          </div>
-          <div>
-            <span className="font-medium">Time window: </span>
-            <span>{context.parameters.timePreset.replaceAll("_", " ")}</span>
-          </div>
-          {context.screeningFactors.length > 0 && (
             <div>
-              <span className="font-medium">Screening factors: </span>
-              <span>{context.screeningFactors.join(", ")}</span>
-            </div>
-          )}
-          <div>
-            <span className="font-medium">Max results: </span>
-            <div className="inline-flex items-center gap-2 mt-1">
-              <button
-                type="button"
-                className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                onClick={() => s.set({ maxResults: Math.max(5, s.maxResults - 5) })}
-                disabled={isRunning}
-                aria-label="Decrease results"
-              >–</button>
-              <span className="min-w-[2ch] text-center">{s.maxResults}</span>
-              <button
-                type="button"
-                className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                onClick={() => s.set({ maxResults: Math.min(200, s.maxResults + 5) })}
-                disabled={isRunning}
-                aria-label="Increase results"
-              >+</button>
+              <span className="font-medium">Screening factors</span>
+              {context.screeningFactors.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {context.screeningFactors.map((factor) => (
+                    <span key={factor} className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                      {factor}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-2 text-gray-500">None added</div>
+              )}
             </div>
           </div>
-          {/* Additional questions step is currently skipped */}
-          {/* {context.additionalQuestions.length > 0 && (
-            <div>
-              <span className="font-medium">Questions: </span>
-              <ul className="list-disc pl-6 mt-2 space-y-1">
-                {context.additionalQuestions.map((q, i) => (
-                  <li key={i}>{q}</li>
-                ))}
-              </ul>
+
+            <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-4">
+              <div className="text-xs uppercase tracking-wide text-blue-700 mb-1">Retrieval limit</div>
+              <p className="text-sm text-gray-700 mb-3">
+                Maximum number of results retrieved from each selected source.
+              </p>
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="font-medium">Max results per source:</span>
+                <div className="inline-flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={() => s.set({ maxResults: Math.max(5, s.maxResults - 5) })}
+                    disabled={isRunning}
+                    aria-label="Decrease results"
+                  >–</button>
+                  <span className="min-w-[2ch] text-center font-semibold">{s.maxResults}</span>
+                  <button
+                    type="button"
+                    className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={() => s.set({ maxResults: Math.min(200, s.maxResults + 5) })}
+                    disabled={isRunning}
+                    aria-label="Increase results"
+                  >+</button>
+                </div>
+                <span className="text-xs text-gray-500">
+                  {context.parameters.sources.length || 0} source{context.parameters.sources.length === 1 ? "" : "s"} selected
+                </span>
+              </div>
             </div>
-          )} */}
         </CardContent>
       </Card>
     </div>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -444,12 +444,6 @@ function ScreenPopulation() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      {/* Navigation at top */}
-      <div className="flex justify-between items-center">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button onClick={() => s.next()}>Next</Button>
-      </div>
-
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you targeting a particular population?</h2>
         <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
@@ -508,6 +502,11 @@ function ScreenPopulation() {
           />
           <Button onClick={addCustom}>+ Add</Button>
         </div>
+      </div>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
       </div>
     </div>
   );
@@ -578,11 +577,6 @@ function ScreenInnerSetting() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      <div className="flex justify-between items-center">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button onClick={() => s.next()}>Next</Button>
-      </div>
-
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular settings?</h2>
         <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information and assess transferability.</p>
@@ -654,6 +648,11 @@ function ScreenInnerSetting() {
           <Button onClick={addCustom}>+ Add</Button>
         </div>
       </div>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+      </div>
     </div>
   );
 }
@@ -708,12 +707,6 @@ function ScreenOutcome() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      {/* Navigation at top */}
-      <div className="flex justify-between items-center">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button onClick={() => s.next()}>Next</Button>
-      </div>
-
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular outcomes?</h2>
         <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
@@ -773,6 +766,11 @@ function ScreenOutcome() {
           <Button onClick={addCustom}>+ Add</Button>
         </div>
       </div>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+      </div>
     </div>
   );
 }
@@ -813,12 +811,6 @@ function ScreenParameters() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      {/* Navigation at top */}
-      <div className="flex justify-between items-center">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button onClick={() => s.next()}>Next</Button>
-      </div>
-
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Sources, time window, and geography</h2>
         <p className="text-gray-600 text-lg">We will use this filter only the most relevant information</p>
@@ -1023,6 +1015,11 @@ function ScreenParameters() {
         </div>
 
       </div>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+      </div>
     </div>
   );
 }
@@ -1079,14 +1076,6 @@ function ScreenScreening() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      {/* Navigation at top */}
-      <div className="flex justify-between items-center">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button onClick={handleNext} disabled={s.isGeneratingOptions}>
-          {s.isGeneratingOptions ? "Generating..." : "Next"}
-        </Button>
-      </div>
-
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Anything else to consider when screening the evidence?</h2>
         <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
@@ -1128,6 +1117,13 @@ function ScreenScreening() {
           <Button onClick={addFactor}>+ Add</Button>
         </div>
       </div>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={handleNext} disabled={s.isGeneratingOptions}>
+          {s.isGeneratingOptions ? "Generating..." : "Next"}
+        </Button>
+      </div>
     </div>
   );
 }
@@ -1163,12 +1159,6 @@ function ScreenAdditionalQuestions() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      {/* Navigation at top */}
-      <div className="flex justify-between items-center">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button onClick={() => s.next()}>Next</Button>
-      </div>
-
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Specific research questions?</h2>
         <p className="text-gray-600 text-lg">We will use these to shape the summary write-up</p>
@@ -1229,6 +1219,11 @@ function ScreenAdditionalQuestions() {
           <Button onClick={addQuestion}>+ Add</Button>
         </div>
       </div>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+      </div>
     </div>
   );
 }
@@ -1249,17 +1244,6 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      {/* Navigation at top */}
-      <div className="flex justify-between items-center">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
-          <Button variant="ghost" onClick={() => s.reset()} disabled={isRunning}>Start new search</Button>
-        </div>
-        <Button onClick={() => onRunAnalysis(context)} disabled={isRunning}>
-          {isRunning ? 'Starting up...' : 'Run Analysis'}
-        </Button>
-      </div>
-
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Summary</h2>
       </div>
@@ -1420,6 +1404,16 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
             </div>
         </CardContent>
       </Card>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()} disabled={isRunning}>Start new search</Button>
+        </div>
+        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => onRunAnalysis(context)} disabled={isRunning}>
+          {isRunning ? 'Starting up...' : 'Run Analysis'}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -648,7 +648,7 @@ function ScreenInnerSetting() {
   );
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-6">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-4">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular settings?</h2>
         <p className="text-gray-600 text-lg">We use this to prioritise context-matched evidence and assess transferability.</p>
@@ -773,7 +773,7 @@ function ScreenOutcome() {
   const customOptions = s.outcome.selected.filter(outcome => !exampleOptions.includes(outcome));
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-2">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-4">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular outcomes?</h2>
         <p className="text-gray-600 text-lg">We use this to prioritise evidence measuring your outcomes of interest.</p>
@@ -903,7 +903,7 @@ function ScreenParameters() {
   }, [s.parameters.access.academic, s.parameters.access.policy]);
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-0">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-4">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Sources, time window, and geography</h2>
         <p className="text-gray-600 text-lg">We use these filters to narrow the evidence set before ranking.</p>
@@ -1074,7 +1074,7 @@ function ScreenScreening() {
   };
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-4">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Additional criteria</h2>
         <p className="text-gray-600 text-lg">
@@ -1251,7 +1251,7 @@ function ScreenAdditionalQuestions() {
   ];
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-4">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Specific research questions?</h2>
         <p className="text-gray-600 text-lg">We will use these to shape the summary write-up</p>
@@ -1547,7 +1547,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
   const primaryAction = getPrimaryAction();
 
   return (
-    <div className="bg-white text-gray-900 min-h-[calc(100vh-8rem)] flex flex-col">
+    <div className="bg-white text-gray-900 min-h-[calc(100vh-8rem)] flex flex-col pb-4">
       <ProgressBar
         step={s.step}
         researchQuestion={s.researchQuestion}
@@ -1565,7 +1565,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
       </div>
 
       {showActionBar && (
-        <div className={cx("max-w-4xl mx-auto w-full px-8", isSummaryStep ? "mt-3 mb-4" : "mt-auto")}>
+        <div className="max-w-4xl mx-auto w-full px-8 mt-3">
           <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
             <div className="flex items-center gap-2">
               <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -219,8 +219,8 @@ export const useWizard = create<WizardState>((set, get) => ({
     }),
   next: () => {
     const s = get();
-    // Skip ADDITIONAL_QUESTIONS step - go directly from SCREENING to SUMMARY
-    const steps: Step[] = ["ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "PARAMETERS", "SCREENING", "ADDITIONAL_QUESTIONS", "SUMMARY"];
+    // Skip ADDITIONAL_QUESTIONS step - go directly from PARAMETERS to SUMMARY
+    const steps: Step[] = ["ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
     const currentIdx = steps.indexOf(s.step);
     if (currentIdx < steps.length - 1) {
       const nextStep = steps[currentIdx + 1];
@@ -234,14 +234,14 @@ export const useWizard = create<WizardState>((set, get) => ({
   },
   back: () => {
     const s = get();
-    // Skip ADDITIONAL_QUESTIONS step - go directly from SUMMARY to SCREENING
-    const steps: Step[] = ["ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "PARAMETERS", "SCREENING", "ADDITIONAL_QUESTIONS", "SUMMARY"];
+    // Skip ADDITIONAL_QUESTIONS step - go directly from SUMMARY to PARAMETERS
+    const steps: Step[] = ["ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
     const currentIdx = steps.indexOf(s.step);
     if (currentIdx > 0) {
       const prevStep = steps[currentIdx - 1];
-      // Skip ADDITIONAL_QUESTIONS - go directly to SCREENING
+      // Skip ADDITIONAL_QUESTIONS - go directly to PARAMETERS
       if (prevStep === "ADDITIONAL_QUESTIONS") {
-        set({ step: "SCREENING" });
+        set({ step: "PARAMETERS" });
       } else {
         set({ step: prevStep });
       }
@@ -278,8 +278,8 @@ function ProgressBar({
     { id: "POPULATION", label: "Population" },
     { id: "INNER_SETTING", label: "Setting" },
     { id: "OUTCOME", label: "Outcome" },
-    { id: "PARAMETERS", label: "Parameters" },
-    { id: "SCREENING", label: "Prioritisation" },
+    { id: "SCREENING", label: "Refinement" },
+    { id: "PARAMETERS", label: "Filters" },
     { id: "SUMMARY", label: "Summary" },
   ];
   const currentIdx = steps.findIndex((s) => s.id === step);
@@ -1052,9 +1052,9 @@ function ScreenScreening() {
   return (
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
       <div className="text-center space-y-3">
-        <h2 className="text-2xl font-semibold">Prioritisation and assessment settings</h2>
+        <h2 className="text-2xl font-semibold">Additional criteria</h2>
         <p className="text-gray-600 text-lg">
-          Optional. Configure how evidence is prioritised during screening and assessed for implementation fit.
+          Optional additional considerations for evidence assessment.
         </p>
       </div>
 
@@ -1062,13 +1062,13 @@ function ScreenScreening() {
         <div className="space-y-4">
           <h3 className="font-semibold text-lg">Implementation constraints</h3>
           <div className="flex items-center gap-2 text-sm text-gray-600">
-            <span>Optionally set your tolerance on implementation factors. Used during impact and transferability assessment.</span>
+            <span>Set your tolerance on implementation factors. This will be used during impact and transferability assessment.</span>
             <Tooltip
               content={
                 <div className="max-w-xs text-sm space-y-1">
-                  <p><span className="font-medium">Low</span>: minimal resources or operational effort required.</p>
-                  <p><span className="font-medium">Moderate</span>: manageable resources and coordination needed.</p>
-                  <p><span className="font-medium">High</span>: substantial resources, staffing, or delivery complexity.</p>
+                  <p><span className="font-medium">Low</span>: minimal resources or operational effort capacity.</p>
+                  <p><span className="font-medium">Moderate</span>: manageable resources and coordination capacity.</p>
+                  <p><span className="font-medium">High</span>: substantial resources, staffing, or delivery capacity.</p>
                 </div>
               }
             >
@@ -1325,7 +1325,7 @@ function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
 
       <Card>
         <CardHeader>
-          <CardTitle>Search parameters</CardTitle>
+          <CardTitle>Search settings</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="grid gap-4">
@@ -1363,6 +1363,42 @@ function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
                 <p className="text-gray-900">{context.outcome.join(", ")}</p>
               ) : (
                 <p className="text-gray-500">No preference</p>
+              )}
+            </button>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Refinement</div>
+            <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
+              <span className="font-medium">Implementation constraints</span>
+              {hasImplementationConstraints ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    Cost: {context.implementationConstraints.cost}
+                  </span>
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    Staffing: {context.implementationConstraints.staffing}
+                  </span>
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    Complexity: {context.implementationConstraints.implementationComplexity}
+                  </span>
+                </div>
+              ) : (
+                <div className="mt-2 text-gray-500">No preference</div>
+              )}
+            </button>
+            <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
+              <span className="font-medium">Screening factors</span>
+              {context.screeningFactors.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {context.screeningFactors.map((factor) => (
+                    <span key={factor} className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                      {factor}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-2 text-gray-500">None added</div>
               )}
             </button>
           </div>
@@ -1415,71 +1451,35 @@ function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
             </div>
           </div>
 
-          <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
-            <div className="text-xs uppercase tracking-wide text-gray-500">Prioritisation</div>
-            <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
-              <span className="font-medium">Implementation constraints</span>
-              {hasImplementationConstraints ? (
-                <div className="mt-2 flex flex-wrap gap-2">
-                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
-                    Cost: {context.implementationConstraints.cost}
-                  </span>
-                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
-                    Staffing: {context.implementationConstraints.staffing}
-                  </span>
-                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
-                    Complexity: {context.implementationConstraints.implementationComplexity}
-                  </span>
-                </div>
-              ) : (
-                <div className="mt-2 text-gray-500">No preference</div>
-              )}
-            </button>
-            <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
-              <span className="font-medium">Screening factors</span>
-              {context.screeningFactors.length > 0 ? (
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {context.screeningFactors.map((factor) => (
-                    <span key={factor} className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
-                      {factor}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <div className="mt-2 text-gray-500">None added</div>
-              )}
-            </button>
-          </div>
-
-            <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-4">
-              <div className="text-xs uppercase tracking-wide text-blue-700 mb-1">Retrieval limit</div>
-              <p className="text-sm text-gray-700 mb-3">
-                Maximum number of results retrieved from each selected source.
-              </p>
-              <div className="flex flex-wrap items-center gap-3">
-                <span className="font-medium">Max results per source:</span>
-                <div className="inline-flex items-center gap-2">
-                  <button
-                    type="button"
-                    className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={() => s.set({ maxResults: Math.max(5, s.maxResults - 5) })}
-                    disabled={isRunning}
-                    aria-label="Decrease results"
-                  >–</button>
-                  <span className="min-w-[2ch] text-center font-semibold">{s.maxResults}</span>
-                  <button
-                    type="button"
-                    className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={() => s.set({ maxResults: Math.min(200, s.maxResults + 5) })}
-                    disabled={isRunning}
-                    aria-label="Increase results"
-                  >+</button>
-                </div>
-                <span className="text-xs text-gray-500">
-                  {context.parameters.sources.length || 0} source{context.parameters.sources.length === 1 ? "" : "s"} selected
-                </span>
+          <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-4">
+            <div className="text-xs uppercase tracking-wide text-blue-700 mb-1">Retrieval limit</div>
+            <p className="text-sm text-gray-700 mb-3">
+              Maximum number of results retrieved from each selected source.
+            </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="font-medium">Max results per source:</span>
+              <div className="inline-flex items-center gap-2">
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => s.set({ maxResults: Math.max(5, s.maxResults - 5) })}
+                  disabled={isRunning}
+                  aria-label="Decrease results"
+                >–</button>
+                <span className="min-w-[2ch] text-center font-semibold">{s.maxResults}</span>
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => s.set({ maxResults: Math.min(200, s.maxResults + 5) })}
+                  disabled={isRunning}
+                  aria-label="Increase results"
+                >+</button>
               </div>
+              <span className="text-xs text-gray-500">
+                {context.parameters.sources.length || 0} source{context.parameters.sources.length === 1 ? "" : "s"} selected
+              </span>
             </div>
+          </div>
         </CardContent>
       </Card>
 
@@ -1519,7 +1519,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
     if (s.step === "SCREENING") {
       return {
         label: s.isGeneratingOptions ? "Generating..." : "Next",
-        onClick: () => s.set({ step: "SUMMARY" }),
+        onClick: () => s.next(),
         disabled: s.isGeneratingOptions,
       };
     }
@@ -1553,8 +1553,8 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
         {s.step === "POPULATION" && <ScreenPopulation />}
         {s.step === "INNER_SETTING" && <ScreenInnerSetting />}
         {s.step === "OUTCOME" && <ScreenOutcome />}
-        {s.step === "PARAMETERS" && <ScreenParameters />}
         {s.step === "SCREENING" && <ScreenScreening />}
+        {s.step === "PARAMETERS" && <ScreenParameters />}
         {s.step === "ADDITIONAL_QUESTIONS" && <ScreenAdditionalQuestions />}
         {s.step === "SUMMARY" && <ScreenSummary isRunning={isRunning} />}
       </div>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -926,6 +926,30 @@ function ScreenParameters() {
               Select at least one source to continue.
             </p>
           )}
+          <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-3">
+            <div className="text-xs uppercase tracking-wide text-gray-500 mb-2">Retrieval limit</div>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="font-medium">Max results screened per source:</span>
+              <div className="inline-flex items-center gap-2">
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => s.set({ maxResults: Math.max(5, s.maxResults - 5) })}
+                  aria-label="Decrease results"
+                >–</button>
+                <span className="min-w-[2ch] text-center font-semibold">{s.maxResults}</span>
+                <button
+                  type="button"
+                  className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => s.set({ maxResults: Math.min(200, s.maxResults + 5) })}
+                  aria-label="Increase results"
+                >+</button>
+              </div>
+              <span className="text-xs text-gray-500">
+                {s.parameters.sources.length || 0} source{s.parameters.sources.length === 1 ? "" : "s"} selected
+              </span>
+            </div>
+          </div>
         </div>
 
         {/* Time window */}
@@ -1293,7 +1317,7 @@ function ScreenAdditionalQuestions() {
   );
 }
 
-function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
+function ScreenSummary({ isRunning: _isRunning = false }: { isRunning?: boolean }) {
   const s = useWizard();
   const context = s.buildContext();
   const goToStep = (step: Step) => s.set({ step });
@@ -1421,6 +1445,17 @@ function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
                 </div>
               </button>
               <button type="button" onClick={() => goToStep("PARAMETERS")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
+                <span className="font-medium">Retrieval limit</span>
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+                    {s.maxResults} per source
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    {context.parameters.sources.length || 0} source{context.parameters.sources.length === 1 ? "" : "s"} selected
+                  </span>
+                </div>
+              </button>
+              <button type="button" onClick={() => goToStep("PARAMETERS")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
                 <span className="font-medium">Time window</span>
                 <div className="mt-2 flex flex-wrap gap-2">
                   <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
@@ -1448,36 +1483,6 @@ function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
                   )}
                 </div>
               </button>
-            </div>
-          </div>
-
-          <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-4">
-            <div className="text-xs uppercase tracking-wide text-blue-700 mb-1">Retrieval limit</div>
-            <p className="text-sm text-gray-700 mb-3">
-              Maximum number of results retrieved from each selected source.
-            </p>
-            <div className="flex flex-wrap items-center gap-3">
-              <span className="font-medium">Max results per source:</span>
-              <div className="inline-flex items-center gap-2">
-                <button
-                  type="button"
-                  className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                  onClick={() => s.set({ maxResults: Math.max(5, s.maxResults - 5) })}
-                  disabled={isRunning}
-                  aria-label="Decrease results"
-                >–</button>
-                <span className="min-w-[2ch] text-center font-semibold">{s.maxResults}</span>
-                <button
-                  type="button"
-                  className="px-2 py-1 rounded-lg ring-1 ring-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                  onClick={() => s.set({ maxResults: Math.min(200, s.maxResults + 5) })}
-                  disabled={isRunning}
-                  aria-label="Increase results"
-                >+</button>
-              </div>
-              <span className="text-xs text-gray-500">
-                {context.parameters.sources.length || 0} source{context.parameters.sources.length === 1 ? "" : "s"} selected
-              </span>
             </div>
           </div>
         </CardContent>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -264,8 +264,15 @@ export const useWizard = create<WizardState>((set, get) => ({
 }));
 
 // ---------------- HELPERS ----------------
-function ProgressBar({ step }: { step: Step }) {
-  // Skip ADDITIONAL_QUESTIONS in progress calculation
+function ProgressBar({
+  step,
+  researchQuestion,
+  onStepClick,
+}: {
+  step: Step;
+  researchQuestion: string;
+  onStepClick: (s: Step) => void;
+}) {
   const steps: { id: Step; label: string }[] = [
     { id: "ASK", label: "Question" },
     { id: "POPULATION", label: "Population" },
@@ -276,15 +283,28 @@ function ProgressBar({ step }: { step: Step }) {
     { id: "SUMMARY", label: "Summary" },
   ];
   const currentIdx = steps.findIndex((s) => s.id === step);
+  const canJump = !!researchQuestion.trim();
+
   return (
     <div className="w-full border-b border-gray-100 bg-white px-4 py-3">
       <div className="mx-auto flex max-w-5xl items-center justify-between gap-2">
         {steps.map((item, idx) => {
           const isCompleted = idx < currentIdx;
           const isCurrent = idx === currentIdx;
+          const isClickable = canJump;
           return (
             <React.Fragment key={item.id}>
-              <div className="min-w-0 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => isClickable && onStepClick(item.id)}
+                disabled={!isClickable}
+                className={cx(
+                  "min-w-0 flex items-center gap-2 text-left transition",
+                  isClickable
+                    ? "cursor-pointer hover:opacity-80"
+                    : "cursor-default"
+                )}
+              >
                 <div
                   className={cx(
                     "flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold ring-1",
@@ -303,7 +323,7 @@ function ProgressBar({ step }: { step: Step }) {
                 >
                   {item.label}
                 </span>
-              </div>
+              </button>
               {idx < steps.length - 1 && (
                 <div
                   className={cx(
@@ -1600,7 +1620,11 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
 
   return (
     <div className="min-h-screen bg-white text-gray-900">
-      <ProgressBar step={s.step} />
+      <ProgressBar
+        step={s.step}
+        researchQuestion={s.researchQuestion}
+        onStepClick={(step) => s.set({ step })}
+      />
       {s.step === "ASK" && <ScreenAsk />}
       {s.step === "POPULATION" && <ScreenPopulation />}
       {s.step === "INNER_SETTING" && <ScreenInnerSetting />}

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -501,7 +501,7 @@ function ScreenPopulation() {
   const customOptions = s.population.selected.filter(pop => !exampleOptions.includes(pop));
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-8">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you targeting a particular population?</h2>
         <p className="text-gray-600 text-lg">We use this to prioritise evidence for the populations you care about.</p>
@@ -1560,7 +1560,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
       </div>
 
       {showActionBar && (
-        <div className="mt-auto max-w-4xl mx-auto w-full px-8">
+        <div className={cx("mt-auto max-w-4xl mx-auto w-full px-8", isSummaryStep && "mb-4")}>
           <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
             <div className="flex items-center gap-2">
               <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -104,15 +104,9 @@ const GEO_LABELS: Record<string, string> = {
 // Search context type - stores all the structured data
 export type SearchContext = {
   researchQuestion: string;
-  population: {
-    selected: string[]; // Selected population options (examples + custom)
-    keepBroad: boolean; // "Keep it broad" option
-  };
+  population: string[];
   innerSetting: string[];
-  outcome: {
-    selected: string[]; // Selected outcome options (examples + custom)
-    keepBroad: boolean; // "Keep it broad" option
-  };
+  outcome: string[];
   implementationConstraints: {
     cost: string;
     staffing: string;
@@ -135,9 +129,9 @@ export type SearchContext = {
 interface WizardState {
   step: Step;
   researchQuestion: string;
-  population: { selected: string[]; keepBroad: boolean };
+  population: { selected: string[]; noPreference: boolean };
   innerSetting: { selected: string[]; noPreference: boolean };
-  outcome: { selected: string[]; keepBroad: boolean };
+  outcome: { selected: string[]; noPreference: boolean };
   implementationConstraints: {
     cost: string;
     staffing: string;
@@ -169,9 +163,9 @@ interface WizardState {
 export const useWizard = create<WizardState>((set, get) => ({
   step: "ASK",
   researchQuestion: "",
-  population: { selected: ["Anyone"], keepBroad: false },
+  population: { selected: [], noPreference: true },
   innerSetting: { selected: [], noPreference: true },
-  outcome: { selected: ["I don't have a particular outcome in mind"], keepBroad: false },
+  outcome: { selected: [], noPreference: true },
   implementationConstraints: {
     cost: "Any",
     staffing: "Any",
@@ -198,9 +192,9 @@ export const useWizard = create<WizardState>((set, get) => ({
     set({
       step: "ASK",
       researchQuestion: "",
-      population: { selected: ["Anyone"], keepBroad: false },
+      population: { selected: [], noPreference: true },
       innerSetting: { selected: [], noPreference: true },
-      outcome: { selected: ["I don't have a particular outcome in mind"], keepBroad: false },
+      outcome: { selected: [], noPreference: true },
       implementationConstraints: {
         cost: "Any",
         staffing: "Any",
@@ -257,9 +251,9 @@ export const useWizard = create<WizardState>((set, get) => ({
     const s = get();
     return {
       researchQuestion: s.researchQuestion,
-      population: s.population,
+      population: s.population.noPreference ? [] : s.population.selected,
       innerSetting: s.innerSetting.noPreference ? [] : s.innerSetting.selected,
-      outcome: s.outcome,
+      outcome: s.outcome.noPreference ? [] : s.outcome.selected,
       implementationConstraints: s.implementationConstraints,
       parameters: s.parameters,
       screeningFactors: s.screeningFactors,
@@ -293,18 +287,18 @@ function generateImpliedResearchQuestion(context: SearchContext): string {
   }
   
   // Add population context
-  if (context.population.selected.length > 0) {
-    const popText = context.population.selected.length === 1 
-      ? context.population.selected[0]
-      : context.population.selected.join(", ");
+  if (context.population.length > 0) {
+    const popText = context.population.length === 1 
+      ? context.population[0]
+      : context.population.join(", ");
     parts.push(`for ${popText}`);
   }
   
   // Add outcome context
-  if (context.outcome.selected.length > 0) {
-    const outcomeText = context.outcome.selected.length === 1
-      ? context.outcome.selected[0]
-      : context.outcome.selected.join(", ");
+  if (context.outcome.length > 0) {
+    const outcomeText = context.outcome.length === 1
+      ? context.outcome[0]
+      : context.outcome.join(", ");
     parts.push(`could achieve ${outcomeText}`);
   }
   
@@ -399,61 +393,42 @@ function ScreenAsk() {
 function ScreenPopulation() {
   const s = useWizard();
   const [customInput, setCustomInput] = useState("");
-  const ANYONE_OPTION = "Anyone";
 
   const togglePopulation = (pop: string) => {
     const current = s.population.selected;
-    // "Anyone" behaves as a mutually exclusive option.
-    if (pop === ANYONE_OPTION) {
-      if (current.includes(ANYONE_OPTION)) {
-        s.set({ population: { ...s.population, selected: [] } });
-      } else {
-        s.set({ population: { ...s.population, selected: [ANYONE_OPTION] } });
-      }
+    if (s.population.noPreference) {
+      s.set({ population: { selected: [pop], noPreference: false } });
       return;
     }
-
     if (current.includes(pop)) {
       const next = current.filter(p => p !== pop);
-      s.set({
-        population: {
-          ...s.population,
-          selected: next.length > 0 ? next : [ANYONE_OPTION],
-        },
-      });
+      s.set({ population: { selected: next, noPreference: next.length === 0 } });
     } else {
-      const withoutAnyone = current.filter(p => p !== ANYONE_OPTION);
-      s.set({ population: { ...s.population, selected: [...withoutAnyone, pop] } });
+      s.set({ population: { selected: [...current, pop], noPreference: false } });
     }
+  };
+
+  const selectNoPreference = () => {
+    s.set({ population: { selected: [], noPreference: true } });
   };
 
   const addCustom = () => {
     const trimmed = customInput.trim();
-    // Use generated options or fallback to defaults
-    const exampleOptions = s.generatedPopulationOptions.length > 0
-      ? [ANYONE_OPTION, ...s.generatedPopulationOptions] as string[]
-      : [ANYONE_OPTION, ...FALLBACK_POPULATION_EXAMPLES] as string[];
-    if (trimmed && !s.population.selected.includes(trimmed) && !exampleOptions.includes(trimmed)) {
-      const withoutAnyone = s.population.selected.filter((p) => p !== ANYONE_OPTION);
-      s.set({ population: { ...s.population, selected: [...withoutAnyone, trimmed] } });
-      setCustomInput("");
+    if (!trimmed) return;
+    if (!s.population.selected.includes(trimmed)) {
+      s.set({ population: { selected: [...s.population.selected, trimmed], noPreference: false } });
     }
+    setCustomInput("");
   };
 
   const removePopulation = (pop: string) => {
     const next = s.population.selected.filter(p => p !== pop);
-    s.set({
-      population: {
-        ...s.population,
-        selected: next.length > 0 ? next : [ANYONE_OPTION],
-      },
-    });
+    s.set({ population: { selected: next, noPreference: next.length === 0 } });
   };
 
-  // Use generated options or fallback to defaults
   const exampleOptions = s.generatedPopulationOptions.length > 0
-    ? [ANYONE_OPTION, ...s.generatedPopulationOptions] as string[]
-    : [ANYONE_OPTION, ...FALLBACK_POPULATION_EXAMPLES] as string[];
+    ? s.generatedPopulationOptions
+    : [...FALLBACK_POPULATION_EXAMPLES];
   const customOptions = s.population.selected.filter(pop => !exampleOptions.includes(pop));
 
   return (
@@ -464,26 +439,19 @@ function ScreenPopulation() {
       </div>
 
       <div className="space-y-6 max-w-2xl mx-auto">
-        {/* Options in single column */}
         <div className="flex flex-col gap-3">
-          {exampleOptions.slice(0, 1).map((pop) => {
-            const isSelected = s.population.selected.includes(pop);
-            return (
-              <button
-                key={pop}
-                type="button"
-                onClick={() => togglePopulation(pop)}
-                className={cx(
-                  "w-full text-left px-4 py-4 rounded-xl transition ring-1 whitespace-normal break-words",
-                  isSelected
-                    ? "bg-blue-600 !text-white ring-blue-600"
-                    : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
-                )}
-              >
-                {pop}
-              </button>
-            );
-          })}
+          <button
+            type="button"
+            onClick={selectNoPreference}
+            className={cx(
+              "w-full text-left px-4 py-4 rounded-xl transition ring-1 whitespace-normal break-words",
+              s.population.noPreference
+                ? "bg-blue-600 !text-white ring-blue-600"
+                : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
+            )}
+          >
+            Anyone
+          </button>
 
           <div className="flex items-center gap-3 py-1">
             <div className="h-px flex-1 bg-gray-200" />
@@ -491,7 +459,7 @@ function ScreenPopulation() {
             <div className="h-px flex-1 bg-gray-200" />
           </div>
 
-          {exampleOptions.slice(1).map((pop) => {
+          {exampleOptions.map((pop) => {
             const isSelected = s.population.selected.includes(pop);
             return (
               <button
@@ -711,61 +679,42 @@ function ScreenInnerSetting() {
 function ScreenOutcome() {
   const s = useWizard();
   const [customInput, setCustomInput] = useState("");
-  const NO_OUTCOME_OPTION = "I don't have a particular outcome in mind";
 
   const toggleOutcome = (outcome: string) => {
     const current = s.outcome.selected;
-    // "No particular outcome" behaves as a mutually exclusive option.
-    if (outcome === NO_OUTCOME_OPTION) {
-      if (current.includes(NO_OUTCOME_OPTION)) {
-        s.set({ outcome: { ...s.outcome, selected: [] } });
-      } else {
-        s.set({ outcome: { ...s.outcome, selected: [NO_OUTCOME_OPTION] } });
-      }
+    if (s.outcome.noPreference) {
+      s.set({ outcome: { selected: [outcome], noPreference: false } });
       return;
     }
-
     if (current.includes(outcome)) {
       const next = current.filter(o => o !== outcome);
-      s.set({
-        outcome: {
-          ...s.outcome,
-          selected: next.length > 0 ? next : [NO_OUTCOME_OPTION],
-        },
-      });
+      s.set({ outcome: { selected: next, noPreference: next.length === 0 } });
     } else {
-      const withoutNoOutcome = current.filter(o => o !== NO_OUTCOME_OPTION);
-      s.set({ outcome: { ...s.outcome, selected: [...withoutNoOutcome, outcome] } });
+      s.set({ outcome: { selected: [...current, outcome], noPreference: false } });
     }
+  };
+
+  const selectNoPreference = () => {
+    s.set({ outcome: { selected: [], noPreference: true } });
   };
 
   const addCustom = () => {
     const trimmed = customInput.trim();
-    // Use generated options or fallback to defaults
-    const exampleOptions = s.generatedOutcomeOptions.length > 0
-      ? [NO_OUTCOME_OPTION, ...s.generatedOutcomeOptions] as string[]
-      : [NO_OUTCOME_OPTION, ...FALLBACK_OUTCOME_EXAMPLES] as string[];
-    if (trimmed && !s.outcome.selected.includes(trimmed) && !exampleOptions.includes(trimmed)) {
-      const withoutNoOutcome = s.outcome.selected.filter(o => o !== NO_OUTCOME_OPTION);
-      s.set({ outcome: { ...s.outcome, selected: [...withoutNoOutcome, trimmed] } });
-      setCustomInput("");
+    if (!trimmed) return;
+    if (!s.outcome.selected.includes(trimmed)) {
+      s.set({ outcome: { selected: [...s.outcome.selected, trimmed], noPreference: false } });
     }
+    setCustomInput("");
   };
 
   const removeOutcome = (outcome: string) => {
     const next = s.outcome.selected.filter(o => o !== outcome);
-    s.set({
-      outcome: {
-        ...s.outcome,
-        selected: next.length > 0 ? next : [NO_OUTCOME_OPTION],
-      },
-    });
+    s.set({ outcome: { selected: next, noPreference: next.length === 0 } });
   };
 
-  // Use generated options or fallback to defaults
   const exampleOptions = s.generatedOutcomeOptions.length > 0
-    ? [NO_OUTCOME_OPTION, ...s.generatedOutcomeOptions] as string[]
-    : [NO_OUTCOME_OPTION, ...FALLBACK_OUTCOME_EXAMPLES] as string[];
+    ? s.generatedOutcomeOptions
+    : [...FALLBACK_OUTCOME_EXAMPLES];
   const customOptions = s.outcome.selected.filter(outcome => !exampleOptions.includes(outcome));
 
   return (
@@ -776,26 +725,19 @@ function ScreenOutcome() {
       </div>
 
       <div className="space-y-6 max-w-2xl mx-auto">
-        {/* Options in single column */}
         <div className="flex flex-col gap-3">
-          {exampleOptions.slice(0, 1).map((outcome) => {
-            const isSelected = s.outcome.selected.includes(outcome);
-            return (
-              <button
-                key={outcome}
-                type="button"
-                onClick={() => toggleOutcome(outcome)}
-                className={cx(
-                  "w-full text-left px-4 py-4 rounded-xl transition ring-1 whitespace-normal break-words",
-                  isSelected
-                    ? "bg-blue-600 !text-white ring-blue-600"
-                    : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
-                )}
-              >
-                {outcome}
-              </button>
-            );
-          })}
+          <button
+            type="button"
+            onClick={selectNoPreference}
+            className={cx(
+              "w-full text-left px-4 py-4 rounded-xl transition ring-1 whitespace-normal break-words",
+              s.outcome.noPreference
+                ? "bg-blue-600 !text-white ring-blue-600"
+                : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
+            )}
+          >
+            I don&apos;t have a particular outcome in mind
+          </button>
 
           <div className="flex items-center gap-3 py-1">
             <div className="h-px flex-1 bg-gray-200" />
@@ -803,7 +745,7 @@ function ScreenOutcome() {
             <div className="h-px flex-1 bg-gray-200" />
           </div>
 
-          {exampleOptions.slice(1).map((outcome) => {
+          {exampleOptions.map((outcome) => {
             const isSelected = s.outcome.selected.includes(outcome);
             return (
               <button
@@ -1370,10 +1312,10 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
               className="rounded-xl border border-gray-200 bg-gray-50/50 p-4 text-left transition hover:bg-gray-50"
             >
               <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Population</div>
-              {context.population.selected.length > 0 ? (
-                <p className="text-gray-900">{context.population.selected.join(", ")}</p>
+              {context.population.length > 0 ? (
+                <p className="text-gray-900">{context.population.join(", ")}</p>
               ) : (
-                <p className="text-gray-500">Not specified</p>
+                <p className="text-gray-500">Anyone</p>
               )}
             </button>
             <button
@@ -1394,10 +1336,10 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
               className="rounded-xl border border-gray-200 bg-gray-50/50 p-4 text-left transition hover:bg-gray-50"
             >
               <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Outcome</div>
-              {context.outcome.selected.length > 0 ? (
-                <p className="text-gray-900">{context.outcome.selected.join(", ")}</p>
+              {context.outcome.length > 0 ? (
+                <p className="text-gray-900">{context.outcome.join(", ")}</p>
               ) : (
-                <p className="text-gray-500">Not specified</p>
+                <p className="text-gray-500">No preference</p>
               )}
             </button>
           </div>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -929,7 +929,7 @@ function ScreenParameters() {
           <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-3">
             <div className="text-xs uppercase tracking-wide text-gray-500 mb-2">Retrieval limit</div>
             <div className="flex flex-wrap items-center gap-3">
-              <span className="font-medium">Max results screened per source:</span>
+              <span className="font-medium">Max results to screen per source:</span>
               <div className="inline-flex items-center gap-2">
                 <button
                   type="button"

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -1619,7 +1619,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
   const s = useWizard();
 
   return (
-    <div className="min-h-screen bg-white text-gray-900">
+    <div className="bg-white text-gray-900">
       <ProgressBar
         step={s.step}
         researchQuestion={s.researchQuestion}

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -1331,6 +1331,7 @@ function ScreenAdditionalQuestions() {
 function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (context: SearchContext) => void; isRunning?: boolean }) {
   const s = useWizard();
   const context = s.buildContext();
+  const goToStep = (step: Step) => s.set({ step });
   const impliedQuestion = generateImpliedResearchQuestion(context);
   const hasImplementationConstraints = [
     context.implementationConstraints.cost,
@@ -1363,36 +1364,48 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="grid gap-4">
-            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-4">
+            <button
+              type="button"
+              onClick={() => goToStep("POPULATION")}
+              className="rounded-xl border border-gray-200 bg-gray-50/50 p-4 text-left transition hover:bg-gray-50"
+            >
               <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Population</div>
               {context.population.selected.length > 0 ? (
                 <p className="text-gray-900">{context.population.selected.join(", ")}</p>
               ) : (
                 <p className="text-gray-500">Not specified</p>
               )}
-            </div>
-            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-4">
+            </button>
+            <button
+              type="button"
+              onClick={() => goToStep("INNER_SETTING")}
+              className="rounded-xl border border-gray-200 bg-gray-50/50 p-4 text-left transition hover:bg-gray-50"
+            >
               <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Setting</div>
               {context.innerSetting.length > 0 ? (
                 <p className="text-gray-900">{context.innerSetting.join(", ")}</p>
               ) : (
                 <p className="text-gray-500">No preference</p>
               )}
-            </div>
-            <div className="rounded-xl border border-gray-200 bg-gray-50/50 p-4">
+            </button>
+            <button
+              type="button"
+              onClick={() => goToStep("OUTCOME")}
+              className="rounded-xl border border-gray-200 bg-gray-50/50 p-4 text-left transition hover:bg-gray-50"
+            >
               <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Outcome</div>
               {context.outcome.selected.length > 0 ? (
                 <p className="text-gray-900">{context.outcome.selected.join(", ")}</p>
               ) : (
                 <p className="text-gray-500">Not specified</p>
               )}
-            </div>
+            </button>
           </div>
 
           <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-4">
             <div className="text-xs uppercase tracking-wide text-gray-500">Filters</div>
             <div className="space-y-3">
-              <div>
+              <button type="button" onClick={() => goToStep("PARAMETERS")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
                 <span className="font-medium">Search sources</span>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {context.parameters.sources.length > 0 ? (
@@ -1405,8 +1418,8 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
                     <span className="text-gray-500">Not specified</span>
                   )}
                 </div>
-              </div>
-              <div>
+              </button>
+              <button type="button" onClick={() => goToStep("PARAMETERS")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
                 <span className="font-medium">Time window</span>
                 <div className="mt-2 flex flex-wrap gap-2">
                   <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
@@ -1419,8 +1432,8 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
                     </span>
                   )}
                 </div>
-              </div>
-              <div>
+              </button>
+              <button type="button" onClick={() => goToStep("PARAMETERS")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
                 <span className="font-medium">Geography</span>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {context.parameters.geography.length > 0 ? (
@@ -1433,13 +1446,13 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
                     <span className="text-gray-500">Not specified</span>
                   )}
                 </div>
-              </div>
+              </button>
             </div>
           </div>
 
           <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
             <div className="text-xs uppercase tracking-wide text-gray-500">Prioritisation</div>
-            <div>
+            <button type="button" onClick={() => goToStep("PARAMETERS")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
               <span className="font-medium">Implementation constraints</span>
               {hasImplementationConstraints ? (
                 <div className="mt-2 flex flex-wrap gap-2">
@@ -1456,8 +1469,8 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
               ) : (
                 <div className="mt-2 text-gray-500">Not specified</div>
               )}
-            </div>
-            <div>
+            </button>
+            <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
               <span className="font-medium">Screening factors</span>
               {context.screeningFactors.length > 0 ? (
                 <div className="mt-2 flex flex-wrap gap-2">
@@ -1470,7 +1483,7 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
               ) : (
                 <div className="mt-2 text-gray-500">None added</div>
               )}
-            </div>
+            </button>
           </div>
 
             <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-4">

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -519,7 +519,7 @@ function ScreenPopulation() {
                 : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
             )}
           >
-            Anyone
+            No preference
           </button>
 
           <div className="flex items-center gap-3 py-1">
@@ -580,13 +580,6 @@ function ScreenPopulation() {
         </div>
       </div>
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
-        </div>
-        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
-      </div>
     </div>
   );
 }
@@ -655,7 +648,7 @@ function ScreenInnerSetting() {
   );
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-6">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular settings?</h2>
         <p className="text-gray-600 text-lg">We use this to prioritise context-matched evidence and assess transferability.</p>
@@ -734,13 +727,6 @@ function ScreenInnerSetting() {
         </div>
       </div>
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
-        </div>
-        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
-      </div>
     </div>
   );
 }
@@ -805,7 +791,7 @@ function ScreenOutcome() {
                 : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
             )}
           >
-            I don&apos;t have a particular outcome in mind
+            No preference
           </button>
 
           <div className="flex items-center gap-3 py-1">
@@ -866,13 +852,6 @@ function ScreenOutcome() {
         </div>
       </div>
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
-        </div>
-        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
-      </div>
     </div>
   );
 }
@@ -1050,20 +1029,6 @@ function ScreenParameters() {
 
       </div>
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
-        </div>
-        <Button
-          variant="secondary"
-          className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
-          onClick={() => s.next()}
-          disabled={!hasSelectedSource || hasInvalidCustomDateRange}
-        >
-          Next
-        </Button>
-      </div>
     </div>
   );
 }
@@ -1082,41 +1047,6 @@ function ScreenScreening() {
 
   const removeFactor = (factor: string) => {
     s.set({ screeningFactors: s.screeningFactors.filter(f => f !== factor) });
-  };
-
-  const handleNext = async () => {
-    // Skip ADDITIONAL_QUESTIONS step - go directly to SUMMARY
-    // (Keeping generation code commented out for future use)
-    // s.set({ isGeneratingOptions: true });
-    // 
-    // try {
-    //   const response = await generateAdditionalQuestions(
-    //     s.researchQuestion,
-    //     s.population.selected,
-    //     s.outcome.selected
-    //   ).catch(() => ({ additional_questions: [] }));
-    //
-    //   const generatedQuestions = response?.additional_questions || [];
-    //   
-    //   // Preselect generated questions
-    //   s.set({ 
-    //     generatedAdditionalQuestions: generatedQuestions,
-    //     additionalQuestions: generatedQuestions,
-    //     step: "ADDITIONAL_QUESTIONS"
-    //   });
-    // } catch (error) {
-    //   console.error('Failed to generate additional questions:', error);
-    //   // Continue with empty questions if generation fails
-    //   s.set({ 
-    //     generatedAdditionalQuestions: [],
-    //     step: "ADDITIONAL_QUESTIONS" 
-    //   });
-    // } finally {
-    //   s.set({ isGeneratingOptions: false });
-    // }
-    
-    // Go directly to SUMMARY
-    s.set({ step: "SUMMARY" });
   };
 
   return (
@@ -1263,15 +1193,6 @@ function ScreenScreening() {
         </div>
       </div>
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
-        </div>
-        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={handleNext} disabled={s.isGeneratingOptions}>
-          {s.isGeneratingOptions ? "Generating..." : "Next"}
-        </Button>
-      </div>
     </div>
   );
 }
@@ -1368,21 +1289,13 @@ function ScreenAdditionalQuestions() {
         </div>
       </div>
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
-        </div>
-        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
-      </div>
     </div>
   );
 }
 
-function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (context: SearchContext) => void; isRunning?: boolean }) {
+function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
   const s = useWizard();
   const context = s.buildContext();
-  const hasSelectedSource = context.parameters.sources.length > 0;
   const goToStep = (step: Step) => s.set({ step });
   const impliedQuestion = generateImpliedResearchQuestion(context);
   const hasImplementationConstraints = [
@@ -1425,7 +1338,7 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
               {context.population.length > 0 ? (
                 <p className="text-gray-900">{context.population.join(", ")}</p>
               ) : (
-                <p className="text-gray-500">Anyone</p>
+                <p className="text-gray-500">No preference</p>
               )}
             </button>
             <button
@@ -1570,40 +1483,6 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
         </CardContent>
       </Card>
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()} disabled={isRunning}>Start new search</Button>
-        </div>
-        <Button
-          variant="secondary"
-          className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
-          onClick={() => onRunAnalysis(context)}
-          disabled={
-            isRunning ||
-            !hasSelectedSource ||
-            (context.parameters.timePreset === "CUSTOM" &&
-              !!context.parameters.customFrom &&
-              !!context.parameters.customTo &&
-              context.parameters.customFrom > context.parameters.customTo)
-          }
-        >
-          {isRunning ? 'Starting up...' : 'Run Analysis'}
-        </Button>
-      </div>
-      {!hasSelectedSource && (
-        <p className="text-sm text-red-600 text-right">
-          Select at least one search source before running analysis.
-        </p>
-      )}
-      {context.parameters.timePreset === "CUSTOM" &&
-        !!context.parameters.customFrom &&
-        !!context.parameters.customTo &&
-        context.parameters.customFrom > context.parameters.customTo && (
-          <p className="text-sm text-red-600 text-right">
-            Fix your custom date range before running analysis.
-          </p>
-        )}
     </div>
   );
 }
@@ -1617,22 +1496,100 @@ interface SearchWizardProps {
 
 export default function SearchWizard({ onRunAnalysis, isRunning = false }: SearchWizardProps) {
   const s = useWizard();
+  const context = s.buildContext();
+  const hasSelectedSource = context.parameters.sources.length > 0;
+  const hasInvalidCustomDateRange =
+    context.parameters.timePreset === "CUSTOM" &&
+    !!context.parameters.customFrom &&
+    !!context.parameters.customTo &&
+    context.parameters.customFrom > context.parameters.customTo;
+
+  const isSummaryStep = s.step === "SUMMARY";
+  const showActionBar = s.step !== "ASK";
+
+  const getPrimaryAction = () => {
+    if (isSummaryStep) {
+      return {
+        label: isRunning ? "Starting up..." : "Run Analysis",
+        onClick: () => onRunAnalysis(context),
+        disabled: isRunning || !hasSelectedSource || hasInvalidCustomDateRange,
+      };
+    }
+
+    if (s.step === "SCREENING") {
+      return {
+        label: s.isGeneratingOptions ? "Generating..." : "Next",
+        onClick: () => s.set({ step: "SUMMARY" }),
+        disabled: s.isGeneratingOptions,
+      };
+    }
+
+    if (s.step === "PARAMETERS") {
+      return {
+        label: "Next",
+        onClick: () => s.next(),
+        disabled: !hasSelectedSource || hasInvalidCustomDateRange,
+      };
+    }
+
+    return {
+      label: "Next",
+      onClick: () => s.next(),
+      disabled: false,
+    };
+  };
+
+  const primaryAction = getPrimaryAction();
 
   return (
-    <div className="bg-white text-gray-900">
+    <div className="bg-white text-gray-900 min-h-[calc(100vh-8rem)] flex flex-col">
       <ProgressBar
         step={s.step}
         researchQuestion={s.researchQuestion}
         onStepClick={(step) => s.set({ step })}
       />
-      {s.step === "ASK" && <ScreenAsk />}
-      {s.step === "POPULATION" && <ScreenPopulation />}
-      {s.step === "INNER_SETTING" && <ScreenInnerSetting />}
-      {s.step === "OUTCOME" && <ScreenOutcome />}
-      {s.step === "PARAMETERS" && <ScreenParameters />}
-      {s.step === "SCREENING" && <ScreenScreening />}
-      {s.step === "ADDITIONAL_QUESTIONS" && <ScreenAdditionalQuestions />}
-      {s.step === "SUMMARY" && <ScreenSummary onRunAnalysis={onRunAnalysis} isRunning={isRunning} />}
+      <div className="flex-1">
+        {s.step === "ASK" && <ScreenAsk />}
+        {s.step === "POPULATION" && <ScreenPopulation />}
+        {s.step === "INNER_SETTING" && <ScreenInnerSetting />}
+        {s.step === "OUTCOME" && <ScreenOutcome />}
+        {s.step === "PARAMETERS" && <ScreenParameters />}
+        {s.step === "SCREENING" && <ScreenScreening />}
+        {s.step === "ADDITIONAL_QUESTIONS" && <ScreenAdditionalQuestions />}
+        {s.step === "SUMMARY" && <ScreenSummary isRunning={isRunning} />}
+      </div>
+
+      {showActionBar && (
+        <div className="mt-auto max-w-4xl mx-auto w-full px-8">
+          <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+            <div className="flex items-center gap-2">
+              <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
+              <Button variant="secondary" onClick={() => s.reset()} disabled={isRunning}>
+                {isSummaryStep ? "Start new search" : "Restart"}
+              </Button>
+            </div>
+            <Button
+              variant="secondary"
+              className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
+              onClick={primaryAction.onClick}
+              disabled={primaryAction.disabled}
+            >
+              {primaryAction.label}
+            </Button>
+          </div>
+
+          {isSummaryStep && !hasSelectedSource && (
+            <p className="mt-2 text-sm text-red-600 text-right">
+              Select at least one search source before running analysis.
+            </p>
+          )}
+          {isSummaryStep && hasInvalidCustomDateRange && (
+            <p className="mt-2 text-sm text-red-600 text-right">
+              Fix your custom date range before running analysis.
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -501,7 +501,7 @@ function ScreenPopulation() {
   const customOptions = s.population.selected.filter(pop => !exampleOptions.includes(pop));
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-8">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-4">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you targeting a particular population?</h2>
         <p className="text-gray-600 text-lg">We use this to prioritise evidence for the populations you care about.</p>
@@ -773,7 +773,7 @@ function ScreenOutcome() {
   const customOptions = s.outcome.selected.filter(outcome => !exampleOptions.includes(outcome));
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-2">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular outcomes?</h2>
         <p className="text-gray-600 text-lg">We use this to prioritise evidence measuring your outcomes of interest.</p>
@@ -903,7 +903,7 @@ function ScreenParameters() {
   }, [s.parameters.access.academic, s.parameters.access.policy]);
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-16 pb-0">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Sources, time window, and geography</h2>
         <p className="text-gray-600 text-lg">We use these filters to narrow the evidence set before ranking.</p>
@@ -1309,7 +1309,7 @@ function ScreenSummary({ isRunning = false }: { isRunning?: boolean }) {
   const timeWindowLabel = TIME_PRESET_LABELS[context.parameters.timePreset];
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+    <div className="max-w-4xl mx-auto space-y-8 px-8 pt-16 pb-2">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Summary</h2>
       </div>
@@ -1548,7 +1548,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
         researchQuestion={s.researchQuestion}
         onStepClick={(step) => s.set({ step })}
       />
-      <div className="flex-1">
+      <div className={isSummaryStep ? "" : "flex-1"}>
         {s.step === "ASK" && <ScreenAsk />}
         {s.step === "POPULATION" && <ScreenPopulation />}
         {s.step === "INNER_SETTING" && <ScreenInnerSetting />}
@@ -1560,7 +1560,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
       </div>
 
       {showActionBar && (
-        <div className={cx("mt-auto max-w-4xl mx-auto w-full px-8", isSummaryStep && "mb-4")}>
+        <div className={cx("max-w-4xl mx-auto w-full px-8", isSummaryStep ? "mt-3 mb-4" : "mt-auto")}>
           <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
             <div className="flex items-center gap-2">
               <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -380,8 +380,10 @@ function ScreenAsk() {
           value={s.researchQuestion} 
           onChange={(e) => s.set({ researchQuestion: e.target.value })} 
         />
-        <div className="flex justify-end">
+        <div className="flex justify-end items-center">
           <Button 
+            variant="secondary"
+            className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
             full 
             disabled={!s.researchQuestion.trim() || s.isGeneratingOptions} 
             onClick={handleNext}
@@ -412,7 +414,13 @@ function ScreenPopulation() {
     }
 
     if (current.includes(pop)) {
-      s.set({ population: { ...s.population, selected: current.filter(p => p !== pop) } });
+      const next = current.filter(p => p !== pop);
+      s.set({
+        population: {
+          ...s.population,
+          selected: next.length > 0 ? next : [ANYONE_OPTION],
+        },
+      });
     } else {
       const withoutAnyone = current.filter(p => p !== ANYONE_OPTION);
       s.set({ population: { ...s.population, selected: [...withoutAnyone, pop] } });
@@ -433,7 +441,13 @@ function ScreenPopulation() {
   };
 
   const removePopulation = (pop: string) => {
-    s.set({ population: { ...s.population, selected: s.population.selected.filter(p => p !== pop) } });
+    const next = s.population.selected.filter(p => p !== pop);
+    s.set({
+      population: {
+        ...s.population,
+        selected: next.length > 0 ? next : [ANYONE_OPTION],
+      },
+    });
   };
 
   // Use generated options or fallback to defaults
@@ -452,7 +466,32 @@ function ScreenPopulation() {
       <div className="space-y-6 max-w-2xl mx-auto">
         {/* Options in single column */}
         <div className="flex flex-col gap-3">
-          {exampleOptions.map((pop) => {
+          {exampleOptions.slice(0, 1).map((pop) => {
+            const isSelected = s.population.selected.includes(pop);
+            return (
+              <button
+                key={pop}
+                type="button"
+                onClick={() => togglePopulation(pop)}
+                className={cx(
+                  "w-full text-left px-4 py-4 rounded-xl transition ring-1 whitespace-normal break-words",
+                  isSelected
+                    ? "bg-blue-600 !text-white ring-blue-600"
+                    : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
+                )}
+              >
+                {pop}
+              </button>
+            );
+          })}
+
+          <div className="flex items-center gap-3 py-1">
+            <div className="h-px flex-1 bg-gray-200" />
+            <span className="text-xs text-gray-500 uppercase tracking-wide">Or select specific populations</span>
+            <div className="h-px flex-1 bg-gray-200" />
+          </div>
+
+          {exampleOptions.slice(1).map((pop) => {
             const isSelected = s.population.selected.includes(pop);
             return (
               <button
@@ -505,8 +544,11 @@ function ScreenPopulation() {
       </div>
 
       <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        </div>
+        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
       </div>
     </div>
   );
@@ -597,6 +639,12 @@ function ScreenInnerSetting() {
             No preference
           </button>
 
+          <div className="flex items-center gap-3 py-1">
+            <div className="h-px flex-1 bg-gray-200" />
+            <span className="text-xs text-gray-500 uppercase tracking-wide">Or select specific settings</span>
+            <div className="h-px flex-1 bg-gray-200" />
+          </div>
+
           {exampleOptions.map((setting) => {
             const isSelected = s.innerSetting.selected.includes(setting);
             return (
@@ -650,8 +698,11 @@ function ScreenInnerSetting() {
       </div>
 
       <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        </div>
+        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
       </div>
     </div>
   );
@@ -675,7 +726,13 @@ function ScreenOutcome() {
     }
 
     if (current.includes(outcome)) {
-      s.set({ outcome: { ...s.outcome, selected: current.filter(o => o !== outcome) } });
+      const next = current.filter(o => o !== outcome);
+      s.set({
+        outcome: {
+          ...s.outcome,
+          selected: next.length > 0 ? next : [NO_OUTCOME_OPTION],
+        },
+      });
     } else {
       const withoutNoOutcome = current.filter(o => o !== NO_OUTCOME_OPTION);
       s.set({ outcome: { ...s.outcome, selected: [...withoutNoOutcome, outcome] } });
@@ -696,7 +753,13 @@ function ScreenOutcome() {
   };
 
   const removeOutcome = (outcome: string) => {
-    s.set({ outcome: { ...s.outcome, selected: s.outcome.selected.filter(o => o !== outcome) } });
+    const next = s.outcome.selected.filter(o => o !== outcome);
+    s.set({
+      outcome: {
+        ...s.outcome,
+        selected: next.length > 0 ? next : [NO_OUTCOME_OPTION],
+      },
+    });
   };
 
   // Use generated options or fallback to defaults
@@ -715,7 +778,32 @@ function ScreenOutcome() {
       <div className="space-y-6 max-w-2xl mx-auto">
         {/* Options in single column */}
         <div className="flex flex-col gap-3">
-          {exampleOptions.map((outcome) => {
+          {exampleOptions.slice(0, 1).map((outcome) => {
+            const isSelected = s.outcome.selected.includes(outcome);
+            return (
+              <button
+                key={outcome}
+                type="button"
+                onClick={() => toggleOutcome(outcome)}
+                className={cx(
+                  "w-full text-left px-4 py-4 rounded-xl transition ring-1 whitespace-normal break-words",
+                  isSelected
+                    ? "bg-blue-600 !text-white ring-blue-600"
+                    : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
+                )}
+              >
+                {outcome}
+              </button>
+            );
+          })}
+
+          <div className="flex items-center gap-3 py-1">
+            <div className="h-px flex-1 bg-gray-200" />
+            <span className="text-xs text-gray-500 uppercase tracking-wide">Or select specific outcomes</span>
+            <div className="h-px flex-1 bg-gray-200" />
+          </div>
+
+          {exampleOptions.slice(1).map((outcome) => {
             const isSelected = s.outcome.selected.includes(outcome);
             return (
               <button
@@ -768,8 +856,11 @@ function ScreenOutcome() {
       </div>
 
       <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        </div>
+        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
       </div>
     </div>
   );
@@ -1017,8 +1108,11 @@ function ScreenParameters() {
       </div>
 
       <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        </div>
+        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
       </div>
     </div>
   );
@@ -1119,8 +1213,11 @@ function ScreenScreening() {
       </div>
 
       <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={handleNext} disabled={s.isGeneratingOptions}>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        </div>
+        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={handleNext} disabled={s.isGeneratingOptions}>
           {s.isGeneratingOptions ? "Generating..." : "Next"}
         </Button>
       </div>
@@ -1221,8 +1318,11 @@ function ScreenAdditionalQuestions() {
       </div>
 
       <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => s.next()}>Next</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        </div>
+        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
       </div>
     </div>
   );
@@ -1410,7 +1510,7 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
           <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
           <Button variant="secondary" onClick={() => s.reset()} disabled={isRunning}>Start new search</Button>
         </div>
-        <Button className="bg-blue-600 !text-white hover:bg-blue-700" onClick={() => onRunAnalysis(context)} disabled={isRunning}>
+        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => onRunAnalysis(context)} disabled={isRunning}>
           {isRunning ? 'Starting up...' : 'Run Analysis'}
         </Button>
       </div>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -930,7 +930,7 @@ function ScreenParameters() {
         <p className="text-gray-600 text-lg">We use these filters to narrow the evidence set before ranking.</p>
       </div>
 
-      <div className="space-y-8">
+      <div className="space-y-8 max-w-2xl mx-auto">
         {/* Sources */}
         <div className="space-y-4">
           <h3 className="font-semibold text-lg">Which sources should we use?</h3>
@@ -964,7 +964,7 @@ function ScreenParameters() {
             ))}
           </div>
           {s.parameters.timePreset === "CUSTOM" && (
-            <div className="max-w-3xl rounded-2xl border border-blue-100 bg-blue-50/40 p-4 space-y-3">
+            <div className="rounded-2xl border border-blue-100 bg-blue-50/40 p-4 space-y-3">
               <p className="text-sm text-gray-600">Select a start and end date for your custom range.</p>
               <div className="grid gap-3 sm:grid-cols-2">
                 <div className="flex-1">
@@ -994,7 +994,7 @@ function ScreenParameters() {
         </div>
 
         {/* Geography */}
-        <div className="space-y-4 max-w-2xl">
+        <div className="space-y-4">
           <h3 className="font-semibold text-lg">In which countries should we look for evidence?</h3>
           <div>
             {/* Selected options */}
@@ -1132,7 +1132,7 @@ function ScreenScreening() {
         <div className="space-y-4">
           <h3 className="font-semibold text-lg">Implementation constraints</h3>
           <div className="flex items-center gap-2 text-sm text-gray-600">
-            <span>Used during impact and transferability assessment.</span>
+            <span>Optionally set your tolerance on implementation factors. Used during impact and transferability assessment.</span>
             <Tooltip
               content={
                 <div className="max-w-xs text-sm space-y-1">
@@ -1221,9 +1221,9 @@ function ScreenScreening() {
         <div className="h-px bg-gray-100" />
 
         <div className="space-y-3">
-          <h3 className="font-semibold text-lg">Screening factors</h3>
+          <h3 className="font-semibold text-lg">Additional screening factors</h3>
           <p className="text-sm text-gray-600">
-            Used during screening to prioritise and rank the most relevant evidence.
+            Add any other criteria that you think are important to consider when screening the evidence.
           </p>
         </div>
 

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -266,12 +266,56 @@ export const useWizard = create<WizardState>((set, get) => ({
 // ---------------- HELPERS ----------------
 function ProgressBar({ step }: { step: Step }) {
   // Skip ADDITIONAL_QUESTIONS in progress calculation
-  const steps: Step[] = ["ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "PARAMETERS", "SCREENING", "SUMMARY"];
-  const currentIdx = steps.indexOf(step);
-  const pct = Math.round(((currentIdx + 1) / steps.length) * 100);
+  const steps: { id: Step; label: string }[] = [
+    { id: "ASK", label: "Question" },
+    { id: "POPULATION", label: "Population" },
+    { id: "INNER_SETTING", label: "Setting" },
+    { id: "OUTCOME", label: "Outcome" },
+    { id: "PARAMETERS", label: "Parameters" },
+    { id: "SCREENING", label: "Screening" },
+    { id: "SUMMARY", label: "Summary" },
+  ];
+  const currentIdx = steps.findIndex((s) => s.id === step);
   return (
-    <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden">
-      <div className="h-full bg-blue-600 transition-all" style={{ width: `${pct}%` }} />
+    <div className="w-full border-b border-gray-100 bg-white px-4 py-3">
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-2">
+        {steps.map((item, idx) => {
+          const isCompleted = idx < currentIdx;
+          const isCurrent = idx === currentIdx;
+          return (
+            <React.Fragment key={item.id}>
+              <div className="min-w-0 flex items-center gap-2">
+                <div
+                  className={cx(
+                    "flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold ring-1",
+                    isCompleted || isCurrent
+                      ? "bg-blue-600 !text-white ring-blue-600"
+                      : "bg-white text-gray-500 ring-gray-300"
+                  )}
+                >
+                  {idx + 1}
+                </div>
+                <span
+                  className={cx(
+                    "hidden text-xs sm:inline",
+                    isCurrent ? "font-semibold text-gray-900" : "text-gray-500"
+                  )}
+                >
+                  {item.label}
+                </span>
+              </div>
+              {idx < steps.length - 1 && (
+                <div
+                  className={cx(
+                    "h-px flex-1",
+                    idx < currentIdx ? "bg-blue-600" : "bg-gray-200"
+                  )}
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -382,7 +426,12 @@ function ScreenAsk() {
             disabled={!s.researchQuestion.trim() || s.isGeneratingOptions} 
             onClick={handleNext}
           >
-            {s.isGeneratingOptions ? 'Generating options...' : 'Continue'}
+            {s.isGeneratingOptions ? (
+              <span className="inline-flex items-center gap-2">
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-black/30 border-t-black" />
+                Generating options...
+              </span>
+            ) : 'Continue'}
           </Button>
         </div>
       </div>
@@ -812,6 +861,8 @@ function ScreenParameters() {
   const s = useWizard();
   const [selectedCountry, setSelectedCountry] = useState("");
   const constraintOptions = ["Any", "Low", "Moderate", "High"];
+  const hasSelectedSource =
+    s.parameters.access.academic || s.parameters.access.policy;
 
   const toggleAccess = (k: keyof Access) => {
     s.set({ parameters: { ...s.parameters, access: { ...s.parameters.access, [k]: !s.parameters.access[k] } } });
@@ -830,7 +881,13 @@ function ScreenParameters() {
   };
 
   const removeGeo = (g: string) => {
-    s.set({ parameters: { ...s.parameters, geography: s.parameters.geography.filter(x => x !== g) } });
+    const next = s.parameters.geography.filter(x => x !== g);
+    s.set({
+      parameters: {
+        ...s.parameters,
+        geography: next.length > 0 ? next : [ANYWHERE_VALUE],
+      },
+    });
   };
 
   // Update sources based on access
@@ -846,7 +903,7 @@ function ScreenParameters() {
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Sources, time window, and geography</h2>
-        <p className="text-gray-600 text-lg">We will use this filter only the most relevant information</p>
+        <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
       </div>
 
       <div className="space-y-8">
@@ -861,6 +918,11 @@ function ScreenParameters() {
               Grey literature (think tanks and governments)
             </Chip>
           </div>
+          {!hasSelectedSource && (
+            <p className="text-sm text-red-600">
+              Select at least one source to continue.
+            </p>
+          )}
         </div>
 
         {/* Time window */}
@@ -1054,7 +1116,14 @@ function ScreenParameters() {
           <Button variant="secondary" onClick={() => s.back()}>Back</Button>
           <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
         </div>
-        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => s.next()}>Next</Button>
+        <Button
+          variant="secondary"
+          className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
+          onClick={() => s.next()}
+          disabled={!hasSelectedSource}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );
@@ -1273,6 +1342,7 @@ function ScreenAdditionalQuestions() {
 function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (context: SearchContext) => void; isRunning?: boolean }) {
   const s = useWizard();
   const context = s.buildContext();
+  const hasSelectedSource = context.parameters.sources.length > 0;
   const goToStep = (step: Step) => s.set({ step });
   const impliedQuestion = generateImpliedResearchQuestion(context);
   const hasImplementationConstraints = [
@@ -1465,10 +1535,20 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
           <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>
           <Button variant="secondary" onClick={() => s.reset()} disabled={isRunning}>Start new search</Button>
         </div>
-        <Button variant="secondary" className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0" onClick={() => onRunAnalysis(context)} disabled={isRunning}>
+        <Button
+          variant="secondary"
+          className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
+          onClick={() => onRunAnalysis(context)}
+          disabled={isRunning || !hasSelectedSource}
+        >
           {isRunning ? 'Starting up...' : 'Run Analysis'}
         </Button>
       </div>
+      {!hasSelectedSource && (
+        <p className="text-sm text-red-600 text-right">
+          Select at least one search source before running analysis.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -169,9 +169,9 @@ interface WizardState {
 export const useWizard = create<WizardState>((set, get) => ({
   step: "ASK",
   researchQuestion: "",
-  population: { selected: [], keepBroad: false },
+  population: { selected: ["Anyone"], keepBroad: false },
   innerSetting: { selected: [], noPreference: true },
-  outcome: { selected: [], keepBroad: false },
+  outcome: { selected: ["I don't have a particular outcome in mind"], keepBroad: false },
   implementationConstraints: {
     cost: "Any",
     staffing: "Any",
@@ -198,9 +198,9 @@ export const useWizard = create<WizardState>((set, get) => ({
     set({
       step: "ASK",
       researchQuestion: "",
-      population: { selected: [], keepBroad: false },
+      population: { selected: ["Anyone"], keepBroad: false },
       innerSetting: { selected: [], noPreference: true },
-      outcome: { selected: [], keepBroad: false },
+      outcome: { selected: ["I don't have a particular outcome in mind"], keepBroad: false },
       implementationConstraints: {
         cost: "Any",
         staffing: "Any",
@@ -397,13 +397,25 @@ function ScreenAsk() {
 function ScreenPopulation() {
   const s = useWizard();
   const [customInput, setCustomInput] = useState("");
+  const ANYONE_OPTION = "Anyone";
 
   const togglePopulation = (pop: string) => {
     const current = s.population.selected;
+    // "Anyone" behaves as a mutually exclusive option.
+    if (pop === ANYONE_OPTION) {
+      if (current.includes(ANYONE_OPTION)) {
+        s.set({ population: { ...s.population, selected: [] } });
+      } else {
+        s.set({ population: { ...s.population, selected: [ANYONE_OPTION] } });
+      }
+      return;
+    }
+
     if (current.includes(pop)) {
       s.set({ population: { ...s.population, selected: current.filter(p => p !== pop) } });
     } else {
-      s.set({ population: { ...s.population, selected: [...current, pop] } });
+      const withoutAnyone = current.filter(p => p !== ANYONE_OPTION);
+      s.set({ population: { ...s.population, selected: [...withoutAnyone, pop] } });
     }
   };
 
@@ -411,10 +423,11 @@ function ScreenPopulation() {
     const trimmed = customInput.trim();
     // Use generated options or fallback to defaults
     const exampleOptions = s.generatedPopulationOptions.length > 0
-      ? ["Anyone", ...s.generatedPopulationOptions] as string[]
-      : ["Anyone", ...FALLBACK_POPULATION_EXAMPLES] as string[];
+      ? [ANYONE_OPTION, ...s.generatedPopulationOptions] as string[]
+      : [ANYONE_OPTION, ...FALLBACK_POPULATION_EXAMPLES] as string[];
     if (trimmed && !s.population.selected.includes(trimmed) && !exampleOptions.includes(trimmed)) {
-      s.set({ population: { ...s.population, selected: [...s.population.selected, trimmed] } });
+      const withoutAnyone = s.population.selected.filter((p) => p !== ANYONE_OPTION);
+      s.set({ population: { ...s.population, selected: [...withoutAnyone, trimmed] } });
       setCustomInput("");
     }
   };
@@ -425,8 +438,8 @@ function ScreenPopulation() {
 
   // Use generated options or fallback to defaults
   const exampleOptions = s.generatedPopulationOptions.length > 0
-    ? ["Anyone", ...s.generatedPopulationOptions] as string[]
-    : ["Anyone", ...FALLBACK_POPULATION_EXAMPLES] as string[];
+    ? [ANYONE_OPTION, ...s.generatedPopulationOptions] as string[]
+    : [ANYONE_OPTION, ...FALLBACK_POPULATION_EXAMPLES] as string[];
   const customOptions = s.population.selected.filter(pop => !exampleOptions.includes(pop));
 
   return (
@@ -648,13 +661,25 @@ function ScreenInnerSetting() {
 function ScreenOutcome() {
   const s = useWizard();
   const [customInput, setCustomInput] = useState("");
+  const NO_OUTCOME_OPTION = "I don't have a particular outcome in mind";
 
   const toggleOutcome = (outcome: string) => {
     const current = s.outcome.selected;
+    // "No particular outcome" behaves as a mutually exclusive option.
+    if (outcome === NO_OUTCOME_OPTION) {
+      if (current.includes(NO_OUTCOME_OPTION)) {
+        s.set({ outcome: { ...s.outcome, selected: [] } });
+      } else {
+        s.set({ outcome: { ...s.outcome, selected: [NO_OUTCOME_OPTION] } });
+      }
+      return;
+    }
+
     if (current.includes(outcome)) {
       s.set({ outcome: { ...s.outcome, selected: current.filter(o => o !== outcome) } });
     } else {
-      s.set({ outcome: { ...s.outcome, selected: [...current, outcome] } });
+      const withoutNoOutcome = current.filter(o => o !== NO_OUTCOME_OPTION);
+      s.set({ outcome: { ...s.outcome, selected: [...withoutNoOutcome, outcome] } });
     }
   };
 
@@ -662,10 +687,11 @@ function ScreenOutcome() {
     const trimmed = customInput.trim();
     // Use generated options or fallback to defaults
     const exampleOptions = s.generatedOutcomeOptions.length > 0
-      ? ["I don't have a particular outcome in mind", ...s.generatedOutcomeOptions] as string[]
-      : ["I don't have a particular outcome in mind", ...FALLBACK_OUTCOME_EXAMPLES] as string[];
+      ? [NO_OUTCOME_OPTION, ...s.generatedOutcomeOptions] as string[]
+      : [NO_OUTCOME_OPTION, ...FALLBACK_OUTCOME_EXAMPLES] as string[];
     if (trimmed && !s.outcome.selected.includes(trimmed) && !exampleOptions.includes(trimmed)) {
-      s.set({ outcome: { ...s.outcome, selected: [...s.outcome.selected, trimmed] } });
+      const withoutNoOutcome = s.outcome.selected.filter(o => o !== NO_OUTCOME_OPTION);
+      s.set({ outcome: { ...s.outcome, selected: [...withoutNoOutcome, trimmed] } });
       setCustomInput("");
     }
   };
@@ -676,8 +702,8 @@ function ScreenOutcome() {
 
   // Use generated options or fallback to defaults
   const exampleOptions = s.generatedOutcomeOptions.length > 0
-    ? ["I don't have a particular outcome in mind", ...s.generatedOutcomeOptions] as string[]
-    : ["I don't have a particular outcome in mind", ...FALLBACK_OUTCOME_EXAMPLES] as string[];
+    ? [NO_OUTCOME_OPTION, ...s.generatedOutcomeOptions] as string[]
+    : [NO_OUTCOME_OPTION, ...FALLBACK_OUTCOME_EXAMPLES] as string[];
   const customOptions = s.outcome.selected.filter(outcome => !exampleOptions.includes(outcome));
 
   return (

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -1547,7 +1547,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
   const primaryAction = getPrimaryAction();
 
   return (
-    <div className="bg-white text-gray-900 min-h-[calc(100vh-8rem)] flex flex-col pb-4">
+    <div className="bg-white text-gray-900 flex-1 flex flex-col pb-4">
       <ProgressBar
         step={s.step}
         researchQuestion={s.researchQuestion}
@@ -1565,7 +1565,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
       </div>
 
       {showActionBar && (
-        <div className="max-w-4xl mx-auto w-full px-8 mt-3">
+        <div className="max-w-4xl mx-auto w-full px-8 mt-3 mb-4">
           <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
             <div className="flex items-center gap-2">
               <Button variant="secondary" onClick={() => s.back()} disabled={isRunning}>Back</Button>

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -272,7 +272,7 @@ function ProgressBar({ step }: { step: Step }) {
     { id: "INNER_SETTING", label: "Setting" },
     { id: "OUTCOME", label: "Outcome" },
     { id: "PARAMETERS", label: "Parameters" },
-    { id: "SCREENING", label: "Screening" },
+    { id: "SCREENING", label: "Prioritisation" },
     { id: "SUMMARY", label: "Summary" },
   ];
   const currentIdx = steps.findIndex((s) => s.id === step);
@@ -484,7 +484,7 @@ function ScreenPopulation() {
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you targeting a particular population?</h2>
-        <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
+        <p className="text-gray-600 text-lg">We use this to prioritise evidence for the populations you care about.</p>
       </div>
 
       <div className="space-y-6 max-w-2xl mx-auto">
@@ -638,7 +638,7 @@ function ScreenInnerSetting() {
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular settings?</h2>
-        <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information and assess transferability.</p>
+        <p className="text-gray-600 text-lg">We use this to prioritise context-matched evidence and assess transferability.</p>
       </div>
 
       <div className="space-y-6 max-w-2xl mx-auto">
@@ -770,7 +770,7 @@ function ScreenOutcome() {
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Are you interested in particular outcomes?</h2>
-        <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
+        <p className="text-gray-600 text-lg">We use this to prioritise evidence measuring your outcomes of interest.</p>
       </div>
 
       <div className="space-y-6 max-w-2xl mx-auto">
@@ -860,9 +860,13 @@ function ScreenOutcome() {
 function ScreenParameters() {
   const s = useWizard();
   const [selectedCountry, setSelectedCountry] = useState("");
-  const constraintOptions = ["Any", "Low", "Moderate", "High"];
   const hasSelectedSource =
     s.parameters.access.academic || s.parameters.access.policy;
+  const hasInvalidCustomDateRange =
+    s.parameters.timePreset === "CUSTOM" &&
+    !!s.parameters.customFrom &&
+    !!s.parameters.customTo &&
+    s.parameters.customFrom > s.parameters.customTo;
 
   const toggleAccess = (k: keyof Access) => {
     s.set({ parameters: { ...s.parameters, access: { ...s.parameters.access, [k]: !s.parameters.access[k] } } });
@@ -903,7 +907,7 @@ function ScreenParameters() {
     <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
       <div className="text-center space-y-3">
         <h2 className="text-2xl font-semibold">Sources, time window, and geography</h2>
-        <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
+        <p className="text-gray-600 text-lg">We use these filters to narrow the evidence set before ranking.</p>
       </div>
 
       <div className="space-y-8">
@@ -960,6 +964,11 @@ function ScreenParameters() {
                   />
                 </div>
               </div>
+              {hasInvalidCustomDateRange && (
+                <p className="text-sm text-red-600">
+                  End date must be the same as or later than the start date.
+                </p>
+              )}
             </div>
           )}
         </div>
@@ -1019,11 +1028,91 @@ function ScreenParameters() {
           </div>
         </div>
 
-        {/* Implementation constraints (optional) */}
-        <div className="space-y-4 max-w-2xl">
-          <h3 className="font-semibold text-lg">Do you have implementation constraints we should consider?</h3>
+      </div>
+
+      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
+          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        </div>
+        <Button
+          variant="secondary"
+          className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
+          onClick={() => s.next()}
+          disabled={!hasSelectedSource || hasInvalidCustomDateRange}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ScreenScreening() {
+  const s = useWizard();
+  const [customInput, setCustomInput] = useState("");
+  const constraintOptions = ["Any", "Low", "Moderate", "High"];
+
+  const addFactor = () => {
+    if (customInput.trim() && !s.screeningFactors.includes(customInput.trim())) {
+      s.set({ screeningFactors: [...s.screeningFactors, customInput.trim()] });
+      setCustomInput("");
+    }
+  };
+
+  const removeFactor = (factor: string) => {
+    s.set({ screeningFactors: s.screeningFactors.filter(f => f !== factor) });
+  };
+
+  const handleNext = async () => {
+    // Skip ADDITIONAL_QUESTIONS step - go directly to SUMMARY
+    // (Keeping generation code commented out for future use)
+    // s.set({ isGeneratingOptions: true });
+    // 
+    // try {
+    //   const response = await generateAdditionalQuestions(
+    //     s.researchQuestion,
+    //     s.population.selected,
+    //     s.outcome.selected
+    //   ).catch(() => ({ additional_questions: [] }));
+    //
+    //   const generatedQuestions = response?.additional_questions || [];
+    //   
+    //   // Preselect generated questions
+    //   s.set({ 
+    //     generatedAdditionalQuestions: generatedQuestions,
+    //     additionalQuestions: generatedQuestions,
+    //     step: "ADDITIONAL_QUESTIONS"
+    //   });
+    // } catch (error) {
+    //   console.error('Failed to generate additional questions:', error);
+    //   // Continue with empty questions if generation fails
+    //   s.set({ 
+    //     generatedAdditionalQuestions: [],
+    //     step: "ADDITIONAL_QUESTIONS" 
+    //   });
+    // } finally {
+    //   s.set({ isGeneratingOptions: false });
+    // }
+    
+    // Go directly to SUMMARY
+    s.set({ step: "SUMMARY" });
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
+      <div className="text-center space-y-3">
+        <h2 className="text-2xl font-semibold">Prioritisation and assessment settings</h2>
+        <p className="text-gray-600 text-lg">
+          Optional. Configure how evidence is prioritised during screening and assessed for implementation fit.
+        </p>
+      </div>
+
+      <div className="space-y-6 max-w-2xl mx-auto">
+        <div className="space-y-4">
+          <h3 className="font-semibold text-lg">Implementation constraints</h3>
           <div className="flex items-center gap-2 text-sm text-gray-600">
-            <span>Optional. Leave as “Any” if you do not want to filter by implementation feasibility.</span>
+            <span>Used during impact and transferability assessment.</span>
             <Tooltip
               content={
                 <div className="max-w-xs text-sm space-y-1">
@@ -1109,84 +1198,15 @@ function ScreenParameters() {
           </div>
         </div>
 
-      </div>
+        <div className="h-px bg-gray-100" />
 
-      <div className="flex justify-between items-center rounded-2xl border border-gray-200 bg-gray-50 p-4">
-        <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={() => s.back()}>Back</Button>
-          <Button variant="secondary" onClick={() => s.reset()}>Restart</Button>
+        <div className="space-y-3">
+          <h3 className="font-semibold text-lg">Screening factors</h3>
+          <p className="text-sm text-gray-600">
+            Used during screening to prioritise and rank the most relevant evidence.
+          </p>
         </div>
-        <Button
-          variant="secondary"
-          className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
-          onClick={() => s.next()}
-          disabled={!hasSelectedSource}
-        >
-          Next
-        </Button>
-      </div>
-    </div>
-  );
-}
 
-function ScreenScreening() {
-  const s = useWizard();
-  const [customInput, setCustomInput] = useState("");
-
-  const addFactor = () => {
-    if (customInput.trim() && !s.screeningFactors.includes(customInput.trim())) {
-      s.set({ screeningFactors: [...s.screeningFactors, customInput.trim()] });
-      setCustomInput("");
-    }
-  };
-
-  const removeFactor = (factor: string) => {
-    s.set({ screeningFactors: s.screeningFactors.filter(f => f !== factor) });
-  };
-
-  const handleNext = async () => {
-    // Skip ADDITIONAL_QUESTIONS step - go directly to SUMMARY
-    // (Keeping generation code commented out for future use)
-    // s.set({ isGeneratingOptions: true });
-    // 
-    // try {
-    //   const response = await generateAdditionalQuestions(
-    //     s.researchQuestion,
-    //     s.population.selected,
-    //     s.outcome.selected
-    //   ).catch(() => ({ additional_questions: [] }));
-    //
-    //   const generatedQuestions = response?.additional_questions || [];
-    //   
-    //   // Preselect generated questions
-    //   s.set({ 
-    //     generatedAdditionalQuestions: generatedQuestions,
-    //     additionalQuestions: generatedQuestions,
-    //     step: "ADDITIONAL_QUESTIONS"
-    //   });
-    // } catch (error) {
-    //   console.error('Failed to generate additional questions:', error);
-    //   // Continue with empty questions if generation fails
-    //   s.set({ 
-    //     generatedAdditionalQuestions: [],
-    //     step: "ADDITIONAL_QUESTIONS" 
-    //   });
-    // } finally {
-    //   s.set({ isGeneratingOptions: false });
-    // }
-    
-    // Go directly to SUMMARY
-    s.set({ step: "SUMMARY" });
-  };
-
-  return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 py-16">
-      <div className="text-center space-y-3">
-        <h2 className="text-2xl font-semibold">Anything else to consider when screening the evidence?</h2>
-        <p className="text-gray-600 text-lg">We will use this to filter only the most relevant information</p>
-      </div>
-
-      <div className="space-y-6 max-w-2xl mx-auto">
         {/* Selected factors as buttons */}
         {s.screeningFactors.length > 0 && (
           <div>
@@ -1427,7 +1447,7 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
                       </span>
                     ))
                   ) : (
-                    <span className="text-gray-500">Not specified</span>
+                    <span className="text-gray-500">None selected</span>
                   )}
                 </div>
               </button>
@@ -1455,7 +1475,7 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
                       </span>
                     ))
                   ) : (
-                    <span className="text-gray-500">Not specified</span>
+                    <span className="text-gray-500">No preference</span>
                   )}
                 </div>
               </button>
@@ -1464,7 +1484,7 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
 
           <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
             <div className="text-xs uppercase tracking-wide text-gray-500">Prioritisation</div>
-            <button type="button" onClick={() => goToStep("PARAMETERS")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
+            <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
               <span className="font-medium">Implementation constraints</span>
               {hasImplementationConstraints ? (
                 <div className="mt-2 flex flex-wrap gap-2">
@@ -1479,7 +1499,7 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
                   </span>
                 </div>
               ) : (
-                <div className="mt-2 text-gray-500">Not specified</div>
+                <div className="mt-2 text-gray-500">No preference</div>
               )}
             </button>
             <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
@@ -1539,7 +1559,14 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
           variant="secondary"
           className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
           onClick={() => onRunAnalysis(context)}
-          disabled={isRunning || !hasSelectedSource}
+          disabled={
+            isRunning ||
+            !hasSelectedSource ||
+            (context.parameters.timePreset === "CUSTOM" &&
+              !!context.parameters.customFrom &&
+              !!context.parameters.customTo &&
+              context.parameters.customFrom > context.parameters.customTo)
+          }
         >
           {isRunning ? 'Starting up...' : 'Run Analysis'}
         </Button>
@@ -1549,6 +1576,14 @@ function ScreenSummary({ onRunAnalysis, isRunning = false }: { onRunAnalysis: (c
           Select at least one search source before running analysis.
         </p>
       )}
+      {context.parameters.timePreset === "CUSTOM" &&
+        !!context.parameters.customFrom &&
+        !!context.parameters.customTo &&
+        context.parameters.customFrom > context.parameters.customTo && (
+          <p className="text-sm text-red-600 text-right">
+            Fix your custom date range before running analysis.
+          </p>
+        )}
     </div>
   );
 }

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -438,7 +438,7 @@ function ScreenAsk() {
           value={s.researchQuestion} 
           onChange={(e) => s.set({ researchQuestion: e.target.value })} 
         />
-        <div className="flex justify-end items-center">
+        <div className="flex justify-end items-center mt-6">
           <Button 
             variant="secondary"
             className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"


### PR DESCRIPTION
## Summary
This PR improves the search wizard flow and results settings experience by:
- adding and refining parameter controls (including `Last 2 years`),
- standardising how “no preference” selections are represented and sent to the backend,
- improving navigation in the wizard,
- aligning search wizard summary and results-page search settings views,

## Key changes

### 1) Time window and date handling
- Added **`Last 2 years`** option to time presets in:
  - wizard UI labels/options,
  - search context conversion to `date_from`,
  - results modal labels.
- Added custom date-range validation (`from <= to`) with inline messaging and submit guarding.

### 2) “No preference” data semantics (frontend → backend)
- Standardised Population/Setting/Outcome handling around a **`noPreference`** pattern.
- Removed dependency on placeholder text values being emitted as real data.
- `buildContext()` now emits empty arrays (`[]`) for no-preference cases.
- Updated search page payload mapping accordingly (`population` and `outcome` now sent as arrays directly).
- This avoids polluting downstream stages (screening, synthesis, transferability, scoring prompts) with UI placeholder strings.

### 3) Wizard UX and navigation improvements
- Added visible **step indicator progress bar** with step labels and clickable navigation.
- Added **restart/start new search** buttons
- Changed colour and location of navigation buttons.
- Added source validation (must select at least one source) before progressing/running analysis.
- Made summary parameter cards clickable for direct step navigation.

### 4) Population/Outcome/Setting interaction fixes
- Enforced mutual exclusivity for general options and specific selections.
- Ensured fallback behaviour: if specific selections are all removed, general option state is restored via `noPreference`.
- Fixed custom-entry interactions so they correctly clear “general/no preference” state when needed.
- Improved visual distinction between general options and specific selections.

### 5) Screening + constraints page refinements
- Moved implementation constraints to page 6.

### 6) Summary and results settings alignment
- Polished wizard Summary content and labels.
- Improved max-results messaging: **“max results per source”** prominence/clarity.
- Updated results-page **Search Settings modal** to mirror summary structure and wording (population/setting/outcome, filters, prioritisation, retrieval limit).
- Added support for `inner_setting` and `implementation_constraints` in modal display.

### 7) Results-page robustness fix
- Fixed project page caching logic to ensure full project payload (including `search_query`) is fetched when needed.
- This addresses cases where completed projects did not show search settings due to partial store data.

### 8) Start new search reset behaviour
- Ensured “Start new search” resets wizard state before returning to `/search`, so users start from a clean initial wizard.

### 9) Footer
- Added footer containing disclaimer throughout.

