### PR TITLE
Fix: Exec briefing refresh

### DIFF
--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -570,6 +570,8 @@ export default function ProjectResultsPage() {
             setIsPolling(false)
             hasStartedPollingRef.current = null
             await refreshData()
+            invalidateProjectCache(projectId)
+            summaryLoadedRef.current = null
           }
         } catch (error) {
           console.error('Failed to poll project status:', error)
@@ -643,8 +645,20 @@ export default function ProjectResultsPage() {
       setIsLoadingSummary(true)
       try {
         const data = await fetchWithAuth(`api/analysis-projects/${projectId}/summary`)
-        setSummaryData(data as SynthesisSummary)
-        setProjectCache('summary', projectId, data)
+        const summary = data as Partial<SynthesisSummary> | null
+        const hasBriefing = Boolean(
+          (typeof summary?.executive_briefing === 'string' && summary.executive_briefing.trim()) ||
+          summary?.structured_briefing
+        )
+
+        if (!hasBriefing) {
+          setSummaryData(null)
+          summaryLoadedRef.current = null
+          return
+        }
+
+        setSummaryData(summary as SynthesisSummary)
+        setProjectCache('summary', projectId, summary)
       } catch (err) {
         console.error('Failed to fetch summary data', err)
         setSummaryData(null)
@@ -655,7 +669,7 @@ export default function ProjectResultsPage() {
     }
     fetchSummary()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlTab, projectId])
+  }, [urlTab, projectId, analysisComplete])
 
   // Navigator stats for summary tab
   const [navigatorStats, setNavigatorStats] = useState({


### PR DESCRIPTION
**Description**  
Fixes the results-page state bug where the progress showed `100% Analysis completed` but the Executive Briefing remained on the “preparing” placeholder until a manual refresh.

### What changed
- Prevented caching of “not ready” summary responses.
- Reset summary fetch guards when polling detects project completion.
- Invalidated per-project cached data on completion so fresh summary data is fetched.
- Added `analysisComplete` as a dependency for summary fetching to trigger a refetch at the right time.

### Why this fixes it
The page could cache a placeholder/partial summary response and then skip refetching after completion. These changes ensure stale summary state is cleared and the real briefing is fetched as soon as synthesis completes.

### Safety
- Scoped to the current `projectId` only to avoid refreshing to non-active projects.
- Uses existing authenticated API calls and per-project cache keys.
- No cross-user/shared-state behaviour introduced.