### PR TITLE
Fix: truncate project title to prevent DB insert failure

### DIFF
--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -28,7 +28,7 @@ export default function SearchPage() {
     try {
       // Read refine state from wizard store
       const { parentProjectId } = useWizard.getState()
-      const baseTitle = (context.researchQuestion || 'New Analysis Project').replace(/ \(refined\)$/, '')
+      const baseTitle = (context.researchQuestion || 'New Analysis Project').replace(/ \(refined\)$/, '').slice(0, 240)
 
       // Create analysis project from search context
       const project = await createAnalysisProject({


### PR DESCRIPTION
## Description

Long research questions were causing "Failed to start analysis" errors because the project title (derived from the research question) exceeded the `analysis_projects.title` VARCHAR(255) column limit.

Adds `.slice(0, 240)` to truncate the title before insert. The 240 limit leaves room for the " (refined)" suffix. The full research question is still passed untruncated in the search context.