### PR TITLE
refactor: use consistent run_name for RCS Langfuse tracing

### DIFF
--- a/backend/app/services/synthesis/nodes/contextual_summarisation.py
+++ b/backend/app/services/synthesis/nodes/contextual_summarisation.py
@@ -22,15 +22,15 @@ from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from app.utils.llm.llm_utils import get_llm, build_langfuse_metadata
 from app.services.synthesis.schemas import (
+    RCSConfig,
     RetrievedChunk,
     ScoredContext,
     ThemeEvidence,
-    RCSConfig,
 )
 from app.services.synthesis.state import SynthesisState
 from app.services.synthesis.utils import escape_braces
+from app.utils.llm.llm_utils import build_langfuse_metadata, get_llm
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +44,8 @@ RCS_MODEL = "gpt-4.1-mini"
 
 RCS_SYSTEM_PROMPT = """You are an expert policy analyst evaluating evidence relevance.
 
-For the given excerpt from a policy document, determine if it contains information 
-relevant to answering the question. If relevant, provide a concise summary of the 
+For the given excerpt from a policy document, determine if it contains information
+relevant to answering the question. If relevant, provide a concise summary of the
 key points that help answer the question.
 
 Respond with JSON only:
@@ -56,7 +56,7 @@ Respond with JSON only:
 
 Scoring guide:
 - 0: Not relevant at all
-- 1-3: Tangentially related, minimal direct relevance  
+- 1-3: Tangentially related, minimal direct relevance
 - 4-6: Moderately relevant, provides useful context
 - 7-8: Highly relevant, directly addresses the question
 - 9-10: Critical evidence, directly answers key aspects
@@ -206,8 +206,9 @@ async def contextual_summarise_chunk(
                         session_id=state.get("langfuse_session_id"),
                         user_id=state.get("policy_user_id"),
                         project_id=state.get("project_id"),
+                        extra={"chunk_id": chunk.chunk_id},
                     ),
-                    "run_name": f"rcs:{chunk.chunk_id[:8]}",
+                    "run_name": "synthesis.rcs",
                 }
 
         response = await llm.ainvoke(messages, config=config)


### PR DESCRIPTION
## Summary
- For RCS tool calls, use static `"synthesis.rcs"` as run_name instead of per-chunk names for Langfuse tracing. This way we can properly aggregate these LLM calls for observability.
- Add `chunk_id` to Langfuse metadata extra for traceability

Instead of:
<img width="269" height="201" alt="image" src="https://github.com/user-attachments/assets/26c2b84e-e575-4633-8ca1-dafe1670f051" />
we now have:
<img width="258" height="181" alt="Screenshot 2026-02-18 at 5 25 56 PM" src="https://github.com/user-attachments/assets/876aeeea-7704-4fba-89cd-8c09c95b7cb1" />

## Test plan
- [ ] Verify Langfuse traces group under `synthesis.rcs` run name
- [ ] Confirm `chunk_id` appears in trace metadata