### PR TITLE
Add results page tutorial

### DIFF
--- a/frontend/app/(main)/results/ExecutiveBriefing.tsx
+++ b/frontend/app/(main)/results/ExecutiveBriefing.tsx
@@ -372,6 +372,7 @@ function CitationLink({
   const linkElement = url ? (
     <a href={url} target="_blank" rel="noopener noreferrer" onClick={handleClick}
        data-tutorial="citation-link"
+       data-citation-inspectable={canInspectInContext ? 'true' : 'false'}
        className={`inline-flex items-center cursor-pointer font-medium transition-colors mx-0.5 ${
          isActiveCitation
            ? "bg-blue-700 text-white hover:text-white hover:bg-blue-800 rounded px-1.5 ring-1 ring-blue-800"
@@ -382,6 +383,7 @@ function CitationLink({
   ) : (
     <span onClick={handleClick}
           data-tutorial="citation-link"
+          data-citation-inspectable={canInspectInContext ? 'true' : 'false'}
           className={`inline-flex items-center font-medium mx-0.5 ${
             isActiveCitation
               ? "bg-blue-700 text-white rounded px-1.5 ring-1 ring-blue-800"

--- a/frontend/components/interventions/ThemeDetailView.tsx
+++ b/frontend/components/interventions/ThemeDetailView.tsx
@@ -425,7 +425,7 @@ export function ThemeDetailView({
   const hasRisks = riskThemes && riskThemes.length > 0
   
   return (
-    <div className="space-y-6">
+    <div data-tutorial="theme-detail-view" className="space-y-6">
       {/* Back button */}
       <div className="pb-1">
         <button

--- a/frontend/components/interventions/ThemeList.tsx
+++ b/frontend/components/interventions/ThemeList.tsx
@@ -138,6 +138,7 @@ export function ThemeList({
       {filteredAndSorted.map(theme => (
         <div
           key={theme.theme_name}
+          data-tutorial="intervention-theme-row"
           className="bg-white border border-gray-100 rounded-xl px-6 py-5 hover:bg-gray-50 hover:border-gray-200 transition-colors cursor-pointer"
           onClick={() => onSelectTheme(theme)}
           role="button"

--- a/frontend/components/results/ResultsTutorial.tsx
+++ b/frontend/components/results/ResultsTutorial.tsx
@@ -17,16 +17,26 @@ const SPOTLIGHT_PADDING = 10
 const CUTOUT_RADIUS = 8
 const TOOLTIP_WIDTH = 320
 const TOOLTIP_GAP = 16
-const STEP_RENDER_DELAY_MS = 300
+const STEP_RENDER_DELAY_MS = 250
+const STEP_TARGET_TIMEOUT_MS = 7000
+const STEP_QUERY_INTERVAL_MS = 120
 
 type Phase = 'idle' | 'intro' | 1 | 2 | 3 | 4
 type Placement = 'below' | 'above'
 
 interface StepConfig {
   selector: string
+  fallbackSelector?: string
   placement: Placement
   body: string
   primaryLabel: string
+  action?: (context: StepActionContext) => Promise<void>
+}
+
+interface StepActionContext {
+  onShowSummary: () => void
+  onShowEvidenceInterventions: () => void
+  onShowEvidenceDocuments: () => void
 }
 
 interface ResultsTutorialProps {
@@ -42,24 +52,48 @@ const STEPS: StepConfig[] = [
     placement: 'below',
     body: 'This card summarises the evidence behind your briefing, including source volume, evidence types, and geographic coverage.',
     primaryLabel: 'Next',
+    action: async ({ onShowSummary }) => {
+      onShowSummary()
+    },
   },
   {
-    selector: '[data-tutorial="citation-link"]',
+    selector: '[data-tutorial="citation-context-panel"]',
+    fallbackSelector: '[data-tutorial="citation-link"]',
     placement: 'below',
-    body: 'Citations are clickable and open a context panel with supporting quotes and document quality metadata.',
+    body: 'Citations are clickable. We have opened one now so you can see its context panel, supporting quote, and source quality details.',
     primaryLabel: 'Next',
+    action: async ({ onShowSummary }) => {
+      onShowSummary()
+      await sleep(STEP_RENDER_DELAY_MS)
+      const inspectableCitation = document.querySelector(
+        '[data-tutorial="citation-link"][data-citation-inspectable="true"]',
+      ) as HTMLElement | null
+      inspectableCitation?.click()
+    },
   },
   {
-    selector: '[data-tutorial="interventions-list"]',
+    selector: '[data-tutorial="theme-detail-view"]',
+    fallbackSelector: '[data-tutorial="interventions-list"]',
     placement: 'above',
-    body: 'Each intervention theme can be opened to view detailed outcomes, implementation considerations, and risk assessments.',
+    body: 'Intervention themes are clickable. We have opened one to show detailed outcomes, implementation considerations, and risk assessments.',
     primaryLabel: 'Next',
+    action: async ({ onShowEvidenceInterventions }) => {
+      onShowEvidenceInterventions()
+      const firstTheme = (await waitForSelector(
+        '[data-tutorial="intervention-theme-row"]',
+        2500,
+      )) as HTMLElement | null
+      firstTheme?.click()
+    },
   },
   {
     selector: '[data-tutorial="documents-table"]',
     placement: 'above',
     body: 'The Documents view contains the full evidence base, with relevance, evidence categories, and impact scores for each source.',
     primaryLabel: 'Done',
+    action: async ({ onShowEvidenceDocuments }) => {
+      onShowEvidenceDocuments()
+    },
   },
 ]
 
@@ -81,6 +115,16 @@ function setSeenFlag(): void {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForSelector(selector: string, timeoutMs: number = STEP_TARGET_TIMEOUT_MS): Promise<Element | null> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt <= timeoutMs) {
+    const element = document.querySelector(selector)
+    if (element) return element
+    await sleep(STEP_QUERY_INTERVAL_MS)
+  }
+  return null
 }
 
 function buildClipPath(rect: DOMRect): string {
@@ -208,35 +252,36 @@ export function ResultsTutorial({
 
   const prepareStepTarget = useCallback(
     async (step: 1 | 2 | 3 | 4): Promise<Element | null> => {
-      if (step === 1 || step === 2) {
-        onShowSummary()
-      } else if (step === 3) {
-        onShowEvidenceInterventions()
-      } else {
-        onShowEvidenceDocuments()
+      const config = STEPS[step - 1]
+      if (config.action) {
+        await config.action({
+          onShowSummary,
+          onShowEvidenceInterventions,
+          onShowEvidenceDocuments,
+        })
       }
-
       await sleep(STEP_RENDER_DELAY_MS)
-      return document.querySelector(STEPS[step - 1].selector)
+      const primaryTarget = await waitForSelector(config.selector)
+      if (primaryTarget) return primaryTarget
+      if (config.fallbackSelector) {
+        return waitForSelector(config.fallbackSelector, 2000)
+      }
+      return null
     },
     [onShowSummary, onShowEvidenceInterventions, onShowEvidenceDocuments],
   )
 
   const advanceTo = useCallback(
     async (step: 1 | 2 | 3 | 4) => {
-      for (let index = step; index <= 4; index += 1) {
-        const currentStep = index as 1 | 2 | 3 | 4
-        const el = await prepareStepTarget(currentStep)
-        if (!el) continue
-
-        await scrollToElement(el)
-
-        setTargetRect(el.getBoundingClientRect())
-        setPhase(currentStep)
+      const el = await prepareStepTarget(step)
+      if (!el) {
+        complete()
         return
       }
 
-      complete()
+      await scrollToElement(el)
+      setTargetRect(el.getBoundingClientRect())
+      setPhase(step)
     },
     [complete, prepareStepTarget],
   )

--- a/frontend/components/synthesis/CitationContextPanel.tsx
+++ b/frontend/components/synthesis/CitationContextPanel.tsx
@@ -387,6 +387,7 @@ export function CitationContextPanel({
 
   return (
     <aside
+      data-tutorial="citation-context-panel"
       className={`fixed inset-y-0 right-0 z-40 w-[30vw] min-w-[360px] max-w-[500px] border-l border-slate-200 bg-white shadow-xl transition-transform duration-300 ${
         isOpen ? "translate-x-0" : "translate-x-full"
       }`}


### PR DESCRIPTION
## Summary
- Introduces a first-run tutorial for the summary/evidence results experience.
- Adds tutorial targets across evidence card, citations, intervention list/detail, and documents table.
- Stabilises tutorial progression so steps do not skip during navigation/render transitions.

## Test plan
- [ ] Clear `localStorage` key `results_tutorial_seen`.
- [ ] Open a completed project and confirm tutorial appears once.
- [ ] Verify step 2 auto-opens citation context.
- [ ] Verify step 3 auto-opens an intervention theme detail.
- [ ] Verify step 4 lands on the documents table.
- [ ] Confirm tutorial can be skipped and does not reappear after completion.