### PR TITLE
Fix evidence score N/A bug: move to dedicated DB columns

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1748,7 +1748,9 @@ def prepare_documents_csv_data(project_id: str) -> pd.DataFrame:
                         "Relevance Reason": doc.get("relevance_reason", ""),
                         "Confidence": doc.get("relevance_confidence", ""),
                         "Evidence Category": evidence_category,
-                        "Evidence Score": evidence_score or "",
+                        "Evidence Score": (
+                            evidence_score if evidence_score is not None else ""
+                        ),
                         "Evidence Justification": evidence_justification,
                         "Impact Score": doc.get("impact_score", ""),
                         "Impact Justification": doc.get("impact_score_label", ""),

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -33,7 +33,10 @@ from app.services.analysis.schemas import (
     AdditionalQuestionsRequest,
     AdditionalQuestionsResponse,
 )
-from app.services.analysis.evidence.strength import get_or_calculate_document_evidence
+from app.services.analysis.evidence.strength import (
+    get_document_evidence_score,
+    calculate_document_evidence_score,
+)
 from app.utils.project_data import (
     filter_prevalence_only_results,
     filter_prevalence_only_extractions,
@@ -1725,16 +1728,10 @@ def prepare_documents_csv_data(project_id: str) -> pd.DataFrame:
                     logger.warning(f"Skipping None document at index {i}")
                     continue
 
-                extraction_results = doc.get("extraction_results", {}) or {}
-                conclusion = extraction_results.get("conclusion", {}) or {}
-                evidence_strength = conclusion.get("evidence_strength", {}) or {}
                 evidence_category = doc.get("evidence_category", "")
-                evidence_score = evidence_strength.get("stars")
-                evidence_justification = evidence_strength.get("justification", "")
-                if evidence_score is None and evidence_category:
-                    evidence_info = get_or_calculate_document_evidence(doc)
-                    evidence_score = evidence_info["stars"]
-                    evidence_justification = evidence_info.get("justification", "")
+                evidence_score = get_document_evidence_score(doc)
+                evidence_result = calculate_document_evidence_score(doc)
+                evidence_justification = evidence_result.get("justification", "")
 
                 # Handle authors field safely
                 authors = doc.get("authors", [])

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -34,8 +34,7 @@ from app.services.analysis.schemas import (
     AdditionalQuestionsResponse,
 )
 from app.services.analysis.evidence.strength import (
-    get_document_evidence_score,
-    calculate_document_evidence_score,
+    get_document_evidence_details,
 )
 from app.utils.project_data import (
     filter_prevalence_only_results,
@@ -1626,11 +1625,8 @@ def prepare_interventions_csv_data(project_id: str) -> pd.DataFrame:
                 raw_data = extraction.get("raw_data", {})
 
                 extraction_results = doc.get("extraction_results", {})
-                conclusion = extraction_results.get("conclusion", {}) or {}
-                evidence_strength = conclusion.get("evidence_strength", {}) or {}
-
                 impact_score = doc.get("impact_score")
-                evidence_score = evidence_strength.get("stars")
+                evidence_score = get_document_evidence_details(doc)["score"]
 
                 # Extract results from document's extraction_results
                 interventions_data = extraction_results.get("interventions", [])
@@ -1729,9 +1725,9 @@ def prepare_documents_csv_data(project_id: str) -> pd.DataFrame:
                     continue
 
                 evidence_category = doc.get("evidence_category", "")
-                evidence_score = get_document_evidence_score(doc)
-                evidence_result = calculate_document_evidence_score(doc)
-                evidence_justification = evidence_result.get("justification", "")
+                evidence_details = get_document_evidence_details(doc)
+                evidence_score = evidence_details["score"]
+                evidence_justification = evidence_details["justification"]
 
                 # Handle authors field safely
                 authors = doc.get("authors", [])

--- a/backend/app/api/test_extraction.py
+++ b/backend/app/api/test_extraction.py
@@ -143,7 +143,7 @@ async def run_extraction_with_custom_prompts(
         InterventionsExtraction,
         MappingsExtraction,
         ResultsExtraction,
-        ConclusionsExtraction,
+        ConclusionItem,
         DocumentExtractionBundle,
     )
     from app.services.analysis.workflows.rct import RCTExtractionWorkflow
@@ -259,7 +259,7 @@ async def run_extraction_with_custom_prompts(
     conclusions_result = await chain.ainvoke(
         {"full_text": text, "interventions_json": interventions_json}
     )
-    conclusions_extraction = ConclusionsExtraction(**conclusions_result)
+    conclusions_extraction = ConclusionItem(**conclusions_result["conclusion"])
 
     return (
         DocumentExtractionBundle(
@@ -268,7 +268,7 @@ async def run_extraction_with_custom_prompts(
             interventions=interventions_extraction.interventions,
             mappings=mappings_extraction.mappings,
             results=all_results,
-            conclusion=conclusions_extraction.conclusion,
+            conclusion=conclusions_extraction,
         ),
         evidence_category,
         confidence,

--- a/backend/app/api/test_extraction.py
+++ b/backend/app/api/test_extraction.py
@@ -259,7 +259,7 @@ async def run_extraction_with_custom_prompts(
     conclusions_result = await chain.ainvoke(
         {"full_text": text, "interventions_json": interventions_json}
     )
-    conclusions_extraction = ConclusionItem(**conclusions_result["conclusion"])
+    conclusions_extraction = ConclusionItem(**conclusions_result.get("conclusion", {}))
 
     return (
         DocumentExtractionBundle(

--- a/backend/app/services/analysis/evidence/__init__.py
+++ b/backend/app/services/analysis/evidence/__init__.py
@@ -7,7 +7,6 @@ from .strength import (
     calculate_document_evidence_score,
     calculate_evidence_strength,
     get_document_evidence_details,
-    get_document_evidence_score,
 )
 
 __all__ = [
@@ -17,5 +16,4 @@ __all__ = [
     "calculate_document_evidence_score",
     "calculate_evidence_strength",
     "get_document_evidence_details",
-    "get_document_evidence_score",
 ]

--- a/backend/app/services/analysis/evidence/__init__.py
+++ b/backend/app/services/analysis/evidence/__init__.py
@@ -6,6 +6,7 @@ from .category import (
 from .strength import (
     calculate_document_evidence_score,
     calculate_evidence_strength,
+    get_document_evidence_details,
     get_document_evidence_score,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "get_evidence_categories_for_api",
     "calculate_document_evidence_score",
     "calculate_evidence_strength",
+    "get_document_evidence_details",
     "get_document_evidence_score",
 ]

--- a/backend/app/services/analysis/evidence/__init__.py
+++ b/backend/app/services/analysis/evidence/__init__.py
@@ -6,6 +6,7 @@ from .category import (
 from .strength import (
     calculate_document_evidence_score,
     calculate_evidence_strength,
+    get_document_evidence_score,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "get_evidence_categories_for_api",
     "calculate_document_evidence_score",
     "calculate_evidence_strength",
+    "get_document_evidence_score",
 ]

--- a/backend/app/services/analysis/evidence/strength.py
+++ b/backend/app/services/analysis/evidence/strength.py
@@ -49,6 +49,14 @@ class DocumentEvidenceScoreResult(TypedDict):
     sample_size: Optional[int]
 
 
+class DocumentEvidenceDetailsResult(TypedDict):
+    """Return type for get_document_evidence_details()."""
+
+    score: int
+    justification: str
+    sample_size: Optional[int]
+
+
 class EvidenceStrengthResult(TypedDict):
     """Return type for calculate_evidence_strength()."""
 
@@ -170,7 +178,7 @@ def build_evidence_info_for_docs(
 
 
 def get_document_evidence_score(doc: dict) -> int:
-    """Get evidence score for a document: DB column first, fallback to calculation.
+    """Get evidence score for a document: DB details first, fallback to calculation.
 
     Args:
         doc: Document dict with optional 'evidence_score' column
@@ -179,10 +187,41 @@ def get_document_evidence_score(doc: dict) -> int:
     Returns:
         Integer evidence score (0-5).
     """
-    stored = doc.get("evidence_score")
-    if stored is not None:
-        return stored
-    return calculate_document_evidence_score(doc)["score"]
+    return get_document_evidence_details(doc)["score"]
+
+
+def get_document_evidence_details(doc: dict) -> DocumentEvidenceDetailsResult:
+    """Get document evidence details: DB columns first, fallback for missing fields.
+
+    Args:
+        doc: Document dict with optional 'evidence_score',
+             'evidence_justification', and 'evidence_sample_size' columns.
+
+    Returns:
+        Dict with score, justification, and sample_size.
+    """
+    score = doc.get("evidence_score")
+    justification = doc.get("evidence_justification")
+    sample_size = doc.get("evidence_sample_size")
+
+    missing_score = score is None
+    missing_justification = justification is None
+    missing_sample_size = sample_size is None
+
+    if missing_score or missing_justification or missing_sample_size:
+        calculated = calculate_document_evidence_score(doc)
+        if missing_score:
+            score = calculated["score"]
+        if missing_justification:
+            justification = calculated["justification"]
+        if missing_sample_size:
+            sample_size = calculated["sample_size"]
+
+    return {
+        "score": score,
+        "justification": justification,
+        "sample_size": sample_size,
+    }
 
 
 def build_evidence_info_from_detailed_interventions(

--- a/backend/app/services/analysis/evidence/strength.py
+++ b/backend/app/services/analysis/evidence/strength.py
@@ -177,21 +177,8 @@ def build_evidence_info_for_docs(
     return result
 
 
-def get_document_evidence_score(doc: dict) -> int:
-    """Get evidence score for a document: DB details first, fallback to calculation.
-
-    Args:
-        doc: Document dict with optional 'evidence_score' column
-             and 'evidence_category' for fallback calculation.
-
-    Returns:
-        Integer evidence score (0-5).
-    """
-    return get_document_evidence_details(doc)["score"]
-
-
 def get_document_evidence_details(doc: dict) -> DocumentEvidenceDetailsResult:
-    """Get document evidence details: DB columns first, fallback for missing fields.
+    """Get document evidence details: DB columns first, fallback to calculation.
 
     Args:
         doc: Document dict with optional 'evidence_score',
@@ -201,26 +188,17 @@ def get_document_evidence_details(doc: dict) -> DocumentEvidenceDetailsResult:
         Dict with score, justification, and sample_size.
     """
     score = doc.get("evidence_score")
-    justification = doc.get("evidence_justification")
-    sample_size = doc.get("evidence_sample_size")
-
-    missing_score = score is None
-    missing_justification = justification is None
-    missing_sample_size = sample_size is None
-
-    if missing_score or missing_justification or missing_sample_size:
-        calculated = calculate_document_evidence_score(doc)
-        if missing_score:
-            score = calculated["score"]
-        if missing_justification:
-            justification = calculated["justification"]
-        if missing_sample_size:
-            sample_size = calculated["sample_size"]
-
+    if score is not None:
+        return {
+            "score": score,
+            "justification": doc.get("evidence_justification") or "",
+            "sample_size": doc.get("evidence_sample_size"),
+        }
+    calculated = calculate_document_evidence_score(doc)
     return {
-        "score": score,
-        "justification": justification,
-        "sample_size": sample_size,
+        "score": calculated["score"],
+        "justification": calculated["justification"],
+        "sample_size": calculated["sample_size"],
     }
 
 

--- a/backend/app/services/analysis/evidence/strength.py
+++ b/backend/app/services/analysis/evidence/strength.py
@@ -169,28 +169,20 @@ def build_evidence_info_for_docs(
     return result
 
 
-def get_or_calculate_document_evidence(doc: dict) -> dict:
-    """Get stored evidence strength or calculate it.
+def get_document_evidence_score(doc: dict) -> int:
+    """Get evidence score for a document: DB column first, fallback to calculation.
 
-    Returns dict with 'stars', 'justification', 'sample_size' keys.
+    Args:
+        doc: Document dict with optional 'evidence_score' column
+             and 'evidence_category' for fallback calculation.
+
+    Returns:
+        Integer evidence score (0-5).
     """
-    extraction_results = doc.get("extraction_results") or {}
-    conclusion = extraction_results.get("conclusion") or {}
-    stored = conclusion.get("evidence_strength") or {}
-
-    if stored:
-        return {
-            "stars": stored.get("stars"),
-            "justification": stored.get("justification", ""),
-            "sample_size": get_document_sample_size(doc),
-        }
-
-    result = calculate_document_evidence_score(doc)
-    return {
-        "stars": result["score"],
-        "justification": result.get("justification", ""),
-        "sample_size": result.get("sample_size"),
-    }
+    stored = doc.get("evidence_score")
+    if stored is not None:
+        return stored
+    return calculate_document_evidence_score(doc)["score"]
 
 
 def build_evidence_info_from_detailed_interventions(

--- a/backend/app/services/analysis/prompts.py
+++ b/backend/app/services/analysis/prompts.py
@@ -324,10 +324,10 @@ CONCLUSIONS_PROMPT = ChatPromptTemplate.from_messages(
         ("system", EXTRACTION_SYSTEM_PROMPT),
         (
             "human",
-            """Task: Extract the KEY CONCLUSION of this study AND assess evidence strength, risk assessment, and study context.
+            """Task: Extract the KEY CONCLUSION of this study AND assess risk assessment and study context.
 
 Schema:
-{{"conclusion":{{"top_line_summary":"...","detailed_explanation":"...","supporting_quote":"...","evidence_strength":{{"stars":1-5,"justification":"...","evidence_gap":"...|null"}},"risk_assessment":{{"risks_identified":["Risk 1","Risk 2"],"unintended_consequences_detected":true|false}},"study_context":{{"country":"...|null","population":"...|null","inner_setting":"...|null","cost_level":"High|Moderate|Low|null","staffing_level":"High|Moderate|Low|null","implementation_complexity_level":"High|Moderate|Low|null"}}}}}}
+{{"conclusion":{{"top_line_summary":"...","detailed_explanation":"...","supporting_quote":"...","risk_assessment":{{"risks_identified":["Risk 1","Risk 2"],"unintended_consequences_detected":true|false}},"study_context":{{"country":"...|null","population":"...|null","inner_setting":"...|null","cost_level":"High|Moderate|Low|null","staffing_level":"High|Moderate|Low|null","implementation_complexity_level":"High|Moderate|Low|null"}}}}}}
 
 Rules for Conclusion:
 - top_line_summary: ONE direct sentence stating the main conclusion (e.g., "The intervention significantly reduced behavioral problems in children").

--- a/backend/app/services/analysis/schemas_langchain.py
+++ b/backend/app/services/analysis/schemas_langchain.py
@@ -160,14 +160,6 @@ class ResultsExtraction(BaseModel):
     results: List[ResultItem]
 
 
-class ImpactRating(BaseModel):
-    """Star rating with justification, used for both evidence strength and predicted impact."""
-
-    stars: Optional[int] = None  # 1-5 star rating, null if insufficient evidence
-    justification: str  # 2-4 sentences explaining rating and discounting logic
-    evidence_gap: Optional[str] = None  # explanation if stars is null
-
-
 class RiskAssessment(BaseModel):
     """Document-level risk assessment for harm surfacing."""
 

--- a/backend/app/services/analysis/schemas_langchain.py
+++ b/backend/app/services/analysis/schemas_langchain.py
@@ -197,15 +197,8 @@ class ConclusionItem(BaseModel):
     top_line_summary: str  # One direct sentence summarizing the main conclusion
     detailed_explanation: str  # Paragraph explaining key reasons for the conclusion
     supporting_quote: str
-    evidence_strength: Optional[ImpactRating] = None  # Overall study evidence quality
     risk_assessment: Optional[RiskAssessment] = None
     study_context: Optional[StudyContext] = None  # Document-level context fallback
-
-
-class ConclusionsExtraction(BaseModel):
-    """Output from the conclusions extraction stage."""
-
-    conclusion: ConclusionItem
 
 
 # Final document extraction bundle

--- a/backend/app/services/analysis/storage.py
+++ b/backend/app/services/analysis/storage.py
@@ -23,6 +23,7 @@ from .scoring import (
     compute_harm_warning,
 )
 from .chunking import chunk_document_text
+from .evidence.strength import calculate_document_evidence_score
 from ..vectorization import VectorizationService
 
 logger = logging.getLogger(__name__)
@@ -148,12 +149,15 @@ class AnalysisStorageService:
         project_id: Optional[str],
         extraction_data: Dict[str, Any],
         doc_source_country: Optional[str] = None,
+        evidence_category: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Compute document-level scores and harm warnings from extraction data.
 
         Args:
             project_id (Optional[str]): Analysis project UUID.
             extraction_data (Dict[str, Any]): Extraction payload for the document.
+            doc_source_country (Optional[str]): Source country for transferability.
+            evidence_category (Optional[str]): Evidence category for evidence score calculation.
 
         Returns:
             Dict[str, Any]: Fields for analysis_documents update.
@@ -293,7 +297,15 @@ class AnalysisStorageService:
                 has_negative_impact, risks_identified
             )
 
+            # Compute evidence score from evidence_category + sample_size
+            doc_stub = {
+                "evidence_category": evidence_category,
+                "extraction_results": {"interventions": interventions},
+            }
+            evidence_result = calculate_document_evidence_score(doc_stub)
+
             return {
+                "evidence_score": evidence_result["score"],
                 "impact_score": score,
                 "impact_score_label": label,
                 "impact_score_breakdown": breakdown,
@@ -394,10 +406,11 @@ class AnalysisStorageService:
                 "upload_step": "extracted",
             }
             source_country = None
+            evidence_category = None
             try:
                 doc_meta = await self._async_supabase_query(
                     lambda: self.supabase.table("analysis_documents")
-                    .select("source_country")
+                    .select("source_country, evidence_category")
                     .eq("analysis_project_id", project_id)
                     .eq("doc_id", doc_id)
                     .limit(1)
@@ -405,11 +418,15 @@ class AnalysisStorageService:
                 )
                 if doc_meta.data:
                     source_country = doc_meta.data[0].get("source_country")
+                    evidence_category = doc_meta.data[0].get("evidence_category")
             except Exception as exc:
                 logger.warning(f"Failed to load source_country for {doc_id}: {exc}")
             doc_update.update(
                 await self._compute_document_scoring_fields(
-                    project_id, extraction_data, doc_source_country=source_country
+                    project_id,
+                    extraction_data,
+                    doc_source_country=source_country,
+                    evidence_category=evidence_category,
                 )
             )
 
@@ -630,16 +647,21 @@ class AnalysisStorageService:
         # Update documents with extraction results
         updates = []
         doc_source_lookup: Dict[str, Optional[str]] = {}
+        doc_category_lookup: Dict[str, Optional[str]] = {}
         try:
             source_rows = await self._async_supabase_query(
                 lambda: self.supabase.table("analysis_documents")
-                .select("doc_id, source_country")
+                .select("doc_id, source_country, evidence_category")
                 .eq("analysis_project_id", project_id)
                 .execute()
             )
             if source_rows.data:
                 doc_source_lookup = {
                     row.get("doc_id"): row.get("source_country")
+                    for row in source_rows.data
+                }
+                doc_category_lookup = {
+                    row.get("doc_id"): row.get("evidence_category")
                     for row in source_rows.data
                 }
         except Exception as exc:
@@ -649,7 +671,10 @@ class AnalysisStorageService:
             if doc_id:
                 source_country = doc_source_lookup.get(doc_id)
                 scoring_fields = await self._compute_document_scoring_fields(
-                    project_id, extraction, doc_source_country=source_country
+                    project_id,
+                    extraction,
+                    doc_source_country=source_country,
+                    evidence_category=doc_category_lookup.get(doc_id),
                 )
                 updates.append(
                     {

--- a/backend/app/services/analysis/storage.py
+++ b/backend/app/services/analysis/storage.py
@@ -648,8 +648,7 @@ class AnalysisStorageService:
 
         # Update documents with extraction results
         updates = []
-        doc_source_lookup: Dict[str, Optional[str]] = {}
-        doc_category_lookup: Dict[str, Optional[str]] = {}
+        doc_meta_lookup: Dict[str, Dict] = {}
         try:
             source_rows = await self._async_supabase_query(
                 lambda: self.supabase.table("analysis_documents")
@@ -658,25 +657,18 @@ class AnalysisStorageService:
                 .execute()
             )
             if source_rows.data:
-                doc_source_lookup = {
-                    row.get("doc_id"): row.get("source_country")
-                    for row in source_rows.data
-                }
-                doc_category_lookup = {
-                    row.get("doc_id"): row.get("evidence_category")
-                    for row in source_rows.data
-                }
+                doc_meta_lookup = {row.get("doc_id"): row for row in source_rows.data}
         except Exception as exc:
-            logger.warning(f"Failed to build source_country lookup: {exc}")
+            logger.warning(f"Failed to build doc metadata lookup: {exc}")
         for extraction in extractions_data.get("extractions", []):
             doc_id = extraction.get("paper_id")
             if doc_id:
-                source_country = doc_source_lookup.get(doc_id)
+                doc_meta = doc_meta_lookup.get(doc_id, {})
                 scoring_fields = await self._compute_document_scoring_fields(
                     project_id,
                     extraction,
-                    doc_source_country=source_country,
-                    evidence_category=doc_category_lookup.get(doc_id),
+                    doc_source_country=doc_meta.get("source_country"),
+                    evidence_category=doc_meta.get("evidence_category"),
                 )
                 updates.append(
                     {

--- a/backend/app/services/analysis/storage.py
+++ b/backend/app/services/analysis/storage.py
@@ -306,6 +306,8 @@ class AnalysisStorageService:
 
             return {
                 "evidence_score": evidence_result["score"],
+                "evidence_justification": evidence_result["justification"],
+                "evidence_sample_size": evidence_result["sample_size"],
                 "impact_score": score,
                 "impact_score_label": label,
                 "impact_score_breakdown": breakdown,

--- a/backend/app/services/analysis/utils/navigator.py
+++ b/backend/app/services/analysis/utils/navigator.py
@@ -3,9 +3,8 @@
 import logging
 
 from app.services.analysis.evidence.strength import (
-    calculate_document_evidence_score,
     calculate_evidence_strength,
-    get_document_sample_size,
+    get_document_evidence_details,
     build_evidence_info_for_docs,
     build_evidence_info_from_detailed_interventions,
     compute_display_evidence_mix_from_detailed,
@@ -137,20 +136,7 @@ def build_doc_scores_and_mappings(
         if not extraction_results:
             continue
 
-        # Get conclusion scores
-        conclusion = extraction_results.get("conclusion", {}) or {}
-        stored_evidence = conclusion.get("evidence_strength", {}) or {}
-
-        # Prefer stored evidence strength, fallback to recompute
-        if stored_evidence:
-            evidence_score = stored_evidence.get("stars")
-            evidence_justification = stored_evidence.get("justification", "")
-            evidence_sample_size = get_document_sample_size(document)
-        else:
-            evidence_result = calculate_document_evidence_score(document)
-            evidence_score = evidence_result["score"]
-            evidence_justification = evidence_result.get("justification", "")
-            evidence_sample_size = evidence_result.get("sample_size")
+        evidence_details = get_document_evidence_details(document)
 
         doc_scores[doc_id] = {
             "impact_score": document.get("impact_score"),
@@ -160,10 +146,10 @@ def build_doc_scores_and_mappings(
             "transferability_breakdown": document.get("transferability_breakdown"),
             "has_harm_warning": bool(document.get("has_harm_warning")),
             "harm_warning_reason": document.get("harm_warning_reason"),
-            "evidence_score": evidence_score,
-            "sample_size": evidence_sample_size,
+            "evidence_score": evidence_details["score"],
+            "sample_size": evidence_details["sample_size"],
             "impact_justification": document.get("impact_score_label", "") or "",
-            "evidence_justification": evidence_justification,
+            "evidence_justification": evidence_details["justification"],
         }
 
         # Find extraction IDs for issues and interventions in this document

--- a/backend/app/services/analysis/workflows/base.py
+++ b/backend/app/services/analysis/workflows/base.py
@@ -31,8 +31,6 @@ from ..schemas_langchain import (
     MappingItem,
     ResultItem,
     ConclusionItem,
-    ConclusionsExtraction,
-    ImpactRating,
 )
 from ..evidence.category import EVIDENCE_CATEGORY_EXPLANATIONS
 from ..evidence.strength import calculate_document_evidence_score
@@ -252,9 +250,9 @@ class BaseExtractionWorkflow(ABC):
                 stage_name="conclusions",
                 extra={"paper_id": paper_id},
             )
-            extraction = ConclusionsExtraction(**result)
+            conclusion = ConclusionItem(**result["conclusion"])
             logger.info(f"[{self.workflow_type.upper()}] Extracted conclusion")
-            return {"conclusion": extraction.conclusion}
+            return {"conclusion": conclusion}
         except Exception as e:
             logger.error(f"[{self.workflow_type.upper()}] Conclusions failed: {e}")
             return {"conclusion": None, "error": str(e)}
@@ -296,26 +294,6 @@ class BaseExtractionWorkflow(ABC):
                 return self._empty_bundle(paper_id)
 
             conclusion = final_state.get("conclusion")
-            if conclusion:
-                interventions = final_state.get("interventions") or []
-                extraction_results = {
-                    "interventions": [
-                        intervention.model_dump() for intervention in interventions
-                    ]
-                }
-                doc_stub = {
-                    "evidence_category": evidence_category,
-                    "extraction_results": extraction_results,
-                }
-                evidence_result = calculate_document_evidence_score(doc_stub)
-                evidence_strength = ImpactRating(
-                    stars=evidence_result["score"],
-                    justification=evidence_result.get("justification", ""),
-                    evidence_gap=None,
-                )
-                conclusion = conclusion.model_copy(
-                    update={"evidence_strength": evidence_strength}
-                )
 
             return DocumentExtractionBundle(
                 paper_id=paper_id,

--- a/backend/app/services/synthesis/nodes/data_loading.py
+++ b/backend/app/services/synthesis/nodes/data_loading.py
@@ -11,7 +11,10 @@ from typing import Dict, List
 from app.services.vectorization import vectorization_service
 from app.services.synthesis.state import SynthesisState, Concept
 from app.services.synthesis.utils import normalize_study_type
-from app.services.analysis.evidence.strength import get_or_calculate_document_evidence
+from app.services.analysis.evidence.strength import (
+    get_document_evidence_score,
+    calculate_document_evidence_score,
+)
 
 
 def clean_null_string(value: object) -> str:
@@ -119,18 +122,20 @@ async def load_raw_extractions(state: SynthesisState) -> SynthesisState:
             else None,
         }
 
-        # Get evidence and impact scores from conclusion (prefer stored, fallback to recompute)
-        evidence_info = get_or_calculate_document_evidence(doc)
+        # Get evidence and impact scores (DB column preferred, fallback to calculation)
+        evidence_result = calculate_document_evidence_score(doc)
 
         doc_scores[doc_uuid] = {
-            "evidence_score": evidence_info["stars"],  # 0-5 with sample size penalty
+            "evidence_score": get_document_evidence_score(
+                doc
+            ),  # 0-5 with sample size penalty
             "impact_score": doc.get("impact_score"),
             "impact_score_label": doc.get("impact_score_label"),
             "impact_score_breakdown": doc.get("impact_score_breakdown"),
             "transferability_score": doc.get("transferability_score"),
             "transferability_breakdown": doc.get("transferability_breakdown"),
             "evidence_category": doc.get("evidence_category"),
-            "evidence_justification": evidence_info["justification"],
+            "evidence_justification": evidence_result["justification"],
             "impact_justification": "",
             "has_harm_warning": bool(doc.get("has_harm_warning")),
             "harm_warning_reason": doc.get("harm_warning_reason"),

--- a/backend/app/services/synthesis/nodes/data_loading.py
+++ b/backend/app/services/synthesis/nodes/data_loading.py
@@ -12,8 +12,7 @@ from app.services.vectorization import vectorization_service
 from app.services.synthesis.state import SynthesisState, Concept
 from app.services.synthesis.utils import normalize_study_type
 from app.services.analysis.evidence.strength import (
-    get_document_evidence_score,
-    calculate_document_evidence_score,
+    get_document_evidence_details,
 )
 
 
@@ -90,7 +89,7 @@ async def load_raw_extractions(state: SynthesisState) -> SynthesisState:
     docs_res = (
         supabase.table("analysis_documents")
         .select(
-            "id, doc_id, title, year, authors, landing_page_url, pdf_url, source, document_type, extraction_results, evidence_category, top_line, is_relevant, impact_score, impact_score_label, impact_score_breakdown, transferability_score, transferability_breakdown, has_harm_warning, harm_warning_reason"
+            "id, doc_id, title, year, authors, landing_page_url, pdf_url, source, document_type, extraction_results, evidence_category, evidence_score, evidence_justification, evidence_sample_size, top_line, is_relevant, impact_score, impact_score_label, impact_score_breakdown, transferability_score, transferability_breakdown, has_harm_warning, harm_warning_reason"
         )
         .eq("analysis_project_id", project_id)
         .execute()
@@ -122,20 +121,17 @@ async def load_raw_extractions(state: SynthesisState) -> SynthesisState:
             else None,
         }
 
-        # Get evidence and impact scores (DB column preferred, fallback to calculation)
-        evidence_result = calculate_document_evidence_score(doc)
+        evidence_details = get_document_evidence_details(doc)
 
         doc_scores[doc_uuid] = {
-            "evidence_score": get_document_evidence_score(
-                doc
-            ),  # 0-5 with sample size penalty
+            "evidence_score": evidence_details["score"],  # 0-5 with sample size penalty
             "impact_score": doc.get("impact_score"),
             "impact_score_label": doc.get("impact_score_label"),
             "impact_score_breakdown": doc.get("impact_score_breakdown"),
             "transferability_score": doc.get("transferability_score"),
             "transferability_breakdown": doc.get("transferability_breakdown"),
             "evidence_category": doc.get("evidence_category"),
-            "evidence_justification": evidence_result["justification"],
+            "evidence_justification": evidence_details["justification"],
             "impact_justification": "",
             "has_harm_warning": bool(doc.get("has_harm_warning")),
             "harm_warning_reason": doc.get("harm_warning_reason"),

--- a/backend/app/utils/project_data.py
+++ b/backend/app/utils/project_data.py
@@ -23,7 +23,9 @@ from app.services.analysis.evidence.strength import (
     parse_sample_size,
     calculate_evidence_strength,
     get_document_max_sample_size,
-    get_or_calculate_document_evidence,
+    get_document_evidence_score,
+    get_document_sample_size,
+    calculate_document_evidence_score,
     build_document_evidence_info,
 )
 from app.services.analysis.utils.navigator import (
@@ -98,13 +100,13 @@ def transform_document_for_api(doc: Dict) -> Dict:
         evidence_category, UNKNOWN_RANK
     )
 
-    evidence_info = get_or_calculate_document_evidence(doc)
-    conclusion = (doc.get("extraction_results") or {}).get("conclusion") or {}
+    doc_copy["evidence_strength"] = get_document_evidence_score(doc)
+    evidence_result = calculate_document_evidence_score(doc)
+    if evidence_result["justification"]:
+        doc_copy["evidence_strength_justification"] = evidence_result["justification"]
+    doc_copy["sample_size"] = get_document_sample_size(doc)
 
-    doc_copy["evidence_strength"] = evidence_info["stars"]
-    if evidence_info["justification"]:
-        doc_copy["evidence_strength_justification"] = evidence_info["justification"]
-    doc_copy["sample_size"] = evidence_info["sample_size"]
+    conclusion = (doc.get("extraction_results") or {}).get("conclusion") or {}
 
     predicted_impact = conclusion.get("predicted_impact") or {}
     doc_copy["predicted_impact"] = predicted_impact.get("stars")
@@ -482,8 +484,7 @@ def get_outcome_contributions_data(project_id: str, outcome_theme_id: str) -> Di
     for doc_id, entry in documents_map.items():
         doc = docs_by_id.get(doc_id)
         if doc:
-            evidence_info = get_or_calculate_document_evidence(doc)
-            entry["evidence_score"] = evidence_info.get("stars")
+            entry["evidence_score"] = get_document_evidence_score(doc)
 
     documents = list(documents_map.values())
     documents.sort(key=lambda doc: (doc.get("title") or ""))

--- a/backend/app/utils/project_data.py
+++ b/backend/app/utils/project_data.py
@@ -23,9 +23,7 @@ from app.services.analysis.evidence.strength import (
     parse_sample_size,
     calculate_evidence_strength,
     get_document_max_sample_size,
-    get_document_evidence_score,
-    get_document_sample_size,
-    calculate_document_evidence_score,
+    get_document_evidence_details,
     build_document_evidence_info,
 )
 from app.services.analysis.utils.navigator import (
@@ -100,11 +98,11 @@ def transform_document_for_api(doc: Dict) -> Dict:
         evidence_category, UNKNOWN_RANK
     )
 
-    doc_copy["evidence_strength"] = get_document_evidence_score(doc)
-    evidence_result = calculate_document_evidence_score(doc)
-    if evidence_result["justification"]:
-        doc_copy["evidence_strength_justification"] = evidence_result["justification"]
-    doc_copy["sample_size"] = get_document_sample_size(doc)
+    evidence_details = get_document_evidence_details(doc)
+    doc_copy["evidence_strength"] = evidence_details["score"]
+    if evidence_details["justification"]:
+        doc_copy["evidence_strength_justification"] = evidence_details["justification"]
+    doc_copy["sample_size"] = evidence_details["sample_size"]
 
     conclusion = (doc.get("extraction_results") or {}).get("conclusion") or {}
 
@@ -484,7 +482,7 @@ def get_outcome_contributions_data(project_id: str, outcome_theme_id: str) -> Di
     for doc_id, entry in documents_map.items():
         doc = docs_by_id.get(doc_id)
         if doc:
-            entry["evidence_score"] = get_document_evidence_score(doc)
+            entry["evidence_score"] = get_document_evidence_details(doc)["score"]
 
     documents = list(documents_map.values())
     documents.sort(key=lambda doc: (doc.get("title") or ""))

--- a/backend/supabase/migrations/20260217181832_add_evidence_score_column.sql
+++ b/backend/supabase/migrations/20260217181832_add_evidence_score_column.sql
@@ -1,5 +1,11 @@
--- Add evidence_score column to analysis_documents
--- Deterministic score (0-5) derived from evidence_category + sample_size.
+-- Add evidence score and details columns to analysis_documents
+-- Deterministic values derived from evidence_category + sample_size.
 -- Computed after extraction; NULL for legacy rows (fallback calculation handles them).
 ALTER TABLE analysis_documents
   ADD COLUMN IF NOT EXISTS evidence_score SMALLINT DEFAULT NULL;
+
+ALTER TABLE analysis_documents
+  ADD COLUMN IF NOT EXISTS evidence_justification TEXT DEFAULT NULL;
+
+ALTER TABLE analysis_documents
+  ADD COLUMN IF NOT EXISTS evidence_sample_size INTEGER DEFAULT NULL;

--- a/backend/supabase/migrations/20260217181832_add_evidence_score_column.sql
+++ b/backend/supabase/migrations/20260217181832_add_evidence_score_column.sql
@@ -1,0 +1,5 @@
+-- Add evidence_score column to analysis_documents
+-- Deterministic score (0-5) derived from evidence_category + sample_size.
+-- Computed after extraction; NULL for legacy rows (fallback calculation handles them).
+ALTER TABLE analysis_documents
+  ADD COLUMN IF NOT EXISTS evidence_score SMALLINT DEFAULT NULL;

--- a/backend/supabase/migrations/20260220000000_add_evidence_details_columns.sql
+++ b/backend/supabase/migrations/20260220000000_add_evidence_details_columns.sql
@@ -1,0 +1,7 @@
+-- Add evidence details columns to analysis_documents
+-- Deterministic values derived from evidence_category + sample_size.
+ALTER TABLE analysis_documents
+  ADD COLUMN IF NOT EXISTS evidence_justification TEXT DEFAULT NULL;
+
+ALTER TABLE analysis_documents
+  ADD COLUMN IF NOT EXISTS evidence_sample_size INTEGER DEFAULT NULL;

--- a/backend/supabase/migrations/20260220000000_add_evidence_details_columns.sql
+++ b/backend/supabase/migrations/20260220000000_add_evidence_details_columns.sql
@@ -1,7 +1,0 @@
--- Add evidence details columns to analysis_documents
--- Deterministic values derived from evidence_category + sample_size.
-ALTER TABLE analysis_documents
-  ADD COLUMN IF NOT EXISTS evidence_justification TEXT DEFAULT NULL;
-
-ALTER TABLE analysis_documents
-  ADD COLUMN IF NOT EXISTS evidence_sample_size INTEGER DEFAULT NULL;

--- a/backend/test/test_evidence_strength.py
+++ b/backend/test/test_evidence_strength.py
@@ -7,7 +7,6 @@ from app.services.analysis.evidence.strength import (
     calculate_document_evidence_score,
     calculate_evidence_strength,
     get_document_evidence_details,
-    get_document_evidence_score,
 )
 
 
@@ -223,36 +222,6 @@ class TestEvidenceStrengthBasics:
         assert result["stars"] == 0
 
 
-class TestGetDocumentEvidenceScore:
-    """Tests for get_document_evidence_score helper."""
-
-    def test_db_column_path(self):
-        """When evidence_score DB column is set, return it directly."""
-        doc = {
-            "evidence_score": 3,
-            "evidence_category": "Observational Research Studies",
-        }
-        assert get_document_evidence_score(doc) == 3
-
-    def test_fallback_path(self):
-        """When evidence_score is None, fall back to calculation from evidence_category."""
-        doc = {
-            "evidence_score": None,
-            "evidence_category": "Policy Syntheses & Guidance Documents",
-        }
-        assert get_document_evidence_score(doc) == 2
-
-    def test_no_category(self):
-        """When both evidence_score and evidence_category are None, return 0."""
-        doc = {"evidence_score": None, "evidence_category": None}
-        assert get_document_evidence_score(doc) == 0
-
-    def test_missing_evidence_score_key(self):
-        """When evidence_score key is missing entirely, fall back to calculation."""
-        doc = {"evidence_category": "RCTs and Quasi-Experimental Studies"}
-        assert get_document_evidence_score(doc) == 4
-
-
 class TestGetDocumentEvidenceDetails:
     """Tests for get_document_evidence_details helper."""
 
@@ -268,35 +237,6 @@ class TestGetDocumentEvidenceDetails:
             "score": 2,
             "justification": "",
             "sample_size": 45,
-        }
-
-    def test_missing_justification_only(self):
-        """When only justification is missing, keep DB score/sample and compute justification."""
-        doc = {
-            "evidence_score": 4,
-            "evidence_justification": None,
-            "evidence_sample_size": 150,
-            "evidence_category": "RCTs and Quasi-Experimental Studies",
-            "extraction_results": {"interventions": [{"sample_size": 150}]},
-        }
-        result = get_document_evidence_details(doc)
-        assert result["score"] == 4
-        assert result["sample_size"] == 150
-        assert "Based on evidence category" in result["justification"]
-
-    def test_missing_sample_size_only(self):
-        """When sample size is missing, keep DB score/justification and compute sample."""
-        doc = {
-            "evidence_score": 3,
-            "evidence_justification": "Stored justification",
-            "evidence_sample_size": None,
-            "evidence_category": "RCTs and Quasi-Experimental Studies",
-            "extraction_results": {"interventions": [{"sample_size": 80}]},
-        }
-        assert get_document_evidence_details(doc) == {
-            "score": 3,
-            "justification": "Stored justification",
-            "sample_size": 80,
         }
 
     def test_missing_all_fields(self):

--- a/backend/test/test_evidence_strength.py
+++ b/backend/test/test_evidence_strength.py
@@ -6,6 +6,7 @@ from app.services.analysis.evidence.strength import (
     build_evidence_info_from_detailed_interventions,
     calculate_document_evidence_score,
     calculate_evidence_strength,
+    get_document_evidence_details,
     get_document_evidence_score,
 )
 
@@ -250,6 +251,79 @@ class TestGetDocumentEvidenceScore:
         """When evidence_score key is missing entirely, fall back to calculation."""
         doc = {"evidence_category": "RCTs and Quasi-Experimental Studies"}
         assert get_document_evidence_score(doc) == 4
+
+
+class TestGetDocumentEvidenceDetails:
+    """Tests for get_document_evidence_details helper."""
+
+    def test_all_db_fields_present(self):
+        """When DB fields are present, return stored values unchanged."""
+        doc = {
+            "evidence_score": 2,
+            "evidence_justification": "",
+            "evidence_sample_size": 45,
+            "evidence_category": "RCTs and Quasi-Experimental Studies",
+        }
+        assert get_document_evidence_details(doc) == {
+            "score": 2,
+            "justification": "",
+            "sample_size": 45,
+        }
+
+    def test_missing_justification_only(self):
+        """When only justification is missing, keep DB score/sample and compute justification."""
+        doc = {
+            "evidence_score": 4,
+            "evidence_justification": None,
+            "evidence_sample_size": 150,
+            "evidence_category": "RCTs and Quasi-Experimental Studies",
+            "extraction_results": {"interventions": [{"sample_size": 150}]},
+        }
+        result = get_document_evidence_details(doc)
+        assert result["score"] == 4
+        assert result["sample_size"] == 150
+        assert "Based on evidence category" in result["justification"]
+
+    def test_missing_sample_size_only(self):
+        """When sample size is missing, keep DB score/justification and compute sample."""
+        doc = {
+            "evidence_score": 3,
+            "evidence_justification": "Stored justification",
+            "evidence_sample_size": None,
+            "evidence_category": "RCTs and Quasi-Experimental Studies",
+            "extraction_results": {"interventions": [{"sample_size": 80}]},
+        }
+        assert get_document_evidence_details(doc) == {
+            "score": 3,
+            "justification": "Stored justification",
+            "sample_size": 80,
+        }
+
+    def test_missing_all_fields(self):
+        """When all DB fields are missing, compute all details."""
+        doc = {
+            "evidence_score": None,
+            "evidence_justification": None,
+            "evidence_sample_size": None,
+            "evidence_category": "Policy Syntheses & Guidance Documents",
+        }
+        assert get_document_evidence_details(doc) == {
+            "score": 2,
+            "justification": "Based on evidence category: Policy Syntheses & Guidance Documents",
+            "sample_size": None,
+        }
+
+    def test_missing_keys_legacy_doc(self):
+        """When evidence detail keys are absent, fallback should still work."""
+        doc = {
+            "evidence_category": "Observational Research Studies",
+            "extraction_results": {"interventions": [{"sample_size": 60}]},
+        }
+        assert get_document_evidence_details(doc) == {
+            "score": 2,
+            "justification": "Based on evidence category: Observational Research Studies. Score reduced due to sample size < 100.",
+            "sample_size": 60,
+        }
 
 
 class TestCalculateDocumentEvidenceScore:

--- a/backend/test/test_evidence_strength.py
+++ b/backend/test/test_evidence_strength.py
@@ -1,56 +1,13 @@
 """Unit tests for evidence strength calculation with sample size penalty."""
 
-import asyncio
 import logging
 
 from app.services.analysis.evidence.strength import (
     build_evidence_info_from_detailed_interventions,
+    calculate_document_evidence_score,
     calculate_evidence_strength,
+    get_document_evidence_score,
 )
-from app.services.analysis.schemas_langchain import ConclusionItem, ImpactRating
-from app.services.analysis.workflows.base import BaseExtractionWorkflow
-
-
-class _TestWorkflow(BaseExtractionWorkflow):
-    """Minimal workflow stub for testing computed evidence_strength persistence."""
-
-    workflow_type = "test"
-
-    def __init__(self):
-        # Avoid OpenAI key requirement and LLM setup for this test workflow.
-        self.model_name = "test"
-        self.json_parser = None
-        self.policy_project_id = None
-        self.policy_user_id = None
-        self._langfuse_session_id = None
-        self._langfuse_handler = None
-        self.workflow = self._build_workflow()
-
-    async def _extract_issues(self, state):
-        return {"issues": []}
-
-    async def _extract_interventions(self, state):
-        return {"interventions": []}
-
-    async def _extract_mappings(self, state):
-        return {"mappings": []}
-
-    async def _extract_results(self, state):
-        return {"results": []}
-
-    async def _extract_conclusions(self, state):
-        return {
-            "conclusion": ConclusionItem(
-                top_line_summary="Summary",
-                detailed_explanation="Details",
-                supporting_quote="Quote",
-                predicted_impact=ImpactRating(
-                    stars=3,
-                    justification="Impact justification",
-                    evidence_gap=None,
-                ),
-            )
-        }
 
 
 logger = logging.getLogger(__name__)
@@ -265,26 +222,60 @@ class TestEvidenceStrengthBasics:
         assert result["stars"] == 0
 
 
-class TestEvidenceStrengthPersistence:
-    """Ensure computed evidence strength is written into extraction results."""
+class TestGetDocumentEvidenceScore:
+    """Tests for get_document_evidence_score helper."""
 
-    def test_conclusion_includes_evidence_strength(self):
-        workflow = _TestWorkflow()
+    def test_db_column_path(self):
+        """When evidence_score DB column is set, return it directly."""
+        doc = {
+            "evidence_score": 3,
+            "evidence_category": "Observational Research Studies",
+        }
+        assert get_document_evidence_score(doc) == 3
 
-        bundle = asyncio.run(
-            workflow.run(
-                paper_id="paper-1",
-                full_text="Quote",
-                evidence_category="RCTs and Quasi-Experimental Studies",
-                evidence_confidence=0.9,
-            )
-        )
+    def test_fallback_path(self):
+        """When evidence_score is None, fall back to calculation from evidence_category."""
+        doc = {
+            "evidence_score": None,
+            "evidence_category": "Policy Syntheses & Guidance Documents",
+        }
+        assert get_document_evidence_score(doc) == 2
 
-        assert bundle.conclusion is not None
-        evidence_strength = bundle.conclusion.evidence_strength
-        assert evidence_strength is not None
-        assert evidence_strength.stars == 4
-        assert "Based on evidence category" in evidence_strength.justification
+    def test_no_category(self):
+        """When both evidence_score and evidence_category are None, return 0."""
+        doc = {"evidence_score": None, "evidence_category": None}
+        assert get_document_evidence_score(doc) == 0
+
+    def test_missing_evidence_score_key(self):
+        """When evidence_score key is missing entirely, fall back to calculation."""
+        doc = {"evidence_category": "RCTs and Quasi-Experimental Studies"}
+        assert get_document_evidence_score(doc) == 4
+
+
+class TestCalculateDocumentEvidenceScore:
+    """Tests for calculate_document_evidence_score."""
+
+    def test_rct_with_small_sample_penalty(self):
+        """RCT with sample size < 100 should get penalty."""
+        doc = {
+            "evidence_category": "RCTs and Quasi-Experimental Studies",
+            "extraction_results": {"interventions": [{"sample_size": 50}]},
+        }
+        result = calculate_document_evidence_score(doc)
+        assert result["base_score"] == 4
+        assert result["penalty_applied"] is True
+        assert result["score"] == 3
+
+    def test_rct_without_penalty(self):
+        """RCT with sample size >= 100 should not get penalty."""
+        doc = {
+            "evidence_category": "RCTs and Quasi-Experimental Studies",
+            "extraction_results": {"interventions": [{"sample_size": 200}]},
+        }
+        result = calculate_document_evidence_score(doc)
+        assert result["base_score"] == 4
+        assert result["penalty_applied"] is False
+        assert result["score"] == 4
 
     def test_evidence_hierarchy(self):
         """Higher evidence types should yield higher base ratings."""

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -84,11 +84,6 @@ interface AnalysisDocument {
       top_line_summary?: string
       detailed_explanation?: string
       supporting_quote?: string
-      evidence_strength?: {
-        stars: number | null
-        justification: string
-        evidence_gap?: string | null
-      }
     }
     issues?: unknown[]
     interventions?: unknown[]
@@ -780,13 +775,6 @@ export default function ProjectResultsPage() {
   // Transform documents for table display
   const { transformedPapers, relevantCount } = useMemo(() => {
     const allTransformed = documents.map((doc: AnalysisDocument) => {
-      const conclusion = doc.extraction_results?.conclusion
-      const legacyEvidenceStrength = conclusion?.evidence_strength
-      const evidenceStrength =
-        doc.evidence_strength ?? legacyEvidenceStrength?.stars
-      const evidenceStrengthJustification =
-        doc.evidence_strength_justification ??
-        legacyEvidenceStrength?.justification
       const isRelevant = Boolean(doc.is_relevant !== false)
       const isEvidence = Boolean(doc.is_evidence !== false)
       const isRelevantEvidence = isRelevant && isEvidence
@@ -815,8 +803,8 @@ export default function ProjectResultsPage() {
         source: doc.source,
         study_strength: studyStrengthMapping[doc.doc_id] || undefined,
         sample_size: sampleSizeMapping[doc.doc_id] || undefined,
-        evidence_strength: evidenceStrength ?? undefined,
-        evidence_strength_justification: evidenceStrengthJustification,
+        evidence_strength: doc.evidence_strength ?? undefined,
+        evidence_strength_justification: doc.evidence_strength_justification,
         impact_score: doc.impact_score,
         impact_score_label: doc.impact_score_label,
         impact_score_breakdown: doc.impact_score_breakdown,

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -781,7 +781,12 @@ export default function ProjectResultsPage() {
   const { transformedPapers, relevantCount } = useMemo(() => {
     const allTransformed = documents.map((doc: AnalysisDocument) => {
       const conclusion = doc.extraction_results?.conclusion
-      const evidenceStrength = conclusion?.evidence_strength
+      const legacyEvidenceStrength = conclusion?.evidence_strength
+      const evidenceStrength =
+        doc.evidence_strength ?? legacyEvidenceStrength?.stars
+      const evidenceStrengthJustification =
+        doc.evidence_strength_justification ??
+        legacyEvidenceStrength?.justification
       const isRelevant = Boolean(doc.is_relevant !== false)
       const isEvidence = Boolean(doc.is_evidence !== false)
       const isRelevantEvidence = isRelevant && isEvidence
@@ -810,8 +815,8 @@ export default function ProjectResultsPage() {
         source: doc.source,
         study_strength: studyStrengthMapping[doc.doc_id] || undefined,
         sample_size: sampleSizeMapping[doc.doc_id] || undefined,
-        evidence_strength: evidenceStrength?.stars || undefined,
-        evidence_strength_justification: evidenceStrength?.justification,
+        evidence_strength: evidenceStrength ?? undefined,
+        evidence_strength_justification: evidenceStrengthJustification,
         impact_score: doc.impact_score,
         impact_score_label: doc.impact_score_label,
         impact_score_breakdown: doc.impact_score_breakdown,

--- a/frontend/app/public/projects/[projectId]/page.tsx
+++ b/frontend/app/public/projects/[projectId]/page.tsx
@@ -67,11 +67,6 @@ interface AnalysisDocument {
       top_line_summary?: string
       detailed_explanation?: string
       supporting_quote?: string
-      evidence_strength?: {
-        stars: number | null
-        justification: string
-        evidence_gap?: string | null
-      }
     }
     issues?: unknown[]
     interventions?: unknown[]
@@ -364,13 +359,6 @@ export default function PublicProjectPage() {
 
   const { transformedPapers, relevantCount } = useMemo(() => {
     const allTransformed = documents.map((doc: AnalysisDocument) => {
-      const conclusion = doc.extraction_results?.conclusion
-      const legacyEvidenceStrength = conclusion?.evidence_strength
-      const evidenceStrength =
-        doc.evidence_strength ?? legacyEvidenceStrength?.stars
-      const evidenceStrengthJustification =
-        doc.evidence_strength_justification ??
-        legacyEvidenceStrength?.justification
       return {
         id: String(doc.id || doc.doc_id || `doc-${Math.random()}`),
         title: String(doc.title || 'Untitled'),
@@ -393,8 +381,8 @@ export default function PublicProjectPage() {
         source: doc.source,
         study_strength: studyStrengthMapping[doc.doc_id] || undefined,
         sample_size: sampleSizeMapping[doc.doc_id] || undefined,
-        evidence_strength: evidenceStrength ?? undefined,
-        evidence_strength_justification: evidenceStrengthJustification,
+        evidence_strength: doc.evidence_strength ?? undefined,
+        evidence_strength_justification: doc.evidence_strength_justification,
         impact_score: doc.impact_score,
         impact_score_label: doc.impact_score_label,
         impact_score_breakdown: doc.impact_score_breakdown,

--- a/frontend/app/public/projects/[projectId]/page.tsx
+++ b/frontend/app/public/projects/[projectId]/page.tsx
@@ -365,7 +365,12 @@ export default function PublicProjectPage() {
   const { transformedPapers, relevantCount } = useMemo(() => {
     const allTransformed = documents.map((doc: AnalysisDocument) => {
       const conclusion = doc.extraction_results?.conclusion
-      const evidenceStrength = conclusion?.evidence_strength
+      const legacyEvidenceStrength = conclusion?.evidence_strength
+      const evidenceStrength =
+        doc.evidence_strength ?? legacyEvidenceStrength?.stars
+      const evidenceStrengthJustification =
+        doc.evidence_strength_justification ??
+        legacyEvidenceStrength?.justification
       return {
         id: String(doc.id || doc.doc_id || `doc-${Math.random()}`),
         title: String(doc.title || 'Untitled'),
@@ -388,8 +393,8 @@ export default function PublicProjectPage() {
         source: doc.source,
         study_strength: studyStrengthMapping[doc.doc_id] || undefined,
         sample_size: sampleSizeMapping[doc.doc_id] || undefined,
-        evidence_strength: evidenceStrength?.stars || undefined,
-        evidence_strength_justification: evidenceStrength?.justification,
+        evidence_strength: evidenceStrength ?? undefined,
+        evidence_strength_justification: evidenceStrengthJustification,
         impact_score: doc.impact_score,
         impact_score_label: doc.impact_score_label,
         impact_score_breakdown: doc.impact_score_breakdown,

--- a/frontend/components/documents/DocumentDetailView.tsx
+++ b/frontend/components/documents/DocumentDetailView.tsx
@@ -71,11 +71,6 @@ interface DocumentDetailResult {
       top_line_summary?: string
       detailed_explanation?: string
       supporting_quote?: string
-      evidence_strength?: {
-        stars?: number | null
-        justification?: string
-        evidence_gap?: string
-      }
     }
     metadata?: Record<string, unknown>
   }
@@ -84,9 +79,11 @@ interface DocumentDetailResult {
 interface DocumentDetailViewProps {
   extraction: DocumentDetailResult['extraction']
   isSystematicReview?: boolean
+  evidenceStrength?: number
+  evidenceStrengthJustification?: string
 }
 
-export function DocumentDetailView({ extraction, isSystematicReview = false }: DocumentDetailViewProps) {
+export function DocumentDetailView({ extraction, isSystematicReview = false, evidenceStrength, evidenceStrengthJustification }: DocumentDetailViewProps) {
   const [openSections, setOpenSections] = useState({
     issues: true,
     interventions: true,
@@ -360,28 +357,18 @@ export function DocumentDetailView({ extraction, isSystematicReview = false }: D
                     </div>
                   )}
 
-                  {conclusion.evidence_strength && (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      {conclusion.evidence_strength && (
-                        <div>
-                          <h6 className="font-medium text-purple-900 text-sm mb-1">Evidence strength</h6>
-                          <div className="text-sm text-gray-700">
-                            {typeof conclusion.evidence_strength.stars === 'number' && (
-                              <div className="mb-1">
-                                <span className="font-medium">Stars: </span>
-                                {"★".repeat(Math.max(0, Math.min(5, conclusion.evidence_strength.stars)))}
-                                {"☆".repeat(Math.max(0, 5 - Math.max(0, Math.min(5, conclusion.evidence_strength.stars))))}
-                              </div>
-                            )}
-                            {conclusion.evidence_strength.justification && (
-                              <p className="text-sm text-gray-700">{conclusion.evidence_strength.justification}</p>
-                            )}
-                            {conclusion.evidence_strength.stars == null && conclusion.evidence_strength.evidence_gap && (
-                              <p className="text-xs text-gray-500 mt-1">Evidence gap: {conclusion.evidence_strength.evidence_gap}</p>
-                            )}
-                          </div>
+                  {typeof evidenceStrength === 'number' && evidenceStrength > 0 && (
+                    <div>
+                      <h6 className="font-medium text-purple-900 text-sm mb-1">Evidence Strength</h6>
+                      <div className="text-sm text-gray-700">
+                        <div className="mb-1" title={evidenceStrengthJustification}>
+                          {"★".repeat(Math.min(5, evidenceStrength))}
+                          {"☆".repeat(Math.max(0, 5 - evidenceStrength))}
                         </div>
-                      )}
+                        {evidenceStrengthJustification && (
+                          <p className="text-sm text-gray-500">{evidenceStrengthJustification}</p>
+                        )}
+                      </div>
                     </div>
                   )}
 


### PR DESCRIPTION
## Description

Fixes a bug where the Documents tab showed N/A for evidence strength on rows that had a valid evidence category. The root cause was that evidence score was sometimes being read from the LLM produced nested field `conclusion.evidence_strength`, which was sometimes absent.

This PR moves evidence score, justification, and sample size to dedicated, deterministic DB columns on supabase table `analysis_documents`. Values are computed at storage time using `_compute_document_scoring_fields()` and read back through the new helper `get_document_evidence_details()`. A lazy fallback to deterministic calculation is retained for legacy rows that pre-date the migrations.

## Changes Made

- **2 DB migrations** add nullable columns `evidence_score` (SMALLINT), `evidence_justification` (TEXT), `evidence_sample_size` (INTEGER) to `analysis_documents`
- **`storage.py`** computes and persists all three fields after extraction for both single and batch paths
- **`schemas_langchain.py` / `prompts.py` / `workflows/base.py`** remove `evidence_strength` from `ConclusionItem`, remove the now unused `ConclusionsExtraction` and `ImpactRating` models, and stop asking the LLM to produce evidence strength fields in the conclusions prompt
- **`evidence/strength.py` + `evidence/__init__.py`** remove `get_or_calculate_document_evidence()` and `get_document_evidence_score()`; the read path is now `get_document_evidence_details()` with a fallback for legacy rows
- **All read call sites** (`project_data.py`, `projects.py`, `data_loading.py`, `navigator.py`) updated to use `get_document_evidence_details()`
- **`projects.py`** fixes blank spaces to 0s: CSV export now preserves score `0` instead of converting it to blank (`evidence_score if evidence_score is not None else ""`)
- **Frontend** (`page.tsx` x2, `DocumentDetailView.tsx`) consumes top-level `doc.evidence_strength` and `doc.evidence_strength_justification` rather than the removed nested field
- **`test_evidence_strength.py`** rewritten to cover DB column read path, fallback path, and legacy-row path (22 tests passing)

## For Reviewers

### What to Focus On

- **Migration ordering** — `data_loading.py` now explicitly selects the new columns. If the two migrations are not run before this code is deployed, queries will fail with missing column errors. 
- **Removal of `conclusion.evidence_strength`** = This nested field is gone from both the schema and the prompt. Any scripts reading raw `extraction_results` JSON from the DB that relied on `conclusion.evidence_strength` will stop receiving that data. The in repo frontend is updated, but worth checking whether any downstream tooling depends on the old structure (think I've checked through to make sure everything downstream is working).

### How to Test

1. Run the unit test suite: `cd backend && uv run pytest test/test_evidence_strength.py -v` (expect 22 passed)
2. Apply the two migrations to a dev database before testing end-to-end
3. Run a document extraction on a project and check `analysis_documents` rows have `evidence_score`, `evidence_justification`, `evidence_sample_size` populated
4. Open the Documents tab for that project, see evidence stars/justification should display without N/A
5. Export the project CSV and verify `Evidence Score` column shows `0` for zero-scored documents rather than a blank cell
6. For a legacy project (rows without populated evidence columns), verify the Documents tab still displays evidence details via the deterministic fallback

### Setup Requirements

- Two migrations must be applied before running end-to-end tests:
  - `backend/supabase/migrations/20260217181832_add_evidence_score_column.sql`
  - `backend/supabase/migrations/20260220000000_add_evidence_details_columns.sql`
- No new environment variables or external dependencies required

## Checklist

- [x] Code has been tested locally (22 unit tests passing)
- [x] No local file dependencies
- [x] Docstrings updated where relevant
- [x] Changes are focused on the evidence scoring path only
- [x] Migrations are additive only (nullable columns, no drops or renames)