### PR TITLE
Fixing evidence source counts

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -998,7 +998,14 @@ async def rerun_synthesis_for_project(
 async def get_project_documents(
     project_id: str, current_user: CurrentUser = Depends(get_current_user)
 ):
-    """Get all documents for an analysis project"""
+    """Get all documents for an analysis project.
+
+    Returns all documents including non-relevant and non-evidence documents.
+    Each document includes:
+    - is_relevant: whether it passed relevance screening
+    - is_evidence: whether it's an evidence document (not "Other (Non-evidence documents)")
+    - is_relevant_evidence: convenience flag combining both checks
+    """
     try:
         # Check authorization
         get_project_with_auth_check(project_id, current_user, "id, organization_id")
@@ -1011,14 +1018,9 @@ async def get_project_documents(
         )
         # Map database field names to frontend expectations
         documents = []
-        filtered_other_count = 0
+        relevant_evidence_count = 0
 
         for doc in docs_result.data:
-            # Filter out "Other (Non-evidence documents)" - these shouldn't reach the UI
-            if is_non_evidence_document(doc):
-                filtered_other_count += 1
-                continue
-
             doc_copy = doc.copy()
             # Map citation_count (database) to cited_by_count (frontend)
             if "citation_count" in doc_copy:
@@ -1042,15 +1044,25 @@ async def get_project_documents(
             doc_copy["predicted_impact_justification"] = predicted_impact.get(
                 "justification"
             )
+
+            # Add is_evidence flag for frontend filtering
+            is_evidence = not is_non_evidence_document(doc)
+            doc_copy["is_evidence"] = is_evidence
+
+            # Add convenience flag combining is_relevant and is_evidence
+            is_relevant = doc_copy.get("is_relevant", True)
+            doc_copy["is_relevant_evidence"] = is_relevant and is_evidence
+
+            if is_relevant and is_evidence:
+                relevant_evidence_count += 1
+
             documents.append(doc_copy)
 
-        if filtered_other_count > 0:
-            logger.info(
-                f"Filtered {filtered_other_count} 'Other (Non-evidence)' documents from project {project_id} "
-                f"(returning {len(documents)} documents to UI)"
-            )
-
-        return {"documents": documents, "total": len(documents)}
+        return {
+            "documents": documents,
+            "total": len(documents),
+            "relevant_evidence_count": relevant_evidence_count,
+        }
 
     except Exception as e:
         logger.error(f"Error fetching documents for project {project_id}: {e}")

--- a/backend/app/services/analysis/service.py
+++ b/backend/app/services/analysis/service.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from .schemas import RunConfig, RunResult
 from .references import ReferencesService
 from .relevance import RelevanceService
-from .evidence.category import EvidenceCategoryService
+from .evidence.category import EvidenceCategoryService, NON_EVIDENCE_CATEGORY
 from .acquire import AcquisitionService
 from .parse import ParsingService
 from .normalize import normalize_text
@@ -137,23 +137,9 @@ class AnalysisService:
                     str(references_csv)
                 )
 
-                # Count relevant documents for reporting
-                try:
-                    df = pd.read_csv(references_csv)
-                    relevant_references = (
-                        df["is_relevant"].sum()
-                        if "is_relevant" in df.columns
-                        else total_references
-                    )
-                except Exception:
-                    relevant_references = total_references
-
-            monitor.record_metric("relevant_references", relevant_references)
             logger.info(
-                "Run %s completed relevance checking: %d relevant out of %d total",
+                "Run %s completed relevance checking",
                 run_id,
-                relevant_references,
-                total_references,
             )
 
             # Step 1.75: Evidence categorisation (only for relevant documents)
@@ -169,6 +155,32 @@ class AnalysisService:
                     str(references_csv)
                 )
                 logger.info("Run %s completed evidence categorisation", run_id)
+
+            # Count relevant documents AFTER evidence categorisation
+            # Exclude both is_relevant=False AND "Other (Non-evidence documents)"
+            try:
+                df = pd.read_csv(references_csv)
+                is_relevant_mask = (
+                    df["is_relevant"].fillna(False).astype(bool)
+                    if "is_relevant" in df.columns
+                    else pd.Series([True] * len(df))
+                )
+                is_evidence_mask = (
+                    df["evidence_category"] != NON_EVIDENCE_CATEGORY
+                    if "evidence_category" in df.columns
+                    else pd.Series([True] * len(df))
+                )
+                relevant_references = int((is_relevant_mask & is_evidence_mask).sum())
+            except Exception:
+                relevant_references = total_references
+
+            monitor.record_metric("relevant_references", relevant_references)
+            logger.info(
+                "Run %s completed screening: %d relevant evidence docs out of %d total",
+                run_id,
+                relevant_references,
+                total_references,
+            )
 
             # STEPWISE UPLOAD: Store initial documents after screening
             if project_id:

--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -147,9 +147,9 @@ export default function AgentLayout({
                   } className="text-xs">
                     {activeProject.status}
                   </Badge>
-                  {activeProject.total_references > 0 && (
+                  {activeProject.relevant_references > 0 && (
                     <span className="text-xs text-slate-500">
-                      {activeProject.total_references} refs
+                      {activeProject.relevant_references} sources
                     </span>
                   )}
                 </div>

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -86,6 +86,9 @@ interface AnalysisDocument {
   impact_score_breakdown?: Record<string, unknown>
   transferability_score?: number
   transferability_breakdown?: Record<string, unknown>
+  // New fields for filtering
+  is_evidence?: boolean
+  is_relevant_evidence?: boolean
 }
 
 type TabType = 'summary' | 'evidence' | 'assistant'
@@ -122,6 +125,9 @@ export default function ProjectResultsPage() {
 
   // Column visibility state
   const [showAdditionalColumns, setShowAdditionalColumns] = useState(false)
+  
+  // Documents filter state - only show relevant evidence documents by default
+  const [showOnlyRelevant, setShowOnlyRelevant] = useState(true)
   
   // Documents download state
   const [isPreparingDocumentsDownload, setIsPreparingDocumentsDownload] = useState(false)
@@ -693,8 +699,10 @@ export default function ProjectResultsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId])
 
-  const overtonCount = documents.filter(doc => doc.source === 'overton').length
-  const openalexCount = documents.filter(doc => doc.source === 'openalex').length
+  // Filter to relevant evidence documents for stats
+  const relevantEvidenceDocs = documents.filter(doc => doc.is_relevant_evidence !== false && doc.is_relevant !== false && doc.is_evidence !== false)
+  const overtonCount = relevantEvidenceDocs.filter(doc => doc.source === 'overton').length
+  const openalexCount = relevantEvidenceDocs.filter(doc => doc.source === 'openalex').length
 
   // Create study strength and sample size mappings
   const { studyStrengthMapping, sampleSizeMapping } = useMemo(() => {
@@ -809,6 +817,10 @@ export default function ProjectResultsPage() {
     const allTransformed = documents.map((doc: AnalysisDocument) => {
       const conclusion = doc.extraction_results?.conclusion
       const evidenceStrength = conclusion?.evidence_strength
+      const isRelevant = Boolean(doc.is_relevant !== false)
+      const isEvidence = Boolean(doc.is_evidence !== false)
+      const isRelevantEvidence = isRelevant && isEvidence
+      
       return {
         id: String(doc.id || doc.doc_id || `doc-${Math.random()}`),
         title: String(doc.title || 'Untitled'),
@@ -816,7 +828,9 @@ export default function ProjectResultsPage() {
         publication_year: Number(doc.year || 0),
         cited_by_count: Number(doc.cited_by_count || 0),
         authors: Array.isArray(doc.authors) ? doc.authors : ['Unknown'],
-        is_relevant: Boolean(doc.is_relevant !== false),
+        is_relevant: isRelevant,
+        is_evidence: isEvidence,
+        is_relevant_evidence: isRelevantEvidence,
         abstract: doc.abstract_or_summary,
         relevance_reason: doc.relevance_reason,
         confidence: doc.relevance_confidence,
@@ -846,12 +860,12 @@ export default function ProjectResultsPage() {
       }
     })
 
-    // Always filter to show only relevant documents
-    const relevant = allTransformed.filter(doc => doc.is_relevant)
+    // Count relevant evidence documents
+    const relevantEvidenceCount = allTransformed.filter(doc => doc.is_relevant_evidence).length
 
     return {
-      transformedPapers: relevant,
-      relevantCount: relevant.length
+      transformedPapers: allTransformed,
+      relevantCount: relevantEvidenceCount
     }
   }, [documents, studyStrengthMapping, sampleSizeMapping])
 
@@ -1074,13 +1088,23 @@ export default function ProjectResultsPage() {
                           className="flex items-center gap-2"
                         >
                           <FileText className="h-3 w-3" />
-                          Documents ({relevantCount})
+                          Documents ({showOnlyRelevant ? relevantCount : `${relevantCount}+${transformedPapers.length - relevantCount}`})
                         </Button>
                       </div>
 
                       {/* Filter Toggles (only show for documents) */}
                       {urlSubTab === 'documents' && (
                         <div className="flex items-center gap-6">
+                          <div className="flex items-center gap-2">
+                            <Switch
+                              id="only-relevant"
+                              checked={showOnlyRelevant}
+                              onCheckedChange={setShowOnlyRelevant}
+                            />
+                            <Label htmlFor="only-relevant" className="text-sm text-slate-700">
+                              Only relevant
+                            </Label>
+                          </div>
                           <div className="flex items-center gap-2">
                             <Label htmlFor="additional-columns" className="text-sm text-slate-700">
                               More info
@@ -1146,7 +1170,14 @@ export default function ProjectResultsPage() {
                           <p className="text-slate-600">{dataError}</p>
                         </div>
                       ) : transformedPapers.length > 0 ? (
-                        <PapersTable papers={transformedPapers} showAdditionalColumns={showAdditionalColumns} />
+                        <PapersTable 
+                          papers={showOnlyRelevant 
+                            ? transformedPapers.filter(p => p.is_relevant_evidence) 
+                            : transformedPapers
+                          } 
+                          showAdditionalColumns={showAdditionalColumns}
+                          highlightNonRelevant={!showOnlyRelevant}
+                        />
                       ) : documents.length > 0 ? (
                         <div className="text-center py-12">
                           <FileText className="h-12 w-12 text-slate-400 mx-auto mb-4" />

--- a/frontend/app/(main)/projects/page.tsx
+++ b/frontend/app/(main)/projects/page.tsx
@@ -269,7 +269,7 @@ export default function ProjectsPage() {
                       <div className="flex items-center justify-between text-xs text-slate-500">
                         <span className="flex items-center gap-1">
                           <Search className="h-3 w-3" />
-                          {project.total_references} total, {project.relevant_references} relevant
+                          {project.relevant_references} sources ({project.total_references} screened)
                         </span>
                         <span className={`px-2 py-1 rounded-md text-xs font-medium ${
                           project.status === 'completed' ? 'bg-green-100 text-green-800' :

--- a/frontend/app/(main)/results/ExecutiveBriefing.tsx
+++ b/frontend/app/(main)/results/ExecutiveBriefing.tsx
@@ -211,10 +211,7 @@ function EvidenceCoverageBadge({ coverage }: { coverage: EvidenceCoverageSnapsho
         <div>
           <div className="text-slate-500 text-xs uppercase tracking-wide mb-1">Sources</div>
           <div className="font-semibold text-slate-800">
-            {coverage.total_synthesised} synthesised
-          </div>
-          <div className="text-slate-600 text-xs mt-0.5">
-            Screened: {coverage.total_screened}
+            {coverage.total_synthesised} sources
           </div>
         </div>
         <div>
@@ -753,7 +750,6 @@ export function ExecutiveBriefing({
       const countryEntries = Object.entries(evidenceCoverage.countries || {}).sort((a, b) => b[1] - a[1]);
       const topCountries = countryEntries.slice(0, 3).map(([c]) => sanitize(c)).join(", ") || "Unknown";
       const synthesised = evidenceCoverage.total_synthesised;
-      const screened = evidenceCoverage.total_screened;
       return `
         <div class="card">
           <div class="card-title">Evidence Base</div>
@@ -761,8 +757,7 @@ export function ExecutiveBriefing({
           <div class="snapshot-grid">
             <div>
               <div class="label">Sources</div>
-              <div class="value">${synthesised} synthesised</div>
-              <div class="value" style="font-size:10px;color:#64748b;">Screened: ${screened}</div>
+              <div class="value">${synthesised} sources</div>
             </div>
             <div>
               <div class="label">Evidence Types</div>

--- a/frontend/components/documents/PapersTable.tsx
+++ b/frontend/components/documents/PapersTable.tsx
@@ -12,6 +12,7 @@ import { getEvidenceCategoryColors, getEvidenceCategoryShortName } from '@/lib/e
 interface PapersTableProps {
   papers: Paper[]
   showAdditionalColumns?: boolean
+  highlightNonRelevant?: boolean
 }
 
 interface DataType extends Paper {
@@ -21,7 +22,7 @@ interface DataType extends Paper {
   relevanceDisplay: string
 }
 
-export function PapersTable({ papers, showAdditionalColumns = false }: PapersTableProps) {
+export function PapersTable({ papers, showAdditionalColumns = false, highlightNonRelevant = false }: PapersTableProps) {
   // Transform papers data for the table
   const tableData: DataType[] = useMemo(() => {
     return papers.map((paper) => ({
@@ -722,7 +723,14 @@ export function PapersTable({ papers, showAdditionalColumns = false }: PapersTab
         scroll={{ x: 1200 }}
         size="small"
         bordered
-        rowClassName={(record) => record.is_relevant ? 'bg-green-50' : 'bg-white'}
+        rowClassName={(record) => {
+          // When showing all docs (highlightNonRelevant=true), gray out non-relevant/non-evidence rows
+          const isRelevantEvidence = record.is_relevant_evidence !== false && record.is_relevant !== false && record.is_evidence !== false
+          if (highlightNonRelevant && !isRelevantEvidence) {
+            return 'bg-slate-100 opacity-60'
+          }
+          return 'bg-white'
+        }}
         sortDirections={['descend', 'ascend']}
       />
     </div>

--- a/frontend/types/search.ts
+++ b/frontend/types/search.ts
@@ -55,6 +55,9 @@ export interface SearchParams {
   impact_score?: number | null // 1-5 impact score (document-level), null when unassessable
   impact_score_label?: string
   impact_score_breakdown?: Record<string, unknown>
+  // Relevance/evidence filtering fields
+  is_evidence?: boolean  // true if not "Other (Non-evidence documents)"
+  is_relevant_evidence?: boolean  // true if is_relevant AND is_evidence
     // Extracted fields (dynamically added based on extraction_fields parameter)
     [key: string]:
       | string


### PR DESCRIPTION
Document counts were inconsistent across different UI components due to varying filter logic and data sources. This PR aligns all counts to use the same definition of "relevant evidence".

### Changes
- **Harmonised "relevant" definition**: Relevant documents now exclude both irrelevant docs AND "Non-evidence" category docs
- **Backend**: Updated `relevant_references` calculation in analysis pipeline to apply new definition (for new searches only)
- **Results page**: Policy/academic counts now only include relevant evidence documents
- **Executive briefing**: Evidence card now shows only synthesised source count
- **Documents table**: Added back in "Only relevant" toggle (default on); non-relevant rows shown as grayed out when off at the end of the table
- **Documents table**: Shows count as `(X+Y)` when toggle is off (where Y is the count of not-relevant docs)
- **Sidebar**: Shows relevant sources instead of total references
- **Project cards**: Display format updated to `X sources (Y screened)`