### PR TITLE
Fix project stuck at failed status due to stale localStorage data

### DIFF
--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -208,14 +208,20 @@ export default function ProjectResultsPage() {
     updateUrl('evidence', subtab)
   }, [updateUrl])
 
-  // Load project from API if not in store or different project
+  // Load project from API if not in store or different project.
+  // Note: when the project is running/synthesising, verifyAndPoll (below)
+  // handles the initial fetch, so we skip here to avoid a duplicate API call.
   useEffect(() => {
     const loadProjectIfNeeded = async () => {
       if (!projectId) {
         setError('No project ID provided')
         return
       }
-      
+
+      // verifyAndPoll handles the fetch for running projects
+      const storeStatus = activeProject?.id === projectId ? activeProject.status : null
+      if (storeStatus === 'running' || storeStatus === 'synthesising') return
+
       // If we already have this project in store with full payload, no need to fetch.
       // The projects list endpoint omits search_query, so we must refetch when that field is missing.
       const hasSearchQueryField =
@@ -526,58 +532,39 @@ export default function ProjectResultsPage() {
     if (hasStartedPollingRef.current === projectId) return
     if (analysisComplete) return
 
-    const checkProjectStatus = async () => {
-      try {
-        const projectData = await getAnalysisProject(projectId)
-        const project = projectData.project
-        setActiveProject(project)
+    // Shared helper: fetch project status and handle terminal states
+    const fetchAndCheckStatus = async () => {
+      const projectData = await getAnalysisProject(projectId)
+      const project = projectData.project
+      setActiveProject(project)
 
-        if (project.status === 'completed' || project.status === 'failed' || project.status === 'created') {
-          setAnalysisComplete(project.status === 'completed' || project.status === 'created')
-          if (project.status === 'failed') {
-            setError('Analysis failed. Please try again.')
-          }
-          return true
+      const isTerminal = project.status === 'completed' || project.status === 'failed' || project.status === 'created'
+      if (isTerminal) {
+        setAnalysisComplete(project.status === 'completed' || project.status === 'created')
+        if (project.status === 'failed') {
+          setError('Analysis failed. Please try again.')
         }
-        return false
-      } catch (error) {
-        console.error('Failed to poll project status:', error)
-        return false
       }
+      return { project, isTerminal }
     }
 
-    const verifyAndPoll = async () => {
-      try {
-        const projectData = await getAnalysisProject(projectId)
-        const project = projectData.project
-        setActiveProject(project)
+    const startPolling = () => {
+      hasStartedPollingRef.current = projectId
 
-        const isRunning = project.status === 'running' || project.status === 'synthesising'
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current)
+        pollingIntervalRef.current = null
+      }
 
-        if (!isRunning) {
-          setAnalysisComplete(project.status === 'completed' || project.status === 'created')
-          if (project.status === 'failed') {
-            setError('Analysis failed. Please try again.')
-          }
-          return
-        }
+      setIsPolling(true)
+      pollingIntervalRef.current = setInterval(async () => {
+        if (!pollingIntervalRef.current) return
 
-        // Project is genuinely running — start polling
-        hasStartedPollingRef.current = projectId
+        await refreshData()
 
-        if (pollingIntervalRef.current) {
-          clearInterval(pollingIntervalRef.current)
-          pollingIntervalRef.current = null
-        }
-
-        setIsPolling(true)
-        pollingIntervalRef.current = setInterval(async () => {
-          if (!pollingIntervalRef.current) return
-
-          await refreshData()
-
-          const isComplete = await checkProjectStatus()
-          if (isComplete) {
+        try {
+          const { isTerminal: done } = await fetchAndCheckStatus()
+          if (done) {
             if (pollingIntervalRef.current) {
               clearInterval(pollingIntervalRef.current)
               pollingIntervalRef.current = null
@@ -586,9 +573,29 @@ export default function ProjectResultsPage() {
             hasStartedPollingRef.current = null
             await refreshData()
           }
-        }, 20000)
+        } catch (error) {
+          console.error('Failed to poll project status:', error)
+        }
+      }, 20000)
+    }
+
+    const verifyAndPoll = async () => {
+      try {
+        const { isTerminal } = await fetchAndCheckStatus()
+
+        if (isTerminal) return
+
+        // Guard against race: another effect may have started polling during the await
+        if (hasStartedPollingRef.current === projectId) return
+
+        startPolling()
       } catch (error) {
         console.error('Failed to verify project status:', error)
+        // Fallback: if the store has a running status, start polling anyway
+        const storeStatus = activeProject?.id === projectId ? activeProject.status : null
+        if (storeStatus === 'running' || storeStatus === 'synthesising') {
+          startPolling()
+        }
       }
     }
 
@@ -602,6 +609,8 @@ export default function ProjectResultsPage() {
       }
       hasStartedPollingRef.current = null
     }
+    // Intentionally omitting analysisComplete, activeProject, refreshData —
+    // these are either refs, stable setters, or guarded by hasStartedPollingRef.
   }, [projectId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load data when navigating to a project

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -209,8 +209,7 @@ export default function ProjectResultsPage() {
   }, [updateUrl])
 
   // Load project from API if not in store or different project.
-  // Note: when the project is running/synthesising, verifyAndPoll (below)
-  // handles the initial fetch, so we skip here to avoid a duplicate API call.
+  // Running projects are handled by the polling effect below.
   useEffect(() => {
     const loadProjectIfNeeded = async () => {
       if (!projectId) {
@@ -524,15 +523,14 @@ export default function ProjectResultsPage() {
     }
   }, [analysisComplete])
 
-  // Always verify status from the API before deciding whether to poll.
-  // This prevents stale localStorage status (e.g. "failed" from a dropped
-  // HTTP connection) from blocking polling when the backend is still running.
+  // Always verify status from the API before polling — stale localStorage
+  // (e.g. "failed" from a dropped HTTP connection) must not block polling.
   useEffect(() => {
     if (!projectId) return
     if (hasStartedPollingRef.current === projectId) return
     if (analysisComplete) return
 
-    // Shared helper: fetch project status and handle terminal states
+    // Fetch project status and handle terminal states
     const fetchAndCheckStatus = async () => {
       const projectData = await getAnalysisProject(projectId)
       const project = projectData.project
@@ -585,13 +583,13 @@ export default function ProjectResultsPage() {
 
         if (isTerminal) return
 
-        // Guard against race: another effect may have started polling during the await
+        // Prevent duplicate polling if another effect started during the await
         if (hasStartedPollingRef.current === projectId) return
 
         startPolling()
       } catch (error) {
         console.error('Failed to verify project status:', error)
-        // Fallback: if the store has a running status, start polling anyway
+        // Fallback to store status if API is unreachable
         const storeStatus = activeProject?.id === projectId ? activeProject.status : null
         if (storeStatus === 'running' || storeStatus === 'synthesising') {
           startPolling()
@@ -609,8 +607,7 @@ export default function ProjectResultsPage() {
       }
       hasStartedPollingRef.current = null
     }
-    // Intentionally omitting analysisComplete, activeProject, refreshData —
-    // these are either refs, stable setters, or guarded by hasStartedPollingRef.
+    // Deps intentionally limited to projectId — other values are refs or stable setters
   }, [projectId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load data when navigating to a project

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -536,14 +536,14 @@ export default function ProjectResultsPage() {
       const project = projectData.project
       setActiveProject(project)
 
-      const isTerminal = project.status === 'completed' || project.status === 'failed' || project.status === 'created'
-      if (isTerminal) {
+      const isStable = project.status === 'completed' || project.status === 'failed' || project.status === 'created'
+      if (isStable) {
         setAnalysisComplete(project.status === 'completed' || project.status === 'created')
         if (project.status === 'failed') {
           setError('Analysis failed. Please try again.')
         }
       }
-      return { project, isTerminal }
+      return { project, isStable }
     }
 
     const startPolling = () => {
@@ -561,7 +561,7 @@ export default function ProjectResultsPage() {
         await refreshData()
 
         try {
-          const { isTerminal: done } = await fetchAndCheckStatus()
+          const { isStable: done } = await fetchAndCheckStatus()
           if (done) {
             if (pollingIntervalRef.current) {
               clearInterval(pollingIntervalRef.current)
@@ -579,9 +579,9 @@ export default function ProjectResultsPage() {
 
     const verifyAndPoll = async () => {
       try {
-        const { isTerminal } = await fetchAndCheckStatus()
+        const { isStable } = await fetchAndCheckStatus()
 
-        if (isTerminal) return
+        if (isStable) return
 
         // Prevent duplicate polling if another effect started during the await
         if (hasStartedPollingRef.current === projectId) return

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -518,33 +518,13 @@ export default function ProjectResultsPage() {
     }
   }, [analysisComplete])
 
-  // Start polling ONLY when the project is actively running/synthesising.
-  // The initial project load is handled by loadProjectIfNeeded above, so we
-  // wait until activeProject is populated to decide whether polling is needed.
+  // Always verify status from the API before deciding whether to poll.
+  // This prevents stale localStorage status (e.g. "failed" from a dropped
+  // HTTP connection) from blocking polling when the backend is still running.
   useEffect(() => {
     if (!projectId) return
-
-    const currentProjectStatus = activeProject?.id === projectId ? activeProject.status : null
-
-    // Wait until the project is loaded before deciding
-    if (!currentProjectStatus) return
-
-    const isProjectRunning = currentProjectStatus === 'running' || currentProjectStatus === 'synthesising'
-
-    if (!isProjectRunning) {
-      setAnalysisComplete(currentProjectStatus === 'completed' || currentProjectStatus === 'created')
-      return
-    }
-
     if (hasStartedPollingRef.current === projectId) return
     if (analysisComplete) return
-
-    hasStartedPollingRef.current = projectId
-
-    if (pollingIntervalRef.current) {
-      clearInterval(pollingIntervalRef.current)
-      pollingIntervalRef.current = null
-    }
 
     const checkProjectStatus = async () => {
       try {
@@ -566,23 +546,53 @@ export default function ProjectResultsPage() {
       }
     }
 
-    setIsPolling(true)
-    pollingIntervalRef.current = setInterval(async () => {
-      if (!pollingIntervalRef.current) return
+    const verifyAndPoll = async () => {
+      try {
+        const projectData = await getAnalysisProject(projectId)
+        const project = projectData.project
+        setActiveProject(project)
 
-      await refreshData()
+        const isRunning = project.status === 'running' || project.status === 'synthesising'
 
-      const isComplete = await checkProjectStatus()
-      if (isComplete) {
+        if (!isRunning) {
+          setAnalysisComplete(project.status === 'completed' || project.status === 'created')
+          if (project.status === 'failed') {
+            setError('Analysis failed. Please try again.')
+          }
+          return
+        }
+
+        // Project is genuinely running — start polling
+        hasStartedPollingRef.current = projectId
+
         if (pollingIntervalRef.current) {
           clearInterval(pollingIntervalRef.current)
           pollingIntervalRef.current = null
         }
-        setIsPolling(false)
-        hasStartedPollingRef.current = null
-        await refreshData()
+
+        setIsPolling(true)
+        pollingIntervalRef.current = setInterval(async () => {
+          if (!pollingIntervalRef.current) return
+
+          await refreshData()
+
+          const isComplete = await checkProjectStatus()
+          if (isComplete) {
+            if (pollingIntervalRef.current) {
+              clearInterval(pollingIntervalRef.current)
+              pollingIntervalRef.current = null
+            }
+            setIsPolling(false)
+            hasStartedPollingRef.current = null
+            await refreshData()
+          }
+        }, 20000)
+      } catch (error) {
+        console.error('Failed to verify project status:', error)
       }
-    }, 20000)
+    }
+
+    verifyAndPoll()
 
     return () => {
       if (pollingIntervalRef.current) {
@@ -592,7 +602,7 @@ export default function ProjectResultsPage() {
       }
       hasStartedPollingRef.current = null
     }
-  }, [projectId, analysisComplete, activeProject?.id, activeProject?.status]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [projectId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load data when navigating to a project
   useEffect(() => {

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -116,9 +116,7 @@ export default function SearchPage() {
         search_context: searchContext,
       }
 
-      // Fire-and-forget: the project page discovers status via polling.
-      // We must not write terminal statuses here — doing so causes a
-      // stale-status bug when the HTTP connection drops mid-analysis.
+      // Fire-and-forget — the project page handles status via polling
       runAnalysisForProject(project.id, analysisConfig)
         .then((result) => {
           console.log('Search analysis completed:', result.run_id)

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -116,21 +116,15 @@ export default function SearchPage() {
         search_context: searchContext,
       }
 
-      // Start analysis (don't wait for completion)
+      // Fire-and-forget: the project page discovers status via polling.
+      // We must not write terminal statuses here — doing so causes a
+      // stale-status bug when the HTTP connection drops mid-analysis.
       runAnalysisForProject(project.id, analysisConfig)
         .then((result) => {
           console.log('Search analysis completed:', result.run_id)
-          setActiveProject({ 
-            ...project, 
-            status: 'completed',
-            run_id: result.run_id,
-            total_references: result.total_references,
-            relevant_references: result.relevant_references
-          })
         })
         .catch((error) => {
-          console.error('Search analysis failed:', error)
-          setActiveProject({ ...project, status: 'failed' })
+          console.error('Search analysis HTTP connection lost (backend may still be running):', error)
         })
 
       // Navigate to results immediately


### PR DESCRIPTION
## Description

Fixes a bug where users intermittently see a project stuck at 25-50% progress with a "failed" status, even though the backend analysis is still running without issue. Refreshing the page fixes it, but leads to users clicking off.

## Why This Bug Happens

When you start a search, two things happen almost simultaneously:

1. The search page fires off the analysis request to the backend
2. The browser immediately navigates to the project results page

The problem is that the analysis request is long running. If the HTTP connection drops for any reason (the browser tab is backgrounded, a network hiccup), the `.catch()` handler on the search page writes `status: 'failed'` into the Zustand store, which gets saved to localStorage.

When the project page loads, it reads the project status from the store, sees `"failed"`, and decides it does not need to poll the backend for updates. So the page just sits there showing a failed state, even though the backend is still happily crunching away.

Refreshing the page works because it fetches the real status from the database before deciding whether to poll.

## Changes Made

### 1. Stop the search page from writing terminal statuses (`search/page.tsx`)
- The `.then()` and `.catch()` handlers on `runAnalysisForProject` were writing `completed` / `failed` into the store
- Since the search page navigates away immediately (fire and forget), it should **not** be the one deciding the project's final status -> that is the project page's job via polling
- Now the handlers just log to console for debugging

### 2. Always verify status from the API before polling (`projects/[projectId]/page.tsx`)
- The polling effect used to read `activeProject.status` from the Zustand store to decide whether polling was needed
- If the store had stale `"failed"` data, polling would never start
- Now the effect always fetches the real status from the API first, which makes stale localStorage data harmless

### 3. Clean up the polling logic (`projects/[projectId]/page.tsx`)
- Extracted `fetchAndCheckStatus` and `startPolling` helpers to reduce duplicated code
- Added a safety check to prevent two polling loops from accidentally running at the same time
- Added error recovery: if the initial status verification fails (e.g. network blip), it falls back to the store status so polling can still start
- Avoided a duplicate API call on page load by letting verifyAndPoll handle the fetch for running projects instead of both functions fetching at the same time

## For Reviewers

### What to Focus On
- The `verifyAndPoll` function in the polling effect -- this is the core fix. Does the flow make sense?
- The error fallback logic: if the API call to verify status fails, we fall back to the store status. Is this the right trade-off?

### How to Test
1. Start a search that triggers a long running analysis
2. While the analysis is running, background the browser tab or simulate a network interruption
3. Navigate to the project page, it should show a loading/progress state and poll until the analysis finishes
4. Previously this would show "failed" and require a page refresh

### Files Changed
- `frontend/app/(main)/search/page.tsx` -- removed stale status writes
- `frontend/app/(main)/projects/[projectId]/page.tsx` -- API-first status verification before polling

## Checklist
- [x] Code has been tested locally
- [x] No local file dependencies
- [x] Changes are reasonably scoped (2 files, one bug fix)