### PR TITLE
feat: add initial screening question

### DIFF
--- a/backend/app/services/analysis/schemas.py
+++ b/backend/app/services/analysis/schemas.py
@@ -78,6 +78,7 @@ class SearchContext(BaseModel):
     max_results: Optional[int] = None
     additional_questions: List[str] = Field(default_factory=list)
     implementation_constraints: Optional[ImplementationConstraints] = None
+    user_type: Optional[str] = None
 
 
 # Search wizard API request/response schemas

--- a/backend/app/services/analysis/schemas.py
+++ b/backend/app/services/analysis/schemas.py
@@ -85,6 +85,7 @@ class SearchContext(BaseModel):
             "horizon_scan",
             "rapid_brief",
             "rapid_evidence_review",
+            "policy_note",
             "not_sure",
         ]
     ] = None

--- a/backend/app/services/analysis/schemas.py
+++ b/backend/app/services/analysis/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 
 class UnifiedReference(BaseModel):
@@ -78,7 +78,16 @@ class SearchContext(BaseModel):
     max_results: Optional[int] = None
     additional_questions: List[str] = Field(default_factory=list)
     implementation_constraints: Optional[ImplementationConstraints] = None
-    user_type: Optional[str] = None
+    # Collected for analytics; does not affect search behavior in alpha
+    user_type: Optional[
+        Literal[
+            "policy_blueprint",
+            "horizon_scan",
+            "rapid_brief",
+            "rapid_evidence_review",
+            "not_sure",
+        ]
+    ] = None
 
 
 # Search wizard API request/response schemas

--- a/backend/app/services/analysis/schemas.py
+++ b/backend/app/services/analysis/schemas.py
@@ -79,6 +79,7 @@ class SearchContext(BaseModel):
     additional_questions: List[str] = Field(default_factory=list)
     implementation_constraints: Optional[ImplementationConstraints] = None
     # Collected for analytics; does not affect search behavior in alpha
+    # Keep in sync with frontend/components/search/SearchWizard.tsx UseCase type
     use_case: Optional[
         Literal[
             "policy_blueprint",

--- a/backend/app/services/analysis/schemas.py
+++ b/backend/app/services/analysis/schemas.py
@@ -79,7 +79,7 @@ class SearchContext(BaseModel):
     additional_questions: List[str] = Field(default_factory=list)
     implementation_constraints: Optional[ImplementationConstraints] = None
     # Collected for analytics; does not affect search behavior in alpha
-    user_type: Optional[
+    use_case: Optional[
         Literal[
             "policy_blueprint",
             "horizon_scan",

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -28,9 +28,6 @@ export default function SearchPage() {
         parent_project_id: parentProjectId ?? undefined,
       })
 
-      // Reset wizard state so a fresh visit to /search starts clean
-      useWizard.getState().reset()
-
       // Set as active project
       setActiveProject(project)
 
@@ -125,6 +122,9 @@ export default function SearchPage() {
         .catch((error) => {
           console.error('Search analysis HTTP connection lost (backend may still be running):', error)
         })
+
+      // Reset wizard state so a fresh visit to /search starts clean
+      useWizard.getState().reset()
 
       // Navigate to results immediately
       router.push(`/projects/${project.id}`)

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -94,6 +94,7 @@ export default function SearchPage() {
         time_to: dateTo,
         max_results: context.maxResults,
         additional_questions: context.additionalQuestions,
+        user_type: context.userType ?? undefined,
         ...(hasImplementationConstraints
           ? { implementation_constraints: implementationConstraints }
           : {}),

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAPI } from '@/lib/api'
 import { useAnalysisProjectStore } from '@/lib/analysisProjectStore'
@@ -11,6 +11,14 @@ export default function SearchPage() {
   const { createAnalysisProject, runAnalysisForProject } = useAPI()
   const { setActiveProject } = useAnalysisProjectStore()
   const [isRunning, setIsRunning] = useState(false)
+
+  // Reset wizard on mount — but not if this is a refine visit
+  // (refine sets parentProjectId via initFromSearchQuery before navigating here)
+  useEffect(() => {
+    if (!useWizard.getState().parentProjectId) {
+      useWizard.getState().reset()
+    }
+  }, [])
 
   const handleRunAnalysis = async (context: SearchContext) => {
     // Prevent user initiating multiple analysis runs with the same search parameters
@@ -91,7 +99,7 @@ export default function SearchPage() {
         time_to: dateTo,
         max_results: context.maxResults,
         additional_questions: context.additionalQuestions,
-        user_type: context.userType ?? undefined,
+        use_case: context.useCase ?? undefined,
         ...(hasImplementationConstraints
           ? { implementation_constraints: implementationConstraints }
           : {}),
@@ -122,9 +130,6 @@ export default function SearchPage() {
         .catch((error) => {
           console.error('Search analysis HTTP connection lost (backend may still be running):', error)
         })
-
-      // Reset wizard state so a fresh visit to /search starts clean
-      useWizard.getState().reset()
 
       // Navigate to results immediately
       router.push(`/projects/${project.id}`)

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -48,7 +48,36 @@ const HelpHint = ({ content }: { content: React.ReactNode }) => (
 );
 
 // ---------------- TYPES & CONSTANTS ----------------
-type Step = "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "PARAMETERS" | "SCREENING" | "ADDITIONAL_QUESTIONS" | "SUMMARY";
+type Step = "USER_TYPE" | "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "PARAMETERS" | "SCREENING" | "ADDITIONAL_QUESTIONS" | "SUMMARY";
+type UserType = "policy_blueprint" | "horizon_scan" | "rapid_brief" | "rapid_evidence_review" | "not_sure";
+
+const USER_TYPE_OPTIONS: { value: UserType; label: string; description: string }[] = [
+  {
+    value: "policy_blueprint",
+    label: "A Policy Blueprint",
+    description: "generate a full report identifying specific interventions, extracting their outcomes, and ranking them by evidence strength and predicted impact.",
+  },
+  {
+    value: "horizon_scan",
+    label: "A Horizon Scan",
+    description: "An exec summary on a new policy area to get up to speed on a policy context and background.",
+  },
+  {
+    value: "rapid_brief",
+    label: "A Rapid Brief",
+    description: "A quick, evidenced answer to a policy-related question.",
+  },
+  {
+    value: "rapid_evidence_review",
+    label: "A Rapid Evidence Review",
+    description: "Search and summarise academic papers and grey literature for a particular policy area.",
+  },
+  {
+    value: "not_sure",
+    label: "I'm not sure",
+    description: "If you’re not sure, our search wizard will help you narrow down your policy question.",
+  },
+];
 type TimePreset = "LAST_YEAR" | "LAST_2_YEARS" | "LAST_5_YEARS" | "LAST_10_YEARS" | "SINCE_2000" | "ANY" | "CUSTOM";
 type Access = { academic: boolean; policy: boolean };
 const DEFAULT_SOURCES = ["openalex", "overton"] as const;
@@ -155,6 +184,7 @@ export type SearchContext = {
 // ---------------- STATE ----------------
 interface WizardState {
   step: Step;
+  userType: UserType | null;
   researchQuestion: string;
   population: { selected: string[]; noPreference: boolean };
   innerSetting: { selected: string[]; noPreference: boolean };
@@ -191,7 +221,8 @@ interface WizardState {
 }
 
 const INITIAL_WIZARD_STATE = {
-  step: "ASK" as Step,
+  step: "USER_TYPE" as Step,
+  userType: null as UserType | null,
   researchQuestion: "",
   population: { selected: [] as string[], noPreference: true },
   innerSetting: { selected: [] as string[], noPreference: true },
@@ -228,7 +259,7 @@ export const useWizard = create<WizardState>((set, get) => ({
   next: () => {
     const s = get();
     // Skip ADDITIONAL_QUESTIONS step - go directly from PARAMETERS to SUMMARY
-    const steps: Step[] = ["ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
+    const steps: Step[] = ["USER_TYPE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
     const currentIdx = steps.indexOf(s.step);
     if (currentIdx < steps.length - 1) {
       const nextStep = steps[currentIdx + 1];
@@ -243,7 +274,7 @@ export const useWizard = create<WizardState>((set, get) => ({
   back: () => {
     const s = get();
     // Skip ADDITIONAL_QUESTIONS step - go directly from SUMMARY to PARAMETERS
-    const steps: Step[] = ["ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
+    const steps: Step[] = ["USER_TYPE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
     const currentIdx = steps.indexOf(s.step);
     if (currentIdx > 0) {
       const prevStep = steps[currentIdx - 1];
@@ -374,6 +405,7 @@ function ProgressBar({
   allStepsVisited: boolean;
 }) {
   const steps: { id: Step; label: string }[] = [
+    { id: "USER_TYPE", label: "Use case" },
     { id: "ASK", label: "Question" },
     { id: "POPULATION", label: "Population" },
     { id: "INNER_SETTING", label: "Setting" },
@@ -512,6 +544,70 @@ function generateImpliedResearchQuestion(context: SearchContext): string {
 }
 
 // ---------------- SCREENS ----------------
+function ScreenUserType() {
+  const s = useWizard();
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-32">
+      <div className="flex items-center justify-center gap-3">
+          <h1 className="text-4xl font-bold tracking-tight">What would you like Policy Atlas to generate?</h1>
+          <Tooltip content={
+            <p className="max-w-xs">
+              Alpha means this is an early prototype with limited functionality. 
+              Features may be incomplete, unstable, or subject to change. 
+              We&apos;re actively developing and improving the tool.
+            </p>
+          }>
+            <Badge variant="default" className="text-sm bg-blue-600 hover:bg-blue-700 text-white font-semibold px-3 py-1 -mt-2">ALPHA</Badge>
+          </Tooltip>
+        </div>
+
+      <div className="max-w-2xl mx-auto">
+        <p className="max-w-2xl mx-auto mt-4 text-sm text-gray-500">
+        Policy atlas is designed to support a range of use cases, from quick evidence checks to in-depth policy reports. We&apos;d love to understand which of these you&apos;d find most useful - this will help us prioritise which features to build next.
+      </p>
+
+        {USER_TYPE_OPTIONS.map((option) => {
+          const isSelected = s.userType === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => s.set({ userType: option.value })}
+              className={cx(
+                "w-full text-left px-5 py-4 !my-2 rounded-xl transition ring-1 whitespace-normal break-words",
+                isSelected
+                  ? "bg-blue-600 !text-white ring-blue-600"
+                  : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
+              )}
+            >
+              <span className="font-medium">{option.label}</span>
+              {option.description && (
+                <span className={cx("block text-sm mt-1", isSelected ? "text-blue-100" : "text-gray-500")}>
+                  {option.description}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex justify-end items-center mt-6 max-w-2xl mx-auto">
+        <Button
+          variant="secondary"
+          className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
+          full
+          disabled={!s.userType}
+          onClick={() => s.set({ step: "ASK" })}
+        >
+          Continue
+        </Button>
+      </div>
+
+    </div>
+  );
+}
+
 function ScreenAsk() {
   const s = useWizard();
   const apis = useAPI();
@@ -1643,8 +1739,8 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
     context.parameters.customFrom > context.parameters.customTo;
 
   const isSummaryStep = s.step === "SUMMARY";
-  const showActionBar = s.step !== "ASK";
-  const showResearchQuestionContext = s.step !== "ASK" && !!trimmedResearchQuestion;
+  const showActionBar = s.step !== "ASK" && s.step !== "USER_TYPE";
+  const showResearchQuestionContext = s.step !== "ASK" && s.step !== "USER_TYPE" && !!trimmedResearchQuestion;
 
   const getPrimaryAction = () => {
     if (isSummaryStep) {
@@ -1695,6 +1791,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
         />
       )}
       <div className={isSummaryStep ? "" : "flex-1"}>
+        {s.step === "USER_TYPE" && <ScreenUserType />}
         {s.step === "ASK" && <ScreenAsk />}
         {s.step === "POPULATION" && <ScreenPopulation />}
         {s.step === "INNER_SETTING" && <ScreenInnerSetting />}

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -59,7 +59,7 @@ const USER_TYPE_OPTIONS: { value: UserType; label: string; tagline?: string; des
     value: "horizon_scan",
     label: "A Horizon Scan",
     tagline: "Explore an unfamiliar area",
-    description: "An executive summary mapping emerging themes and blind spots, best for getting up to speed on an unknown policy area.",
+    description: "An executive summary mapping emerging themes and blind spots, best for getting up to speed on an unfamiliar policy area.",
   },
   {
     value: "rapid_brief",
@@ -82,7 +82,7 @@ const USER_TYPE_OPTIONS: { value: UserType; label: string; tagline?: string; des
   {
     value: "rapid_evidence_review",
     label: "A Rapid Evidence Review",
-    tagline: "Deep evidence synthesis",
+    tagline: "Review the evidence in depth",
     description: "A deep evidence review synthesising findings across 100+ sources. Best for rigorous literature reviews and evidence mapping.",
   },
   {

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -55,22 +55,22 @@ const USER_TYPE_OPTIONS: { value: UserType; label: string; description: string }
   {
     value: "policy_blueprint",
     label: "A Policy Blueprint",
-    description: "A full report identifying specific interventions, extracting their outcomes, and ranking them by evidence strength and predicted impact.",
+    description: "A full report identifying interventions, extracting outcomes, and ranking them by evidence strength and predicted impact. Ideal for designing new strategies or major spend decisions.",
   },
   {
     value: "horizon_scan",
     label: "A Horizon Scan",
-    description: "An exec summary on a new policy area to get up to speed on a policy context and background.",
+    description: "An executive summary mapping emerging themes and blind spots, best for getting up to speed on unknown policy areas.",
   },
   {
     value: "rapid_brief",
     label: "A Rapid Brief",
-    description: "A quick, evidenced answer to a policy-related question.",
+    description: "A 1-page summary answering a specific question with key citations, perfect for urgent meeting prep or sense checking.",
   },
   {
     value: "rapid_evidence_review",
     label: "A Rapid Evidence Review",
-    description: "Search and summarise academic papers and grey literature for a particular policy area.",
+    description: "An exhaustive data extraction of 100+ sources, designed for deep-dive literature synthesis and rigorous evidence mapping.",
   },
   {
     value: "not_sure",
@@ -548,26 +548,27 @@ function ScreenUserType() {
   const s = useWizard();
 
   return (
-    <div className="max-w-4xl mx-auto space-y-8 p-8 pt-32">
-      <div className="flex items-center justify-center gap-3">
+    <div className="max-w-4xl mx-auto space-y-6 p-8 pt-32">
+      <div className="text-center space-y-3">
+        <div className="flex items-center justify-center gap-3">
           <h1 className="text-4xl font-bold tracking-tight">What would you like Policy Atlas to generate?</h1>
           <Tooltip content={
             <p className="max-w-xs">
-              Alpha means this is an early prototype with limited functionality. 
-              Features may be incomplete, unstable, or subject to change. 
+              Alpha means this is an early prototype with limited functionality.
+              Features may be incomplete, unstable, or subject to change.
               We&apos;re actively developing and improving the tool.
             </p>
           }>
             <Badge variant="default" className="text-sm bg-blue-600 hover:bg-blue-700 text-white font-semibold px-3 py-1 -mt-2">ALPHA</Badge>
           </Tooltip>
         </div>
+        <p className="max-w-2xl mx-auto text-sm text-gray-500">
+          Policy Atlas is designed to support a range of use cases, from quick evidence checks to in-depth policy reports. We&apos;re testing which outputs users find most valuable to help prioritise what to build next. This won&apos;t change your search flow or output in alpha.
+        </p>
+      </div>
 
-      <div className="max-w-2xl mx-auto">
-        <p className="max-w-2xl mx-auto mt-4 text-sm text-gray-500">
-        Policy atlas is designed to support a range of use cases, from quick evidence checks to in-depth policy reports. We&apos;d love to understand which of these you&apos;d find most useful - this will help us prioritise which features to build next.
-      </p>
-
-        {USER_TYPE_OPTIONS.map((option) => {
+      <div className="max-w-2xl mx-auto flex flex-col gap-3">
+        {USER_TYPE_OPTIONS.filter((o) => o.value !== "not_sure").map((option) => {
           const isSelected = s.userType === option.value;
           return (
             <button
@@ -575,9 +576,9 @@ function ScreenUserType() {
               type="button"
               onClick={() => s.set({ userType: option.value })}
               className={cx(
-                "w-full text-left px-5 py-4 !my-2 rounded-xl transition ring-1 whitespace-normal break-words",
+                "w-full text-left px-5 py-4 rounded-xl transition-all ring-1 whitespace-normal break-words hover:-translate-y-0.5 hover:shadow-md",
                 isSelected
-                  ? "bg-blue-600 !text-white ring-blue-600"
+                  ? "bg-blue-600 !text-white ring-blue-600 shadow-md"
                   : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
               )}
             >
@@ -590,6 +591,29 @@ function ScreenUserType() {
             </button>
           );
         })}
+
+        {/* "I'm not sure" as a distinct lighter option */}
+        {(() => {
+          const notSure = USER_TYPE_OPTIONS.find((o) => o.value === "not_sure")!;
+          const isSelected = s.userType === "not_sure";
+          return (
+            <button
+              type="button"
+              onClick={() => s.set({ userType: "not_sure" })}
+              className={cx(
+                "w-full text-center px-5 py-3 mt-4 rounded-xl transition-all ring-1 whitespace-normal break-words",
+                isSelected
+                  ? "bg-gray-700 !text-white ring-gray-700"
+                  : "bg-transparent text-gray-500 ring-gray-200 hover:bg-gray-50 hover:text-gray-700"
+              )}
+            >
+              <span className="font-medium">{notSure.label}</span>
+              <span className={cx("block text-sm mt-1", isSelected ? "text-gray-300" : "text-gray-400")}>
+                {notSure.description}
+              </span>
+            </button>
+          );
+        })()}
       </div>
 
       <div className="flex justify-end items-center mt-6 max-w-2xl mx-auto">
@@ -603,7 +627,6 @@ function ScreenUserType() {
           Continue
         </Button>
       </div>
-
     </div>
   );
 }

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -52,7 +52,9 @@ type Step = "USE_CASE" | "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "P
 const STEPS: Step[] = ["USE_CASE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
 /** Steps that appear before the research question is entered */
 const PRE_QUESTION_STEPS: ReadonlySet<Step> = new Set(["USE_CASE", "ASK"]);
+// Keep in sync with backend/app/services/analysis/schemas.py SearchContext.use_case
 type UseCase = "policy_blueprint" | "horizon_scan" | "rapid_brief" | "rapid_evidence_review" | "policy_note" | "not_sure";
+const VALID_USE_CASES: ReadonlySet<string> = new Set<UseCase>(["policy_blueprint", "horizon_scan", "rapid_brief", "rapid_evidence_review", "policy_note", "not_sure"]);
 
 const USE_CASE_OPTIONS: { value: UseCase; label: string; tagline?: string; description: string }[] = [
   {
@@ -331,7 +333,7 @@ export const useWizard = create<WizardState>((set, get) => ({
 
     set({
       step: "SUMMARY",
-      useCase: (sq.use_case as UseCase) || null,
+      useCase: VALID_USE_CASES.has(sq.use_case ?? "") ? (sq.use_case as UseCase) : null,
       researchQuestion: sq.research_question || sq.original_query || "",
       population: toSelection(population),
       innerSetting: toSelection(innerSetting),

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -48,47 +48,47 @@ const HelpHint = ({ content }: { content: React.ReactNode }) => (
 );
 
 // ---------------- TYPES & CONSTANTS ----------------
-type Step = "USER_TYPE" | "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "PARAMETERS" | "SCREENING" | "ADDITIONAL_QUESTIONS" | "SUMMARY";
-const STEPS: Step[] = ["USER_TYPE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
+type Step = "USE_CASE" | "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "PARAMETERS" | "SCREENING" | "ADDITIONAL_QUESTIONS" | "SUMMARY";
+const STEPS: Step[] = ["USE_CASE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
 /** Steps that appear before the research question is entered */
-const PRE_QUESTION_STEPS: ReadonlySet<Step> = new Set(["USER_TYPE", "ASK"]);
-type UserType = "policy_blueprint" | "horizon_scan" | "rapid_brief" | "rapid_evidence_review" | "policy_note" | "not_sure";
+const PRE_QUESTION_STEPS: ReadonlySet<Step> = new Set(["USE_CASE", "ASK"]);
+type UseCase = "policy_blueprint" | "horizon_scan" | "rapid_brief" | "rapid_evidence_review" | "policy_note" | "not_sure";
 
-const USER_TYPE_OPTIONS: { value: UserType; label: string; tagline?: string; description: string }[] = [
+const USE_CASE_OPTIONS: { value: UseCase; label: string; tagline?: string; description: string }[] = [
   {
     value: "horizon_scan",
-    label: "A Horizon Scan",
+    label: "Horizon Scan",
     tagline: "Explore an unfamiliar area",
-    description: "An executive summary mapping emerging themes and blind spots, best for getting up to speed on an unfamiliar policy area.",
+    description: "An overview of emerging themes, best for getting up to speed on an unfamiliar policy area.",
   },
   {
     value: "rapid_brief",
-    label: "A Rapid Brief",
+    label: "Rapid Brief",
     tagline: "Answer one question fast",
-    description: "A concise 1-page evidence brief answering a specific policy question, with key findings and citations. Best for urgent meeting prep, quick sense-checks, or getting up to speed fast.",
+    description: "A one-page evidence brief answering a specific policy question, with key findings and citations from the most relevant sources. Best for urgent prep or a quick sense-check.",
   },
   {
     value: "policy_note",
-    label: "A Policy Note",
+    label: "Policy Note",
     tagline: "Recommend a course of action",
-    description: "A three-page decision note structured around the problem, policy options, and a recommended course of action. Designed for senior review, with concise evidence, trade-offs, and clear rationale.",
+    description: "A three-page decision note setting out the problem, options and recommendations. Designed for senior review, with the most relevant evidence and trade-offs.",
   },
   {
     value: "policy_blueprint",
-    label: "A Policy Blueprint",
+    label: "Policy Blueprint",
     tagline: "Design a strategy",
-    description: "A full report comparing interventions and ranking them by evidence strength and likely impact. Ideal for designing strategies or informing major spend decisions.",
+    description: "A report ranking policy interventions by evidence strength and impact, based on comprehensive evidence. Ideal for designing strategies or informing major spend decisions.",
   },
   {
     value: "rapid_evidence_review",
-    label: "A Rapid Evidence Review",
-    tagline: "Review the evidence in depth",
-    description: "A deep evidence review synthesising findings across 100+ sources. Best for rigorous literature reviews and evidence mapping.",
+    label: "Rapid Evidence Review",
+    tagline: "Deep-dive into the literature",
+    description: "A rigorous synthesis of 100+ academic and grey literature sources on a policy question.",
   },
   {
     value: "not_sure",
     label: "I’m not sure",
-    description: "If you’re not sure, our search wizard will help you narrow down your policy question.",
+    description: "Our search wizard will help you narrow down your policy question.",
   },
 ];
 type TimePreset = "LAST_YEAR" | "LAST_2_YEARS" | "LAST_5_YEARS" | "LAST_10_YEARS" | "SINCE_2000" | "ANY" | "CUSTOM";
@@ -192,13 +192,13 @@ export type SearchContext = {
   screeningFactors: string[]; // Free text factors for screening
   additionalQuestions: string[]; // Additional research questions
   maxResults: number;
-  userType: UserType | null;
+  useCase: UseCase | null;
 };
 
 // ---------------- STATE ----------------
 interface WizardState {
   step: Step;
-  userType: UserType | null;
+  useCase: UseCase | null;
   researchQuestion: string;
   population: { selected: string[]; noPreference: boolean };
   innerSetting: { selected: string[]; noPreference: boolean };
@@ -235,8 +235,8 @@ interface WizardState {
 }
 
 const INITIAL_WIZARD_STATE = {
-  step: "USER_TYPE" as Step,
-  userType: null as UserType | null,
+  step: "USE_CASE" as Step,
+  useCase: null as UseCase | null,
   researchQuestion: "",
   population: { selected: [] as string[], noPreference: true },
   innerSetting: { selected: [] as string[], noPreference: true },
@@ -301,7 +301,7 @@ export const useWizard = create<WizardState>((set, get) => ({
       screeningFactors: s.screeningFactors,
       additionalQuestions: s.additionalQuestions,
       maxResults: s.maxResults,
-      userType: s.userType,
+      useCase: s.useCase,
     };
   },
   initFromSearchQuery: (sq: NonNullable<AnalysisProject['search_query']>, parentProjectId: string) => {
@@ -331,7 +331,7 @@ export const useWizard = create<WizardState>((set, get) => ({
 
     set({
       step: "SUMMARY",
-      userType: (sq.user_type as UserType) || null,
+      useCase: (sq.use_case as UseCase) || null,
       researchQuestion: sq.research_question || sq.original_query || "",
       population: toSelection(population),
       innerSetting: toSelection(innerSetting),
@@ -409,7 +409,7 @@ function ProgressBar({
   allStepsVisited: boolean;
 }) {
   const steps: { id: Step; label: string }[] = [
-    { id: "USER_TYPE", label: "Output" },
+    { id: "USE_CASE", label: "Output" },
     { id: "ASK", label: "Question" },
     { id: "POPULATION", label: "Population" },
     { id: "INNER_SETTING", label: "Setting" },
@@ -548,14 +548,14 @@ function generateImpliedResearchQuestion(context: SearchContext): string {
 }
 
 // ---------------- SCREENS ----------------
-function ScreenUserType() {
+function ScreenUseCase() {
   const s = useWizard();
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6 p-8 pt-32">
+    <div className="max-w-4xl mx-auto space-y-6 p-8 pt-20">
       <div className="text-center space-y-3">
         <div className="flex items-center justify-center gap-3">
-          <h1 className="text-4xl font-bold tracking-tight">What would you like Policy Atlas to generate?</h1>
+          <h1 className="text-4xl font-bold tracking-tight">How can Policy Atlas help?</h1>
           <Tooltip content={
             <p className="max-w-xs">
               Alpha means this is an early prototype with limited functionality.
@@ -566,27 +566,24 @@ function ScreenUserType() {
             <Badge variant="default" className="text-sm bg-blue-600 hover:bg-blue-700 text-white font-semibold px-3 py-1 -mt-2">ALPHA</Badge>
           </Tooltip>
         </div>
-        <p className="max-w-2xl mx-auto text-sm text-gray-500">
-          Policy Atlas supports a range of use cases, from quick evidence checks to in-depth policy reports. We&apos;re testing which outputs users find most valuable to help prioritise what to build next. This selection won&apos;t change your search flow or output in alpha.
-        </p>
       </div>
 
-      <div className="max-w-2xl mx-auto flex flex-col gap-3">
-        {USER_TYPE_OPTIONS.map((option) => {
-          const isSelected = s.userType === option.value;
+      <div className="max-w-3xl mx-auto flex flex-col gap-3">
+        {USE_CASE_OPTIONS.map((option) => {
+          const isSelected = s.useCase === option.value;
           const isNotSure = option.value === "not_sure";
           return (
             <button
               key={option.value}
               type="button"
-              onClick={() => s.set({ userType: option.value })}
+              onClick={() => s.set({ useCase: option.value })}
               className={cx(
-                "w-full px-5 rounded-xl transition-all ring-1 whitespace-normal break-words",
+                "w-full px-6 rounded-xl transition-all ring-1 whitespace-normal break-words",
                 isNotSure
                   ? cx("text-center py-3 mt-4", isSelected
                       ? "bg-gray-700 !text-white ring-gray-700"
                       : "bg-transparent text-gray-500 ring-gray-200 hover:bg-gray-50 hover:text-gray-700")
-                  : cx("text-left py-4 hover:-translate-y-0.5 hover:shadow-md", isSelected
+                  : cx("text-left py-5 hover:-translate-y-0.5 hover:shadow-md", isSelected
                       ? "bg-blue-600 !text-white ring-blue-600 shadow-md"
                       : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50")
               )}
@@ -601,7 +598,7 @@ function ScreenUserType() {
                 </span>
               )}
               <span className={cx(
-                "block text-sm mt-1",
+                "block text-sm mt-0.5",
                 isNotSure
                   ? (isSelected ? "text-gray-300" : "text-gray-400")
                   : (isSelected ? "text-blue-100" : "text-gray-500")
@@ -613,16 +610,17 @@ function ScreenUserType() {
         })}
       </div>
 
-      <div className="flex justify-end items-center mt-6 max-w-2xl mx-auto">
+      <div className="flex flex-col items-center gap-3 mt-6 max-w-3xl mx-auto">
         <Button
           variant="secondary"
           className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
           full
-          disabled={!s.userType}
+          disabled={!s.useCase}
           onClick={() => s.next()}
         >
           Continue
         </Button>
+        <p className="text-xs text-gray-400">We&apos;ll use your selection to prioritise new features. It won&apos;t affect today&apos;s results.</p>
       </div>
     </div>
   );
@@ -644,7 +642,7 @@ function ScreenAsk() {
     <div className="max-w-4xl mx-auto space-y-8 p-8 pt-32">
       <div className="text-center space-y-4">
         <div className="flex items-center justify-center gap-3">
-          <h1 className="text-4xl font-bold tracking-tight">Find evidence on policy interventions</h1>
+          <h1 className="text-4xl font-bold tracking-tight">What policy interventions are you exploring?</h1>
           <Tooltip content={
             <p className="max-w-xs">
               Alpha means this is an early prototype with limited functionality. 
@@ -1812,7 +1810,7 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
         />
       )}
       <div className={isSummaryStep ? "" : "flex-1"}>
-        {s.step === "USER_TYPE" && <ScreenUserType />}
+        {s.step === "USE_CASE" && <ScreenUseCase />}
         {s.step === "ASK" && <ScreenAsk />}
         {s.step === "POPULATION" && <ScreenPopulation />}
         {s.step === "INNER_SETTING" && <ScreenInnerSetting />}

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -49,6 +49,9 @@ const HelpHint = ({ content }: { content: React.ReactNode }) => (
 
 // ---------------- TYPES & CONSTANTS ----------------
 type Step = "USER_TYPE" | "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "PARAMETERS" | "SCREENING" | "ADDITIONAL_QUESTIONS" | "SUMMARY";
+const STEPS: Step[] = ["USER_TYPE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
+/** Steps that appear before the research question is entered */
+const PRE_QUESTION_STEPS: ReadonlySet<Step> = new Set(["USER_TYPE", "ASK"]);
 type UserType = "policy_blueprint" | "horizon_scan" | "rapid_brief" | "rapid_evidence_review" | "not_sure";
 
 const USER_TYPE_OPTIONS: { value: UserType; label: string; description: string }[] = [
@@ -259,32 +262,20 @@ export const useWizard = create<WizardState>((set, get) => ({
   reset: () => set({ ...INITIAL_WIZARD_STATE }),
   next: () => {
     const s = get();
-    // Skip ADDITIONAL_QUESTIONS step - go directly from PARAMETERS to SUMMARY
-    const steps: Step[] = ["USER_TYPE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
-    const currentIdx = steps.indexOf(s.step);
-    if (currentIdx < steps.length - 1) {
-      const nextStep = steps[currentIdx + 1];
+    const currentIdx = STEPS.indexOf(s.step);
+    if (currentIdx < STEPS.length - 1) {
+      const nextStep = STEPS[currentIdx + 1];
       // Skip ADDITIONAL_QUESTIONS - go directly to SUMMARY
-      if (nextStep === "ADDITIONAL_QUESTIONS") {
-        set({ step: "SUMMARY" });
-      } else {
-        set({ step: nextStep });
-      }
+      set({ step: nextStep === "ADDITIONAL_QUESTIONS" ? "SUMMARY" : nextStep });
     }
   },
   back: () => {
     const s = get();
-    // Skip ADDITIONAL_QUESTIONS step - go directly from SUMMARY to PARAMETERS
-    const steps: Step[] = ["USER_TYPE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
-    const currentIdx = steps.indexOf(s.step);
+    const currentIdx = STEPS.indexOf(s.step);
     if (currentIdx > 0) {
-      const prevStep = steps[currentIdx - 1];
+      const prevStep = STEPS[currentIdx - 1];
       // Skip ADDITIONAL_QUESTIONS - go directly to PARAMETERS
-      if (prevStep === "ADDITIONAL_QUESTIONS") {
-        set({ step: "PARAMETERS" });
-      } else {
-        set({ step: prevStep });
-      }
+      set({ step: prevStep === "ADDITIONAL_QUESTIONS" ? "PARAMETERS" : prevStep });
     }
   },
   buildContext: () => {
@@ -330,6 +321,7 @@ export const useWizard = create<WizardState>((set, get) => ({
 
     set({
       step: "SUMMARY",
+      userType: (sq.user_type as UserType) || null,
       researchQuestion: sq.research_question || sq.original_query || "",
       population: toSelection(population),
       innerSetting: toSelection(innerSetting),
@@ -570,52 +562,37 @@ function ScreenUserType() {
       </div>
 
       <div className="max-w-2xl mx-auto flex flex-col gap-3">
-        {USER_TYPE_OPTIONS.filter((o) => o.value !== "not_sure").map((option) => {
+        {USER_TYPE_OPTIONS.map((option) => {
           const isSelected = s.userType === option.value;
+          const isNotSure = option.value === "not_sure";
           return (
             <button
               key={option.value}
               type="button"
               onClick={() => s.set({ userType: option.value })}
               className={cx(
-                "w-full text-left px-5 py-4 rounded-xl transition-all ring-1 whitespace-normal break-words hover:-translate-y-0.5 hover:shadow-md",
-                isSelected
-                  ? "bg-blue-600 !text-white ring-blue-600 shadow-md"
-                  : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50"
+                "w-full px-5 rounded-xl transition-all ring-1 whitespace-normal break-words",
+                isNotSure
+                  ? cx("text-center py-3 mt-4", isSelected
+                      ? "bg-gray-700 !text-white ring-gray-700"
+                      : "bg-transparent text-gray-500 ring-gray-200 hover:bg-gray-50 hover:text-gray-700")
+                  : cx("text-left py-4 hover:-translate-y-0.5 hover:shadow-md", isSelected
+                      ? "bg-blue-600 !text-white ring-blue-600 shadow-md"
+                      : "bg-white text-gray-900 ring-gray-300 hover:bg-gray-50")
               )}
             >
               <span className="font-medium">{option.label}</span>
-              {option.description && (
-                <span className={cx("block text-sm mt-1", isSelected ? "text-blue-100" : "text-gray-500")}>
-                  {option.description}
-                </span>
-              )}
-            </button>
-          );
-        })}
-
-        {/* "I'm not sure" as a distinct lighter option */}
-        {(() => {
-          const notSure = USER_TYPE_OPTIONS.find((o) => o.value === "not_sure")!;
-          const isSelected = s.userType === "not_sure";
-          return (
-            <button
-              type="button"
-              onClick={() => s.set({ userType: "not_sure" })}
-              className={cx(
-                "w-full text-center px-5 py-3 mt-4 rounded-xl transition-all ring-1 whitespace-normal break-words",
-                isSelected
-                  ? "bg-gray-700 !text-white ring-gray-700"
-                  : "bg-transparent text-gray-500 ring-gray-200 hover:bg-gray-50 hover:text-gray-700"
-              )}
-            >
-              <span className="font-medium">{notSure.label}</span>
-              <span className={cx("block text-sm mt-1", isSelected ? "text-gray-300" : "text-gray-400")}>
-                {notSure.description}
+              <span className={cx(
+                "block text-sm mt-1",
+                isNotSure
+                  ? (isSelected ? "text-gray-300" : "text-gray-400")
+                  : (isSelected ? "text-blue-100" : "text-gray-500")
+              )}>
+                {option.description}
               </span>
             </button>
           );
-        })()}
+        })}
       </div>
 
       <div className="flex justify-end items-center mt-6 max-w-2xl mx-auto">
@@ -624,7 +601,7 @@ function ScreenUserType() {
           className="!bg-[#A5D6E1] !text-black hover:!bg-[#93c9d6] border-0 ring-0"
           full
           disabled={!s.userType}
-          onClick={() => s.set({ step: "ASK" })}
+          onClick={() => s.next()}
         >
           Continue
         </Button>
@@ -1764,8 +1741,9 @@ export default function SearchWizard({ onRunAnalysis, isRunning = false }: Searc
     context.parameters.customFrom > context.parameters.customTo;
 
   const isSummaryStep = s.step === "SUMMARY";
-  const showActionBar = s.step !== "ASK" && s.step !== "USER_TYPE";
-  const showResearchQuestionContext = s.step !== "ASK" && s.step !== "USER_TYPE" && !!trimmedResearchQuestion;
+  const isPastQuestionStep = !PRE_QUESTION_STEPS.has(s.step);
+  const showActionBar = isPastQuestionStep;
+  const showResearchQuestionContext = isPastQuestionStep && !!trimmedResearchQuestion;
 
   const getPrimaryAction = () => {
     if (isSummaryStep) {

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -55,7 +55,7 @@ const USER_TYPE_OPTIONS: { value: UserType; label: string; description: string }
   {
     value: "policy_blueprint",
     label: "A Policy Blueprint",
-    description: "generate a full report identifying specific interventions, extracting their outcomes, and ranking them by evidence strength and predicted impact.",
+    description: "A full report identifying specific interventions, extracting their outcomes, and ranking them by evidence strength and predicted impact.",
   },
   {
     value: "horizon_scan",

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -52,32 +52,42 @@ type Step = "USER_TYPE" | "ASK" | "POPULATION" | "INNER_SETTING" | "OUTCOME" | "
 const STEPS: Step[] = ["USER_TYPE", "ASK", "POPULATION", "INNER_SETTING", "OUTCOME", "SCREENING", "PARAMETERS", "ADDITIONAL_QUESTIONS", "SUMMARY"];
 /** Steps that appear before the research question is entered */
 const PRE_QUESTION_STEPS: ReadonlySet<Step> = new Set(["USER_TYPE", "ASK"]);
-type UserType = "policy_blueprint" | "horizon_scan" | "rapid_brief" | "rapid_evidence_review" | "not_sure";
+type UserType = "policy_blueprint" | "horizon_scan" | "rapid_brief" | "rapid_evidence_review" | "policy_note" | "not_sure";
 
-const USER_TYPE_OPTIONS: { value: UserType; label: string; description: string }[] = [
-  {
-    value: "policy_blueprint",
-    label: "A Policy Blueprint",
-    description: "A full report identifying interventions, extracting outcomes, and ranking them by evidence strength and predicted impact. Ideal for designing new strategies or major spend decisions.",
-  },
+const USER_TYPE_OPTIONS: { value: UserType; label: string; tagline?: string; description: string }[] = [
   {
     value: "horizon_scan",
     label: "A Horizon Scan",
-    description: "An executive summary mapping emerging themes and blind spots, best for getting up to speed on unknown policy areas.",
+    tagline: "Explore an unfamiliar area",
+    description: "An executive summary mapping emerging themes and blind spots, best for getting up to speed on an unknown policy area.",
   },
   {
     value: "rapid_brief",
     label: "A Rapid Brief",
-    description: "A 1-page summary answering a specific question with key citations, perfect for urgent meeting prep or sense checking.",
+    tagline: "Answer one question fast",
+    description: "A concise 1-page evidence brief answering a specific policy question, with key findings and citations. Best for urgent meeting prep, quick sense-checks, or getting up to speed fast.",
+  },
+  {
+    value: "policy_note",
+    label: "A Policy Note",
+    tagline: "Recommend a course of action",
+    description: "A three-page decision note structured around the problem, policy options, and a recommended course of action. Designed for senior review, with concise evidence, trade-offs, and clear rationale.",
+  },
+  {
+    value: "policy_blueprint",
+    label: "A Policy Blueprint",
+    tagline: "Design a strategy",
+    description: "A full report comparing interventions and ranking them by evidence strength and likely impact. Ideal for designing strategies or informing major spend decisions.",
   },
   {
     value: "rapid_evidence_review",
     label: "A Rapid Evidence Review",
-    description: "An exhaustive data extraction of 100+ sources, designed for deep-dive literature synthesis and rigorous evidence mapping.",
+    tagline: "Deep evidence synthesis",
+    description: "A deep evidence review synthesising findings across 100+ sources. Best for rigorous literature reviews and evidence mapping.",
   },
   {
     value: "not_sure",
-    label: "I'm not sure",
+    label: "I’m not sure",
     description: "If you’re not sure, our search wizard will help you narrow down your policy question.",
   },
 ];
@@ -399,7 +409,7 @@ function ProgressBar({
   allStepsVisited: boolean;
 }) {
   const steps: { id: Step; label: string }[] = [
-    { id: "USER_TYPE", label: "Use case" },
+    { id: "USER_TYPE", label: "Output" },
     { id: "ASK", label: "Question" },
     { id: "POPULATION", label: "Population" },
     { id: "INNER_SETTING", label: "Setting" },
@@ -582,6 +592,14 @@ function ScreenUserType() {
               )}
             >
               <span className="font-medium">{option.label}</span>
+              {option.tagline && (
+                <span className={cx(
+                  "ml-2 text-sm font-normal",
+                  isSelected ? "text-blue-200" : "text-gray-400"
+                )}>
+                  — {option.tagline}
+                </span>
+              )}
               <span className={cx(
                 "block text-sm mt-1",
                 isNotSure

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -179,6 +179,7 @@ export type SearchContext = {
   screeningFactors: string[]; // Free text factors for screening
   additionalQuestions: string[]; // Additional research questions
   maxResults: number;
+  userType: UserType | null;
 };
 
 // ---------------- STATE ----------------
@@ -299,6 +300,7 @@ export const useWizard = create<WizardState>((set, get) => ({
       screeningFactors: s.screeningFactors,
       additionalQuestions: s.additionalQuestions,
       maxResults: s.maxResults,
+      userType: s.userType,
     };
   },
   initFromSearchQuery: (sq: NonNullable<AnalysisProject['search_query']>, parentProjectId: string) => {

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -567,7 +567,7 @@ function ScreenUserType() {
           </Tooltip>
         </div>
         <p className="max-w-2xl mx-auto text-sm text-gray-500">
-          Policy Atlas is designed to support a range of use cases, from quick evidence checks to in-depth policy reports. We&apos;re testing which outputs users find most valuable to help prioritise what to build next. This won&apos;t change your search flow or output in alpha.
+          Policy Atlas supports a range of use cases, from quick evidence checks to in-depth policy reports. We&apos;re testing which outputs users find most valuable to help prioritise what to build next. This selection won&apos;t change your search flow or output in alpha.
         </p>
       </div>
 

--- a/frontend/lib/analysisProjectStore.ts
+++ b/frontend/lib/analysisProjectStore.ts
@@ -50,7 +50,7 @@ export interface AnalysisProject {
     custom_excludes?: string[]
     relevance_enabled?: boolean
     use_abstracts_only?: boolean
-    user_type?: string
+    use_case?: string
   }
   progress?: {
     stage_label: string

--- a/frontend/lib/analysisProjectStore.ts
+++ b/frontend/lib/analysisProjectStore.ts
@@ -50,6 +50,7 @@ export interface AnalysisProject {
     custom_excludes?: string[]
     relevance_enabled?: boolean
     use_abstracts_only?: boolean
+    user_type?: string
   }
   progress?: {
     stage_label: string

--- a/scripts/product_analytics/user_type_metrics.py
+++ b/scripts/product_analytics/user_type_metrics.py
@@ -1,0 +1,94 @@
+"""
+Query use_case selections from the analysis_projects table
+and output a bar chart of counts and percentages.
+
+Usage:
+    python scripts/product_analytics/user_type_metrics.py
+
+Requires SUPABASE_URL and SUPABASE_KEY environment variables
+(reads from backend/.env automatically).
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from supabase import create_client
+import matplotlib.pyplot as plt
+
+# Load env from backend/.env
+load_dotenv(Path(__file__).resolve().parents[2] / "backend" / ".env")
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_KEY")
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    print("Error: SUPABASE_URL and SUPABASE_KEY must be set (check backend/.env)")
+    sys.exit(1)
+
+supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+# Only include projects created after use_case was deployed (2026-04-10)
+USE_CASE_DEPLOY_DATE = "2026-04-10T00:00:00"
+
+response = (
+    supabase.table("analysis_projects")
+    .select("search_query, created_at")
+    .not_.is_("search_query", "null")
+    .gte("created_at", USE_CASE_DEPLOY_DATE)
+    .execute()
+)
+
+# Extract use_case values
+use_cases = []
+for row in response.data:
+    sq = row.get("search_query") or {}
+    uc = sq.get("use_case")
+    use_cases.append(uc if uc else "not_set")
+
+# Count occurrences
+from collections import Counter
+
+counts = Counter(use_cases)
+total = sum(counts.values())
+
+# Print table
+print(f"\n{'Use Case':<30} {'Count':>6} {'Percentage':>10}")
+print("-" * 48)
+for label, count in counts.most_common():
+    pct = (count / total) * 100 if total else 0
+    print(f"{label:<30} {count:>6} {pct:>9.1f}%")
+print("-" * 48)
+print(f"{'Total':<30} {total:>6}")
+
+# Bar chart
+labels = [k for k, _ in counts.most_common()]
+values = [v for _, v in counts.most_common()]
+percentages = [(v / total) * 100 for v in values]
+
+fig, ax1 = plt.subplots(figsize=(10, 5))
+
+bars = ax1.bar(labels, values, color="#3B82F6", alpha=0.8)
+ax1.set_ylabel("Count")
+ax1.set_xlabel("Use Case")
+ax1.set_title("Use Case Selections")
+
+# Add percentage labels on bars
+for bar, pct in zip(bars, percentages):
+    ax1.text(
+        bar.get_x() + bar.get_width() / 2,
+        bar.get_height() + 0.3,
+        f"{pct:.1f}%",
+        ha="center",
+        va="bottom",
+        fontsize=10,
+    )
+
+plt.xticks(rotation=30, ha="right")
+plt.tight_layout()
+
+output_path = Path(__file__).parent / "use_case_chart.png"
+plt.savefig(output_path, dpi=150)
+print(f"\nChart saved to {output_path}")
+plt.show()


### PR DESCRIPTION
This PR adds an initial screening question to the search journey, asking how users want to use Policy Atlas. this will hopefully let us gather some data on:

- which of the use cases we’ve defined are our current users most interested in
- whether users are able to understand the use cases we’ve outlined and self-define as fitting into one of those categories up front

Right now, this question is not imported into the db when a user completes the journey, we’re planning to just monitor which options are selected using posthog, however we may change this approach.