### PR TITLE
Remove summary chunks

### DIFF
--- a/backend/app/services/analysis/chunking.py
+++ b/backend/app/services/analysis/chunking.py
@@ -95,7 +95,7 @@ class TextChunker:
 
         Args:
             text: The text to chunk
-            chunk_type: Type of content being chunked ("content", "abstract", "summary")
+            chunk_type: Type of content being chunked ("content", "abstract")
 
         Returns:
             List of TextChunk objects
@@ -194,7 +194,6 @@ def chunk_document_text(
     Chunk a document into multiple types for optimal RAG performance.
 
     Creates:
-    - Summary chunk: title + top_line + relevance (for quick overview)
     - Abstract chunk: just the abstract (for focused abstract search)
     - Content chunks: overlapping full text chunks (for detailed content)
 
@@ -205,31 +204,7 @@ def chunk_document_text(
     chunks = []
     chunk_index = 0
 
-    # 1. Summary chunk (title + key findings)
-    if title or top_line or relevance_reason:
-        summary_parts = []
-        if title:
-            summary_parts.append(f"Title: {title}")
-        if top_line:
-            summary_parts.append(f"Key Finding: {top_line}")
-        if relevance_reason:
-            summary_parts.append(f"Relevance: {relevance_reason}")
-
-        if summary_parts:
-            content = "\n\n".join(summary_parts)
-            chunks.append(
-                TextChunk(
-                    content=content,
-                    chunk_index=chunk_index,
-                    chunk_type="summary",
-                    start_char=0,
-                    end_char=len(content),
-                    token_count=chunker.estimate_tokens(content),
-                )
-            )
-            chunk_index += 1
-
-    # 2. Abstract chunk (separate for focused abstract search)
+    # 1. Abstract chunk (separate for focused abstract search)
     if abstract and abstract.strip():
         chunks.append(
             TextChunk(
@@ -243,7 +218,7 @@ def chunk_document_text(
         )
         chunk_index += 1
 
-    # 3. Full text chunks (if available and not abstract-only mode)
+    # 2. Full text chunks (if available and not abstract-only mode)
     if full_text and not use_abstracts_only and len(full_text.strip()) > 500:
         content_chunks = chunker.chunk_text(full_text, chunk_type="content")
         # Update chunk indices to continue from where we left off

--- a/backend/app/services/analysis/storage.py
+++ b/backend/app/services/analysis/storage.py
@@ -496,7 +496,7 @@ class AnalysisStorageService:
         use_abstracts_only: bool = False,
     ) -> bool:
         """
-        Store document chunks for RAG. Creates summary, abstract, and content chunks.
+        Store document chunks for RAG. Creates abstract and content chunks.
 
         Args:
             project_id: The analysis project ID

--- a/backend/app/services/synthesis/schemas.py
+++ b/backend/app/services/synthesis/schemas.py
@@ -25,7 +25,7 @@ class RetrievedChunk(BaseModel):
     chunk_id: str = Field(..., description="Unique chunk identifier")
     document_id: str = Field(..., description="analysis_documents.id UUID")
     content: str = Field(..., description="Chunk text content")
-    chunk_type: str = Field("content", description="summary | abstract | content")
+    chunk_type: str = Field("content", description="abstract | content")
     similarity: float = Field(0.0, description="Cosine similarity score")
     doc_title: Optional[str] = Field(None, description="Document title")
     author_short: Optional[str] = Field(None, description="Author surname")

--- a/backend/supabase/migrations/20260225000000_set_chunks_chunk_type_default_abstract.sql
+++ b/backend/supabase/migrations/20260225000000_set_chunks_chunk_type_default_abstract.sql
@@ -1,0 +1,3 @@
+-- Set chunks.chunk_type default to abstract for defensive fallback inserts.
+ALTER TABLE public.chunks
+ALTER COLUMN chunk_type SET DEFAULT 'abstract'::text;


### PR DESCRIPTION
## Summary
Removes generation of `summary` chunks during ingestion to prevent vector search from retrieving LLM-derived text instead of raw document content. The chunk pipeline now only creates `abstract` and `content` chunks for new projects.

## What Changed
- Removed `summary` chunk creation from `chunking` logic.
- Updated related backend docstrings/schema descriptions to reflect supported chunk types (`abstract | content`).
- Added a Supabase migration to change `public.chunks.chunk_type` default from `summary` to `abstract`.

## Why
`summary` chunks were constructed from generated/derived fields (e.g. top-line/relevance text), which can contaminate downstream retrieval and grounding quality. Restricting ingestion to source-derived chunks improves grounding integrity.

## Testing
- Run search and verify that there are no summary chunks created in the DB

Closes #129 