### PR TITLE
Upgrade chatbot to GPT-5.4 Responses API with streaming and metadata

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -115,8 +115,8 @@ class Settings(BaseSettings):
     LLM_MODEL: str = "gpt-4o-mini"
     LLM_TEMPERATURE: float = 0.7
     LLM_MAX_TOKENS: int = 4000
-    CHATBOT_MODEL: str = "gpt-4o-mini"
-    CHATBOT_REASONING_EFFORT: str = "minimal"
+    CHATBOT_MODEL: str = "gpt-5.4"
+    CHATBOT_REASONING_EFFORT: str = "medium"
 
     # Boolean Query Generation Settings
     BOOLEAN_QUERY_GENERATION_MODE: str = "multi"  # "single" or "multi"

--- a/backend/app/services/chatbot/__init__.py
+++ b/backend/app/services/chatbot/__init__.py
@@ -3,9 +3,10 @@ Chatbot service module for RAG-based chat functionality.
 """
 
 from .chat_service import ChatbotService
-from .models import ChatRequest, ChatResponse
+from .models import AnswerMetadata, ChatRequest, ChatResponse
 
 __all__ = [
+    "AnswerMetadata",
     "ChatbotService",
     "ChatRequest",
     "ChatResponse",

--- a/backend/app/services/chatbot/chat_service.py
+++ b/backend/app/services/chatbot/chat_service.py
@@ -21,6 +21,7 @@ from app.services.synthesis.schemas import (
 )
 from app.services.vectorization import vectorization_service
 from .models import (
+    AnswerMetadata,
     ChatEvent,
     ChatRequest,
     ChatResponse,
@@ -203,6 +204,8 @@ class ChatbotService:
                         message=response.message,
                         references=response.references,
                         activity_summary=response.activity_summary,
+                        answer_metadata=response.answer_metadata,
+                        response_id=response.response_id,
                     )
                 )
             except Exception:
@@ -251,10 +254,12 @@ class ChatbotService:
             input_items,
             tool_handlers,
             instructions=instructions,
+            previous_response_id=request.previous_response_id,
             steps=steps,
             emit_event=emit_event,
         )
         final_content = self._extract_assistant_text(final_message)
+        response_id = getattr(final_message, "response_id", None)
         has_final_content = bool(final_content)
         if not has_final_content:
             final_content = EMPTY_ASSISTANT_FALLBACK
@@ -276,12 +281,15 @@ class ChatbotService:
             final_content = self._strip_unresolved_internal_citations(final_content)
 
         activity_summary = self._build_activity_summary(steps, references)
+        answer_metadata = self._build_answer_metadata(turn_state, references)
 
         return ChatResponse(
             message=final_content,
             references=references,
             steps=steps,
             activity_summary=activity_summary,
+            answer_metadata=answer_metadata,
+            response_id=response_id,
         )
 
     def _get_ordered_references(
@@ -301,6 +309,45 @@ class ChatbotService:
         return (
             f"Used {action_count} action{'s' if action_count != 1 else ''} "
             f"and {source_count} source{'s' if source_count != 1 else ''}"
+        )
+
+    def _build_answer_metadata(
+        self,
+        turn_state: ChatTurnState,
+        references: List[DocumentReference],
+    ) -> AnswerMetadata:
+        """Compute structured metadata about sources used in the answer.
+
+        Args:
+            turn_state: The mutable state accumulated during this chat turn.
+            references: The final list of cited document references.
+
+        Returns:
+            Populated AnswerMetadata with source counts and date range.
+        """
+        evidence_doc_ids = set(turn_state.evidence_reference_numbers.keys())
+        parliament_doc_ids = set(turn_state.parliament_reference_numbers.keys())
+
+        evidence_count = sum(
+            1 for ref in references if ref.document_id in evidence_doc_ids
+        )
+        parliament_count = sum(
+            1 for ref in references if ref.document_id in parliament_doc_ids
+        )
+
+        years = [ref.year for ref in references if ref.year is not None]
+        date_range = None
+        if years:
+            min_year, max_year = min(years), max(years)
+            date_range = (
+                str(min_year) if min_year == max_year else f"{min_year}\u2013{max_year}"
+            )
+
+        return AnswerMetadata(
+            source_count=len(references),
+            evidence_source_count=evidence_count,
+            parliament_source_count=parliament_count,
+            date_range=date_range,
         )
 
     def _truncate_for_label(self, value: str, max_chars: int = 60) -> str:
@@ -880,7 +927,7 @@ class ChatbotService:
                 result = (
                     vectorization_service.supabase.table("analysis_documents")
                     .select(
-                        "id, doc_id, title, authors, doi, overton_url, source_country, year, published_on"
+                        "id, doc_id, title, authors, doi, overton_url, landing_page_url, pdf_url, source_country, year, published_on"
                     )
                     .in_("id", document_ids)
                     .execute()
@@ -910,6 +957,10 @@ class ChatbotService:
                         "document_authors": doc_details.get("authors", []),
                         "document_doi": doc_details.get("doi"),
                         "document_overton_url": doc_details.get("overton_url"),
+                        "document_landing_page_url": doc_details.get(
+                            "landing_page_url"
+                        ),
+                        "document_pdf_url": doc_details.get("pdf_url"),
                         "document_source_country": doc_details.get("source_country"),
                         "document_published_date": published_date,
                         "document_year": doc_details.get("year"),
@@ -966,6 +1017,7 @@ class ChatbotService:
         tool_handlers: Dict[str, Callable],
         *,
         instructions: Optional[str] = None,
+        previous_response_id: Optional[str] = None,
         steps: Optional[List[ChatStep]] = None,
         emit_event: Optional[EventEmitter] = None,
     ) -> Any:
@@ -979,11 +1031,26 @@ class ChatbotService:
 
         for iteration in range(MAX_AGENT_ITERATIONS):
             logger.info("[chatbot] Agent loop iteration %d", iteration + 1)
-            response = await self._create_response(
-                input_items, instructions=instructions
-            )
+            iter_prev_id = previous_response_id if iteration == 0 else None
+
+            if emit_event:
+                response = await self._create_streaming_response(
+                    input_items,
+                    instructions=instructions,
+                    previous_response_id=iter_prev_id,
+                    emit_event=emit_event,
+                )
+            else:
+                response = await self._create_response(
+                    input_items,
+                    instructions=instructions,
+                    previous_response_id=iter_prev_id,
+                )
+
             function_calls = [
-                item for item in response.output if item.type == "function_call"
+                item
+                for item in response.output
+                if getattr(item, "type", None) == "function_call"
             ]
 
             if not function_calls:
@@ -1007,7 +1074,11 @@ class ChatbotService:
                     len(assistant_text),
                     assistant_text[:200],
                 )
-                return SimpleNamespace(content=assistant_text, tool_calls=None)
+                return SimpleNamespace(
+                    content=assistant_text,
+                    tool_calls=None,
+                    response_id=getattr(response, "id", None),
+                )
 
             await self._complete_step(active_status_step, emit_event)
 
@@ -1124,14 +1195,144 @@ class ChatbotService:
             active_status_step=active_status_step,
         )
 
+    async def _create_streaming_response(
+        self,
+        input_items: List[Any],
+        *,
+        instructions: Optional[str] = None,
+        tool_choice: Optional[str] = None,
+        previous_response_id: Optional[str] = None,
+        emit_event: Optional[EventEmitter] = None,
+    ) -> SimpleNamespace:
+        """Stream a response, emitting message.delta events for text output.
+
+        Handles both text and function-call responses. Text tokens are
+        emitted as `message.delta` events for progressive rendering.
+        Function calls are collected silently.
+
+        Args:
+            input_items: Conversation input items to send.
+            instructions: System-level instructions for the model.
+            tool_choice: Constrain tool selection (e.g. "none").
+            previous_response_id: Responses API cache key for multi-turn context.
+            emit_event: Callback to emit streaming delta events.
+
+        Returns:
+            SimpleNamespace mimicking the non-streaming response shape:
+            output (list of items), output_text (str), and id (str).
+        """
+        request_kwargs: Dict[str, Any] = {
+            "model": settings.CHATBOT_MODEL,
+            "input": input_items,
+            "tools": TOOL_DEFINITIONS,
+            "max_output_tokens": CHATBOT_MAX_COMPLETION_TOKENS,
+            "stream": True,
+        }
+
+        if instructions is not None:
+            request_kwargs["instructions"] = instructions
+
+        if tool_choice is not None:
+            request_kwargs["tool_choice"] = tool_choice
+
+        if previous_response_id is not None:
+            request_kwargs["previous_response_id"] = previous_response_id
+
+        model_name = settings.CHATBOT_MODEL
+        if model_name.startswith("gpt-5"):
+            request_kwargs["reasoning"] = {
+                "effort": settings.CHATBOT_REASONING_EFFORT,
+            }
+        else:
+            request_kwargs["temperature"] = settings.LLM_TEMPERATURE
+
+        try:
+            stream = await self.openai_client.responses.create(**request_kwargs)
+        except Exception:
+            if previous_response_id is not None:
+                logger.warning(
+                    "[chatbot] previous_response_id failed in streaming; retrying without cache"
+                )
+                request_kwargs.pop("previous_response_id", None)
+                stream = await self.openai_client.responses.create(**request_kwargs)
+            else:
+                raise
+
+        full_text = ""
+        response_id = None
+        output_items: List[Any] = []
+
+        fc_args_buffers: Dict[str, str] = {}
+
+        async for event in stream:
+            event_type = getattr(event, "type", None)
+
+            if event_type == "response.output_text.delta":
+                delta = getattr(event, "delta", "")
+                if delta and emit_event:
+                    await emit_event(ChatEvent(type="message.delta", message=delta))
+                full_text += delta
+
+            elif event_type == "response.output_item.added":
+                item = getattr(event, "item", None)
+                if item:
+                    output_items.append(item)
+                    if getattr(item, "type", None) == "function_call":
+                        fc_args_buffers[getattr(item, "call_id", "")] = ""
+
+            elif event_type == "response.function_call_arguments.delta":
+                call_id = getattr(event, "call_id", "")
+                if call_id in fc_args_buffers:
+                    fc_args_buffers[call_id] += getattr(event, "delta", "")
+
+            elif event_type == "response.output_item.done":
+                item = getattr(event, "item", None)
+                if item:
+                    idx = next(
+                        (
+                            i
+                            for i, o in enumerate(output_items)
+                            if getattr(o, "call_id", None)
+                            == getattr(item, "call_id", None)
+                            and getattr(o, "type", None) == "function_call"
+                        ),
+                        None,
+                    )
+                    if idx is not None:
+                        output_items[idx] = item
+
+            elif event_type == "response.completed":
+                resp = getattr(event, "response", None)
+                if resp:
+                    response_id = getattr(resp, "id", None)
+                    completed_output = getattr(resp, "output", None)
+                    if completed_output:
+                        output_items = list(completed_output)
+
+        return SimpleNamespace(
+            output=output_items,
+            output_text=full_text,
+            id=response_id,
+        )
+
     async def _create_response(
         self,
         input_items: List[Any],
         *,
         instructions: Optional[str] = None,
         tool_choice: Optional[str] = None,
+        previous_response_id: Optional[str] = None,
     ) -> Any:
-        """Create a response using the Responses API with the configured chatbot model."""
+        """Create a response using the Responses API with the configured chatbot model.
+
+        Args:
+            input_items: Conversation input items to send.
+            instructions: System-level instructions for the model.
+            tool_choice: Constrain tool selection (e.g. "none").
+            previous_response_id: Responses API cache key for multi-turn
+                context. Falls back to full input if the cached response
+                has been evicted.
+        """
         request_kwargs: Dict[str, Any] = {
             "model": settings.CHATBOT_MODEL,
             "input": input_items,
@@ -1145,6 +1346,9 @@ class ChatbotService:
         if tool_choice is not None:
             request_kwargs["tool_choice"] = tool_choice
 
+        if previous_response_id is not None:
+            request_kwargs["previous_response_id"] = previous_response_id
+
         model_name = settings.CHATBOT_MODEL
         if model_name.startswith("gpt-5"):
             request_kwargs["reasoning"] = {
@@ -1153,7 +1357,16 @@ class ChatbotService:
         else:
             request_kwargs["temperature"] = settings.LLM_TEMPERATURE
 
-        return await self.openai_client.responses.create(**request_kwargs)
+        try:
+            return await self.openai_client.responses.create(**request_kwargs)
+        except Exception:
+            if previous_response_id is not None:
+                logger.warning(
+                    "[chatbot] previous_response_id failed; retrying without cache"
+                )
+                request_kwargs.pop("previous_response_id", None)
+                return await self.openai_client.responses.create(**request_kwargs)
+            raise
 
     async def _request_final_answer(
         self,
@@ -1176,18 +1389,32 @@ class ChatbotService:
         retry_input = input_items + [
             {"role": "user", "content": FINAL_ANSWER_RETRY_PROMPT}
         ]
-        response = await self._create_response(
-            retry_input,
-            instructions=instructions,
-            tool_choice="none",
-        )
+
+        if emit_event:
+            response = await self._create_streaming_response(
+                retry_input,
+                instructions=instructions,
+                tool_choice="none",
+                emit_event=emit_event,
+            )
+        else:
+            response = await self._create_response(
+                retry_input,
+                instructions=instructions,
+                tool_choice="none",
+            )
+
         assistant_text = response.output_text
         await self._complete_step(
             active_status_step,
             emit_event,
             summary="Answer drafted" if assistant_text else None,
         )
-        return SimpleNamespace(content=assistant_text, tool_calls=None)
+        return SimpleNamespace(
+            content=assistant_text,
+            tool_calls=None,
+            response_id=getattr(response, "id", None),
+        )
 
     def _extract_assistant_text(self, message: Any) -> str:
         """Normalize assistant content into a plain text string."""
@@ -1296,11 +1523,13 @@ class ChatbotService:
         self,
         doi: Optional[str],
         overton_url: Optional[str],
+        landing_page_url: Optional[str] = None,
+        pdf_url: Optional[str] = None,
     ) -> Optional[str]:
         """Build a reference URL from DOI metadata or an existing document URL."""
         if doi:
             return f"https://doi.org/{doi}" if not doi.startswith("http") else doi
-        return overton_url
+        return overton_url or landing_page_url or pdf_url
 
     def _build_references(
         self, chunks: List[Dict[str, Any]]
@@ -1442,7 +1671,12 @@ class ChatbotService:
         """Build a single document reference from an enriched evidence chunk."""
         doi = chunk.get("document_doi")
         overton_url = chunk.get("document_overton_url")
-        url = self._build_document_url(doi, overton_url)
+        url = self._build_document_url(
+            doi,
+            overton_url,
+            landing_page_url=chunk.get("document_landing_page_url"),
+            pdf_url=chunk.get("document_pdf_url"),
+        )
 
         return DocumentReference(
             document_id=chunk.get("document_id", f"chunk-{id(chunk)}"),

--- a/backend/app/services/chatbot/chat_service.py
+++ b/backend/app/services/chatbot/chat_service.py
@@ -79,56 +79,53 @@ TOOL_LABELS = {
 TOOL_DEFINITIONS = [
     {
         "type": "function",
-        "function": {
-            "name": "get_project_synthesis",
-            "description": "Fetch the project's synthesised evidence summary for high-level questions about what works, main findings, top interventions, or recommendations.",
-            "parameters": {
-                "type": "object",
-                "properties": {},
-            },
+        "name": "get_project_synthesis",
+        "description": "Fetch the project's synthesised evidence summary for high-level questions about what works, main findings, top interventions, or recommendations.",
+        "parameters": {
+            "type": "object",
+            "properties": {},
         },
+        "strict": False,
     },
     {
         "type": "function",
-        "function": {
-            "name": "search_project_evidence",
-            "description": "Search the project's collected research documents and policy evidence for information relevant to the query.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "The search query to find relevant evidence.",
-                    },
+        "name": "search_project_evidence",
+        "description": "Search the project's collected research documents and policy evidence for information relevant to the query.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query to find relevant evidence.",
                 },
-                "required": ["query"],
             },
+            "required": ["query"],
         },
+        "strict": False,
     },
     {
         "type": "function",
-        "function": {
-            "name": "search_parliament",
-            "description": "Search UK Parliament records including Hansard debates, contributions, written statements, written answers, and answered written parliamentary questions. Use short specific keyword queries rather than full sentences.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "The search query for parliamentary records.",
-                    },
-                    "date_from": {
-                        "type": "string",
-                        "description": "Start date filter in YYYY-MM-DD format.",
-                    },
-                    "date_to": {
-                        "type": "string",
-                        "description": "End date filter in YYYY-MM-DD format.",
-                    },
+        "name": "search_parliament",
+        "description": "Search UK Parliament records including Hansard debates, contributions, written statements, written answers, and answered written parliamentary questions. Use short specific keyword queries rather than full sentences.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query for parliamentary records.",
                 },
-                "required": ["query"],
+                "date_from": {
+                    "type": "string",
+                    "description": "Start date filter in YYYY-MM-DD format.",
+                },
+                "date_to": {
+                    "type": "string",
+                    "description": "End date filter in YYYY-MM-DD format.",
+                },
             },
+            "required": ["query"],
         },
+        "strict": False,
     },
 ]
 
@@ -242,26 +239,18 @@ class ChatbotService:
         steps: List[ChatStep] = []
 
         project_title = await self._get_project_title(project_id)
+        instructions = self._build_system_prompt(project_title)
 
-        # Build messages
-        messages: List[Dict[str, Any]] = [
-            {
-                "role": "system",
-                "content": self._build_system_prompt(project_title),
-            },
-        ]
-
-        # Add conversation history
+        input_items: List[Any] = []
         if request.recent_messages:
             for msg in request.recent_messages[-5:]:
-                messages.append({"role": msg.role.value, "content": msg.content})
+                input_items.append({"role": msg.role.value, "content": msg.content})
+        input_items.append({"role": "user", "content": request.message})
 
-        messages.append({"role": "user", "content": request.message})
-
-        # Run agent loop
         final_message = await self._run_agent_loop(
-            messages,
+            input_items,
             tool_handlers,
+            instructions=instructions,
             steps=steps,
             emit_event=emit_event,
         )
@@ -973,13 +962,14 @@ class ChatbotService:
 
     async def _run_agent_loop(
         self,
-        messages: List[Dict[str, Any]],
+        input_items: List[Any],
         tool_handlers: Dict[str, Callable],
         *,
+        instructions: Optional[str] = None,
         steps: Optional[List[ChatStep]] = None,
         emit_event: Optional[EventEmitter] = None,
     ) -> Any:
-        """Run the tool-calling agent loop. Returns the final assistant message."""
+        """Run the tool-calling agent loop via the Responses API."""
         step_list = steps if steps is not None else []
         active_status_step = await self._start_status_step(
             step_list,
@@ -989,18 +979,23 @@ class ChatbotService:
 
         for iteration in range(MAX_AGENT_ITERATIONS):
             logger.info("[chatbot] Agent loop iteration %d", iteration + 1)
-            response = await self._create_chat_completion(messages)
-            assistant_message = response.choices[0].message
+            response = await self._create_response(
+                input_items, instructions=instructions
+            )
+            function_calls = [
+                item for item in response.output if item.type == "function_call"
+            ]
 
-            if not assistant_message.tool_calls:
-                assistant_text = self._extract_assistant_text(assistant_message)
+            if not function_calls:
+                assistant_text = response.output_text
                 if not assistant_text:
                     logger.warning(
                         "[chatbot] Empty final response after iteration %d; retrying without tools",
                         iteration + 1,
                     )
                     return await self._request_final_answer(
-                        messages,
+                        input_items,
+                        instructions=instructions,
                         steps=step_list,
                         emit_event=emit_event,
                         active_status_step=active_status_step,
@@ -1016,32 +1011,14 @@ class ChatbotService:
 
             await self._complete_step(active_status_step, emit_event)
 
-            # Append assistant message (with tool_calls) to conversation
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": assistant_message.content,
-                    "tool_calls": [
-                        {
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                        }
-                        for tc in assistant_message.tool_calls
-                    ],
-                }
-            )
+            input_items.extend(response.output)
 
-            # Execute each tool call
-            for tool_call in assistant_message.tool_calls:
-                tool_name = tool_call.function.name
+            for fc in function_calls:
+                tool_name = fc.name
                 handler = tool_handlers.get(tool_name)
 
                 try:
-                    kwargs = self._parse_tool_arguments(tool_call.function.arguments)
+                    kwargs = self._parse_tool_arguments(fc.arguments)
                 except Exception as exc:
                     logger.warning(
                         "[chatbot] Failed to parse tool arguments for %s: %s",
@@ -1061,11 +1038,11 @@ class ChatbotService:
                         emit_event,
                         summary="Tool failed",
                     )
-                    messages.append(
+                    input_items.append(
                         {
-                            "role": "tool",
-                            "tool_call_id": tool_call.id,
-                            "content": failure_reason,
+                            "type": "function_call_output",
+                            "call_id": fc.call_id,
+                            "output": failure_reason,
                         }
                     )
                     continue
@@ -1073,7 +1050,7 @@ class ChatbotService:
                 logger.info(
                     "[chatbot] Tool call: %s(%s)",
                     tool_name,
-                    tool_call.function.arguments,
+                    fc.arguments,
                 )
                 step = await self._start_tool_step(
                     step_list,
@@ -1124,11 +1101,11 @@ class ChatbotService:
                     len(tool_result.content),
                     tool_result.content[:300],
                 )
-                messages.append(
+                input_items.append(
                     {
-                        "role": "tool",
-                        "tool_call_id": tool_call.id,
-                        "content": tool_result.content,
+                        "type": "function_call_output",
+                        "call_id": fc.call_id,
+                        "output": tool_result.content,
                     }
                 )
 
@@ -1138,44 +1115,51 @@ class ChatbotService:
                 emit_event,
             )
 
-        # Hit iteration cap — force one last plain-text answer.
         logger.warning("[chatbot] Hit agent iteration cap; forcing final answer")
         return await self._request_final_answer(
-            messages,
+            input_items,
+            instructions=instructions,
             steps=step_list,
             emit_event=emit_event,
             active_status_step=active_status_step,
         )
 
-    async def _create_chat_completion(
+    async def _create_response(
         self,
-        messages: List[Dict[str, Any]],
+        input_items: List[Any],
         *,
+        instructions: Optional[str] = None,
         tool_choice: Optional[str] = None,
     ) -> Any:
-        """Create a chat completion using the configured chatbot model."""
+        """Create a response using the Responses API with the configured chatbot model."""
         request_kwargs: Dict[str, Any] = {
             "model": settings.CHATBOT_MODEL,
-            "messages": messages,
+            "input": input_items,
             "tools": TOOL_DEFINITIONS,
-            "max_completion_tokens": CHATBOT_MAX_COMPLETION_TOKENS,
+            "max_output_tokens": CHATBOT_MAX_COMPLETION_TOKENS,
         }
-        model_name = settings.CHATBOT_MODEL
+
+        if instructions is not None:
+            request_kwargs["instructions"] = instructions
 
         if tool_choice is not None:
             request_kwargs["tool_choice"] = tool_choice
 
+        model_name = settings.CHATBOT_MODEL
         if model_name.startswith("gpt-5"):
-            request_kwargs["reasoning_effort"] = settings.CHATBOT_REASONING_EFFORT
+            request_kwargs["reasoning"] = {
+                "effort": settings.CHATBOT_REASONING_EFFORT,
+            }
         else:
             request_kwargs["temperature"] = settings.LLM_TEMPERATURE
 
-        return await self.openai_client.chat.completions.create(**request_kwargs)
+        return await self.openai_client.responses.create(**request_kwargs)
 
     async def _request_final_answer(
         self,
-        messages: List[Dict[str, Any]],
+        input_items: List[Any],
         *,
+        instructions: Optional[str] = None,
         steps: Optional[List[ChatStep]] = None,
         emit_event: Optional[EventEmitter] = None,
         active_status_step: Optional[ChatStep] = None,
@@ -1189,15 +1173,15 @@ class ChatbotService:
                 emit_event,
             )
 
-        retry_messages = messages + [
+        retry_input = input_items + [
             {"role": "user", "content": FINAL_ANSWER_RETRY_PROMPT}
         ]
-        response = await self._create_chat_completion(
-            retry_messages,
+        response = await self._create_response(
+            retry_input,
+            instructions=instructions,
             tool_choice="none",
         )
-        assistant_message = response.choices[0].message
-        assistant_text = self._extract_assistant_text(assistant_message)
+        assistant_text = response.output_text
         await self._complete_step(
             active_status_step,
             emit_event,

--- a/backend/app/services/chatbot/models.py
+++ b/backend/app/services/chatbot/models.py
@@ -26,6 +26,7 @@ class ChatRequest(BaseModel):
 
     message: str = Field(..., min_length=1, max_length=2000)
     recent_messages: Optional[List[ChatMessage]] = Field(default=None, max_length=10)
+    previous_response_id: Optional[str] = None
 
 
 class DocumentReference(BaseModel):
@@ -40,6 +41,15 @@ class DocumentReference(BaseModel):
     relevance_score: Optional[float] = None
     published_date: Optional[str] = None
     year: Optional[int] = None
+
+
+class AnswerMetadata(BaseModel):
+    """Structured metadata about the sources behind an answer."""
+
+    source_count: int = 0
+    evidence_source_count: int = 0
+    parliament_source_count: int = 0
+    date_range: Optional[str] = None
 
 
 class ChatStep(BaseModel):
@@ -62,11 +72,14 @@ class ChatEvent(BaseModel):
         "tool.failed",
         "message.completed",
         "message.failed",
+        "message.delta",
     ]
     step: Optional[ChatStep] = None
     message: Optional[str] = None
     references: List[DocumentReference] = Field(default_factory=list)
     activity_summary: Optional[str] = None
+    answer_metadata: Optional[AnswerMetadata] = None
+    response_id: Optional[str] = None
     error: Optional[str] = None
 
 
@@ -77,4 +90,6 @@ class ChatResponse(BaseModel):
     references: List[DocumentReference] = Field(default_factory=list)
     steps: List[ChatStep] = Field(default_factory=list)
     activity_summary: Optional[str] = None
+    answer_metadata: Optional[AnswerMetadata] = None
+    response_id: Optional[str] = None
     context_used: Optional[str] = None  # For debugging

--- a/backend/app/services/chatbot/prompts.py
+++ b/backend/app/services/chatbot/prompts.py
@@ -19,9 +19,11 @@ TOOL_STRATEGY_RULES = [
     "For mixed evidence and Parliament questions, cover the evidence side and the Parliament side separately.",
     "Use specific policy-topic queries rather than generic search phrases.",
     "If a tool returns no relevant results, tell the user the evidence base does not cover that topic. Do not fall back to general knowledge.",
+    "When the user's question is a follow-up that references prior conversation context (e.g. 'What about X?', 'And in rural areas?'), incorporate the relevant context from the conversation history into your tool search queries. For example, if the previous question was about housing interventions and the follow-up asks 'What about rural areas?', search for 'rural housing interventions' rather than just 'rural areas'.",
 ]
 
 EVIDENCE_STANDARDS = [
+    "IMPORTANT — RESPONSE DEPTH: Your users are policy professionals who need substantive, well-evidenced answers. Write thorough, detailed responses that extract the maximum useful information from every retrieved source. A typical answer should be 500-800 words. For complex or multi-source questions, aim higher. Do not summarise a source in one sentence when it contains several relevant findings — unpack each one. Include specific findings, data points, effect sizes, mechanisms, comparisons, and contextual detail wherever the sources provide them.",
     "Answer the user's question directly, then provide supporting detail drawn from the retrieved sources.",
     "Every factual statement must be traceable to a specific retrieved source. If you cannot cite a source for a claim, do not make it.",
     "Cite each source you draw on using [N] inline citations. Prefer citing multiple sources to strengthen a point rather than relying on a single source.",
@@ -33,7 +35,8 @@ EVIDENCE_STANDARDS = [
     "Treat committee evidence, inquiry submissions, expert testimony, and similar policy documents as contextual or expert input, not as equivalent to an empirical impact study.",
     "For Parliament material, do not claim Parliament proposed, endorsed, resolved, or is actively pursuing an action unless that is explicit in the retrieved record.",
     "Do not infer ongoing discussion, broad support, momentum, or policy intent from a single parliamentary record.",
-    "Scale response length to the complexity of the question and the amount of relevant evidence retrieved: a simple factual question may need 100-200 words, while a broad evidence summary should use 300-500 words.",
+    "End your answer with a brief confidence qualifier in italics on its own line, reflecting how well-grounded the answer is. Examples: *Based on 4 directly relevant sources.* or *Limited coverage — based on 1 partially relevant source.* The qualifier should reflect the number of sources cited and whether they are direct or indirect evidence.",
+    'After the confidence qualifier, suggest 2-3 brief follow-up questions the user could ask to explore the evidence further. Format them as a bulleted list under a "**Follow-up questions:**" heading.',
 ]
 
 CITATION_RULES = [
@@ -44,6 +47,7 @@ CITATION_RULES = [
 
 FINAL_ANSWER_RULES = [
     "Do not call any more tools.",
+    "IMPORTANT — RESPONSE DEPTH: Write a thorough, detailed answer of 500-800 words. Extract the maximum useful information from every retrieved source — include specific findings, data points, effect sizes, mechanisms, and contextual detail rather than brief one-sentence summaries.",
     "Base your answer only on the retrieved material already in this conversation. Do not add facts, figures, or claims from your training data.",
     "If the retrieved material does not adequately cover the user's question, say so clearly.",
     "Respond with plain text and cite only sources you actually mention using [1] style citations.",
@@ -51,8 +55,9 @@ FINAL_ANSWER_RULES = [
     "Do not add a 'Sources', 'Sources cited', or 'References' section.",
     "Start with the bottom line in the first sentence, but do not use a 'Bottom line:' label.",
     "If headings are used, only use 'Evidence' and 'Parliament'.",
-    "Scale response length to the question: short factual answers can be 100-200 words; broad or multi-source answers should be 300-500 words.",
-    "Do not add recap sections, policy implications, next steps, or follow-up offers unless the user asked for that.",
+    "Do not add recap sections, policy implications, or next steps unless the user asked for that.",
+    "End your answer with a brief confidence qualifier in italics on its own line, e.g. *Based on 3 directly relevant sources.* or *Limited coverage — based on 1 partially relevant source.*",
+    'After the confidence qualifier, suggest 2-3 brief follow-up questions as a bulleted list under a "**Follow-up questions:**" heading.',
 ]
 
 SYNTHESIS_SOURCE_NOTE = (

--- a/backend/app/services/chatbot/prompts.py
+++ b/backend/app/services/chatbot/prompts.py
@@ -12,23 +12,28 @@ TOOL_GUIDANCE = [
 ]
 
 TOOL_STRATEGY_RULES = [
-    "Use a relevant tool before answering; do not answer from memory alone.",
+    "Always use a relevant tool before answering. Never answer a factual question from memory or training data alone.",
     "For high-level evidence questions, start with get_project_synthesis.",
     "If synthesis is unavailable or the user wants study-level detail, use search_project_evidence.",
     "If the user asks about Parliament, ministers, or government positions, use search_parliament.",
     "For mixed evidence and Parliament questions, cover the evidence side and the Parliament side separately.",
     "Use specific policy-topic queries rather than generic search phrases.",
+    "If a tool returns no relevant results, tell the user the evidence base does not cover that topic. Do not fall back to general knowledge.",
 ]
 
 EVIDENCE_STANDARDS = [
-    "Answer the user's question directly and synthesize overlapping sources.",
+    "Answer the user's question directly, then provide supporting detail drawn from the retrieved sources.",
+    "Every factual statement must be traceable to a specific retrieved source. If you cannot cite a source for a claim, do not make it.",
+    "Cite each source you draw on using [N] inline citations. Prefer citing multiple sources to strengthen a point rather than relying on a single source.",
     "Distinguish direct evidence from indirect or contextual evidence.",
-    "If the project does not contain direct evidence on the exact question, say so explicitly.",
+    "If the project does not contain direct evidence on the exact question, say so explicitly and clearly. Do not attempt to answer from general knowledge instead.",
+    "If only partial evidence exists, describe what the evidence does cover and identify what is missing.",
     "Do not describe an intervention as effective, beneficial, supported, promising, or likely to work unless the retrieved material directly supports that claim.",
     'Do not write phrases like "this suggests X would work" when X lacks direct evidence in the project.',
     "Treat committee evidence, inquiry submissions, expert testimony, and similar policy documents as contextual or expert input, not as equivalent to an empirical impact study.",
     "For Parliament material, do not claim Parliament proposed, endorsed, resolved, or is actively pursuing an action unless that is explicit in the retrieved record.",
     "Do not infer ongoing discussion, broad support, momentum, or policy intent from a single parliamentary record.",
+    "Scale response length to the complexity of the question and the amount of relevant evidence retrieved: a simple factual question may need 100-200 words, while a broad evidence summary should use 300-500 words.",
 ]
 
 CITATION_RULES = [
@@ -39,13 +44,15 @@ CITATION_RULES = [
 
 FINAL_ANSWER_RULES = [
     "Do not call any more tools.",
+    "Base your answer only on the retrieved material already in this conversation. Do not add facts, figures, or claims from your training data.",
+    "If the retrieved material does not adequately cover the user's question, say so clearly.",
     "Respond with plain text and cite only sources you actually mention using [1] style citations.",
     "Do not mention tool names, retrieval labels, section names, or 'Document N'.",
     "Do not add a 'Sources', 'Sources cited', or 'References' section.",
     "Start with the bottom line in the first sentence, but do not use a 'Bottom line:' label.",
     "If headings are used, only use 'Evidence' and 'Parliament'.",
-    "Keep mixed evidence and Parliament answers under about 220 words unless the user asked for detail.",
-    "Do not add recap sections, policy implications, next steps, cited documents, or follow-up offers unless the user asked for that.",
+    "Scale response length to the question: short factual answers can be 100-200 words; broad or multi-source answers should be 300-500 words.",
+    "Do not add recap sections, policy implications, next steps, or follow-up offers unless the user asked for that.",
 ]
 
 SYNTHESIS_SOURCE_NOTE = (
@@ -83,8 +90,9 @@ def _build_project_context(project_title: Optional[str]) -> str:
 def build_chatbot_system_prompt(project_title: Optional[str] = None) -> str:
     """Compose the chatbot system prompt from smaller named sections."""
     sections = [
-        "You are a policy research assistant that helps users understand evidence from academic documents and policy research.",
-        "You have access to tools to retrieve project evidence and policy context. Use the relevant tools before answering.",
+        "You are a policy research assistant used by civil servants in government. Your role is to help users understand evidence that has been collected in this project. Trust and accuracy are paramount.",
+        "GROUNDING RULE: Every factual claim in your answer MUST be supported by material retrieved through your tools. Do not use your training data to fill gaps, speculate, or supplement the retrieved evidence. If the retrieved sources do not contain information to answer a question, say so clearly rather than attempting an answer. It is always better to say the evidence base does not cover something than to risk providing inaccurate information.",
+        "You have access to tools to retrieve project evidence and policy context. Always use the relevant tools before answering.",
         _build_project_context(project_title),
         _render_bullet_section("TOOLS:", TOOL_GUIDANCE),
         _render_bullet_section("TOOL STRATEGY:", TOOL_STRATEGY_RULES),
@@ -97,7 +105,7 @@ def build_chatbot_system_prompt(project_title: Optional[str] = None) -> str:
 def build_final_answer_retry_prompt() -> str:
     """Build the plain-text fallback prompt used after the tool loop."""
     sections = [
-        "Answer the user's original question now using only the retrieved material already in this conversation.",
+        "Answer the user's original question now using only the retrieved material already in this conversation. Do not supplement with information from your training data. If the retrieved material does not cover the question, say so.",
         _render_bullet_section("FINAL ANSWER RULES:", FINAL_ANSWER_RULES),
     ]
     return "\n\n".join(section for section in sections if section)

--- a/backend/test/test_chatbot_tools.py
+++ b/backend/test/test_chatbot_tools.py
@@ -16,7 +16,7 @@ def _make_text_response(content: str = "Here is my answer."):
     message_item = SimpleNamespace(
         type="message", role="assistant", content=[text_part]
     )
-    return SimpleNamespace(output=[message_item], output_text=content)
+    return SimpleNamespace(output=[message_item], output_text=content, id="resp_test")
 
 
 def _make_tool_call_response(tool_name: str, arguments: dict, call_id: str = "call_1"):
@@ -28,6 +28,65 @@ def _make_tool_call_response(tool_name: str, arguments: dict, call_id: str = "ca
         arguments=json.dumps(arguments),
     )
     return SimpleNamespace(output=[fc_item], output_text="")
+
+
+class _AsyncIter:
+    """Minimal async iterable wrapping a list of stream events."""
+
+    def __init__(self, events):
+        self._events = events
+        self._index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._events):
+            raise StopAsyncIteration
+        event = self._events[self._index]
+        self._index += 1
+        return event
+
+
+def _make_streaming_tool_call_response(
+    tool_name: str, arguments: dict, call_id: str = "call_1"
+):
+    """Build a fake streaming response that yields function-call events."""
+    fc_item = SimpleNamespace(
+        type="function_call",
+        call_id=call_id,
+        name=tool_name,
+        arguments=json.dumps(arguments),
+    )
+    return _AsyncIter(
+        [
+            SimpleNamespace(type="response.output_item.added", item=fc_item),
+            SimpleNamespace(type="response.output_item.done", item=fc_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(id="resp_stream", output=[fc_item]),
+            ),
+        ]
+    )
+
+
+def _make_streaming_text_response(content: str = "Here is my answer."):
+    """Build a fake streaming response that yields text delta events."""
+    text_item = SimpleNamespace(type="message", role="assistant")
+    events = [
+        SimpleNamespace(type="response.output_item.added", item=text_item),
+    ]
+    for word in content.split(" "):
+        events.append(
+            SimpleNamespace(type="response.output_text.delta", delta=word + " ")
+        )
+    events.append(
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(id="resp_stream", output=[text_item]),
+        )
+    )
+    return _AsyncIter(events)
 
 
 @pytest.mark.asyncio
@@ -295,8 +354,10 @@ async def test_agent_loop_emits_progress_steps():
     service = ChatbotService()
     fake_create = AsyncMock(
         side_effect=[
-            _make_tool_call_response("search_project_evidence", {"query": "housing"}),
-            _make_text_response("Based on the evidence..."),
+            _make_streaming_tool_call_response(
+                "search_project_evidence", {"query": "housing"}
+            ),
+            _make_streaming_text_response("Based on the evidence..."),
         ]
     )
     service._openai_client = SimpleNamespace(
@@ -322,7 +383,7 @@ async def test_agent_loop_emits_progress_steps():
         emit_event=collect,
     )
 
-    assert result.content == "Based on the evidence..."
+    assert "Based on the evidence" in result.content
     assert [step.label for step in steps] == [
         "Understanding your question",
         'Searching project evidence for "housing"',
@@ -334,14 +395,12 @@ async def test_agent_loop_emits_progress_steps():
         "completed",
     ]
     assert steps[1].summary == "2 relevant documents found"
-    assert [event.type for event in events] == [
-        "agent.status",
-        "agent.status",
-        "tool.started",
-        "tool.completed",
-        "agent.status",
-        "agent.status",
-    ]
+
+    event_types = [event.type for event in events]
+    assert "agent.status" in event_types
+    assert "tool.started" in event_types
+    assert "tool.completed" in event_types
+    assert "message.delta" in event_types
 
 
 @pytest.mark.asyncio

--- a/backend/test/test_chatbot_tools.py
+++ b/backend/test/test_chatbot_tools.py
@@ -11,22 +11,23 @@ from app.services.chatbot.parliament import search_parliament
 
 
 def _make_text_response(content: str = "Here is my answer."):
-    """Build a plain-text fake chat completion response."""
-    message = SimpleNamespace(content=content, tool_calls=None)
-    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    """Build a plain-text fake Responses API response."""
+    text_part = SimpleNamespace(type="output_text", text=content)
+    message_item = SimpleNamespace(
+        type="message", role="assistant", content=[text_part]
+    )
+    return SimpleNamespace(output=[message_item], output_text=content)
 
 
 def _make_tool_call_response(tool_name: str, arguments: dict, call_id: str = "call_1"):
-    """Build a fake chat completion response that requests one tool call."""
-    tool_call = SimpleNamespace(
-        id=call_id,
-        function=SimpleNamespace(
-            name=tool_name,
-            arguments=json.dumps(arguments),
-        ),
+    """Build a fake Responses API response that requests one function call."""
+    fc_item = SimpleNamespace(
+        type="function_call",
+        call_id=call_id,
+        name=tool_name,
+        arguments=json.dumps(arguments),
     )
-    message = SimpleNamespace(content=None, tool_calls=[tool_call])
-    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    return SimpleNamespace(output=[fc_item], output_text="")
 
 
 @pytest.mark.asyncio
@@ -244,13 +245,13 @@ async def test_agent_loop_executes_tool_and_loops():
         ]
     )
     service._openai_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        responses=SimpleNamespace(create=fake_create)
     )
 
     mock_handler = AsyncMock(return_value="Evidence about housing found.")
 
     result = await service._run_agent_loop(
-        messages=[{"role": "user", "content": "Tell me about housing"}],
+        input_items=[{"role": "user", "content": "Tell me about housing"}],
         tool_handlers={"search_project_evidence": mock_handler},
     )
 
@@ -272,13 +273,13 @@ async def test_agent_loop_retries_with_tool_choice_none_after_empty_final_turn()
         ]
     )
     service._openai_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        responses=SimpleNamespace(create=fake_create)
     )
 
     mock_handler = AsyncMock(return_value="Evidence about housing found.")
 
     result = await service._run_agent_loop(
-        messages=[{"role": "user", "content": "Tell me about housing"}],
+        input_items=[{"role": "user", "content": "Tell me about housing"}],
         tool_handlers={"search_project_evidence": mock_handler},
     )
 
@@ -299,7 +300,7 @@ async def test_agent_loop_emits_progress_steps():
         ]
     )
     service._openai_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        responses=SimpleNamespace(create=fake_create)
     )
 
     mock_handler = AsyncMock(
@@ -315,7 +316,7 @@ async def test_agent_loop_emits_progress_steps():
         events.append(event)
 
     result = await service._run_agent_loop(
-        messages=[{"role": "user", "content": "Tell me about housing"}],
+        input_items=[{"role": "user", "content": "Tell me about housing"}],
         tool_handlers={"search_project_evidence": mock_handler},
         steps=steps,
         emit_event=collect,
@@ -355,14 +356,14 @@ async def test_agent_loop_can_call_get_project_synthesis(monkeypatch):
         ]
     )
     service._openai_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        responses=SimpleNamespace(create=fake_create)
     )
 
     mock_get_synthesis = AsyncMock(return_value="HEADLINE\nUseful synthesis text.")
     monkeypatch.setattr(service, "_get_project_synthesis", mock_get_synthesis)
 
     result = await service._run_agent_loop(
-        messages=[{"role": "user", "content": "What works overall?"}],
+        input_items=[{"role": "user", "content": "What works overall?"}],
         tool_handlers=service._build_tool_handlers("proj-1"),
     )
 
@@ -407,7 +408,7 @@ async def test_chat_full_loop_with_evidence_tool(monkeypatch):
         ]
     )
     service._openai_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        responses=SimpleNamespace(create=fake_create)
     )
 
     response = await service.chat(
@@ -469,7 +470,7 @@ async def test_chat_full_loop_with_both_tools(monkeypatch):
         ]
     )
     service._openai_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        responses=SimpleNamespace(create=fake_create)
     )
 
     response = await service.chat(
@@ -500,7 +501,7 @@ async def test_chat_handles_tool_error_gracefully(monkeypatch):
         ]
     )
     service._openai_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        responses=SimpleNamespace(create=fake_create)
     )
 
     response = await service.chat("proj-1", ChatRequest(message="test"))

--- a/frontend/app/(main)/projects/[projectId]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/page.tsx
@@ -1157,7 +1157,7 @@ export default function ProjectResultsPage() {
 
         {/* Show results tabs */}
         {projectId && !error && (
-          <Tabs value={urlTab} onValueChange={handleTabChange} className="flex flex-col">
+          <Tabs value={urlTab} onValueChange={handleTabChange} className="flex flex-1 min-h-0 flex-col">
             <div className="px-6 pt-4">
               <TabsList className="!grid w-full grid-cols-3">
                 <TabsTrigger value="summary" className="flex items-center gap-2">
@@ -1175,7 +1175,7 @@ export default function ProjectResultsPage() {
               </TabsList>
             </div>
 
-            <div>
+            <div className="flex flex-1 min-h-0 flex-col">
               <TabsContent value="summary" className="p-6 m-0">
                 <div className="max-w-6xl mx-auto">
                   {/* Stat Cards Row */}
@@ -1388,7 +1388,7 @@ export default function ProjectResultsPage() {
                 </div>
               </TabsContent>
 
-              <TabsContent value="assistant" className="m-0 h-[600px]">
+              <TabsContent value="assistant" className="m-0 flex-1 min-h-0">
                 <ChatInterface 
                   autoFocus={urlTab === 'assistant'}
                   placeholder="Ask about the evidence in this project..."

--- a/frontend/components/chatbot/ChatInterface.tsx
+++ b/frontend/components/chatbot/ChatInterface.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Send, Bot, User, ExternalLink, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react'
 import {
   useChatStore,
+  AnswerMetadata,
   ChatMessage,
   ChatStep,
   ChatStreamEvent,
@@ -83,6 +84,41 @@ function getCurrentStep(steps: ChatStep[] | undefined): ChatStep | undefined {
   return undefined
 }
 
+function formatAnswerMetadata(metadata: AnswerMetadata): string {
+  const parts: string[] = []
+  if (metadata.evidence_source_count > 0) {
+    parts.push(`${metadata.evidence_source_count} evidence source${metadata.evidence_source_count !== 1 ? 's' : ''}`)
+  }
+  if (metadata.parliament_source_count > 0) {
+    parts.push(`${metadata.parliament_source_count} parliamentary record${metadata.parliament_source_count !== 1 ? 's' : ''}`)
+  }
+  if (parts.length === 0 && metadata.source_count > 0) {
+    parts.push(`${metadata.source_count} source${metadata.source_count !== 1 ? 's' : ''}`)
+  }
+  let result = parts.join(', ')
+  if (metadata.date_range) {
+    result += ` | Evidence from ${metadata.date_range}`
+  }
+  return result
+}
+
+const FOLLOW_UP_HEADING_RE = /\*\*Follow-up questions:?\*\*\s*/i
+const FOLLOW_UP_ITEM_RE = /^[-*]\s+(.+)/gm
+
+function extractFollowUpQuestions(content: string): string[] {
+  const headingMatch = content.match(FOLLOW_UP_HEADING_RE)
+  if (!headingMatch || headingMatch.index === undefined) return []
+
+  const afterHeading = content.slice(headingMatch.index + headingMatch[0].length)
+  const questions: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = FOLLOW_UP_ITEM_RE.exec(afterHeading)) !== null) {
+    const q = match[1].trim()
+    if (q) questions.push(q)
+  }
+  return questions
+}
+
 function getActivityHeader(message: ChatMessage): string {
   if (message.error) {
     return message.error
@@ -113,6 +149,8 @@ function toPersistedAssistantMessage(message: ChatMessage): ChatMessage {
     references: message.references,
     steps: message.steps,
     activitySummary: message.activitySummary,
+    answerMetadata: message.answerMetadata,
+    responseId: message.responseId,
   }
 }
 
@@ -124,7 +162,16 @@ function applyChatStreamEvent(message: ChatMessage, event: ChatStreamEvent): Cha
       references: event.references ?? message.references,
       isStreaming: false,
       activitySummary: event.activity_summary ?? message.activitySummary,
+      answerMetadata: event.answer_metadata ?? message.answerMetadata,
+      responseId: event.response_id ?? message.responseId,
       error: undefined,
+    }
+  }
+
+  if (event.type === 'message.delta') {
+    return {
+      ...message,
+      content: message.content + (event.message ?? ''),
     }
   }
 
@@ -286,19 +333,21 @@ export function ChatInterface({
     clearError()
 
     try {
-      // Prepare recent messages for context (last 5 messages, excluding current)
       const recentMessages = projectMessages.slice(-5).map(msg => ({
         role: msg.role,
         content: msg.content,
         timestamp: msg.timestamp
       }))
 
-      // Call the v2 chat API
+      const lastAssistantMessage = [...projectMessages].reverse().find(m => m.role === 'assistant')
+      const previousResponseId = lastAssistantMessage?.responseId ?? undefined
+
       const response = await fetchWithAuth(`/api/analysis-projects/${projectId}/chat/stream`, {
         method: 'POST',
         body: JSON.stringify({
           message: userMessage.content,
-          recent_messages: recentMessages
+          recent_messages: recentMessages,
+          previous_response_id: previousResponseId,
         })
       }, true)
 
@@ -463,6 +512,11 @@ export function ChatInterface({
                             <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
                           )}
                           <span>{getActivityHeader(message)}</span>
+                          {!message.isStreaming && !message.error && message.answerMetadata && (
+                            <span className="text-gray-500 font-normal">
+                              — {formatAnswerMetadata(message.answerMetadata)}
+                            </span>
+                          )}
                         </div>
 
                         {!message.isStreaming && message.steps && message.steps.length > 0 && (
@@ -512,30 +566,61 @@ export function ChatInterface({
                 })()
               )}
 
-              {message.content && (
-                <div className="prose prose-sm max-w-none">
-                  <ReactMarkdown
-                    components={{
-                      a: ({ href, children, ...props }) => (
-                        <a
-                          href={href}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-600 hover:text-blue-800 hover:underline"
-                          {...props}
-                        >
-                          {children}
-                        </a>
-                      ),
-                    }}
-                  >
-                    {message.role === 'assistant' && message.references
-                      ? processInTextCitations(message.content, message.references)
-                      : message.content
-                    }
-                  </ReactMarkdown>
-                </div>
-              )}
+              {message.content && (() => {
+                const followUpQuestions = message.role === 'assistant' && !message.isStreaming
+                  ? extractFollowUpQuestions(message.content)
+                  : []
+                const displayContent = followUpQuestions.length > 0
+                  ? message.content.replace(new RegExp(FOLLOW_UP_HEADING_RE.source + '[\\s\\S]*$', 'i'), '').trimEnd()
+                  : message.content
+                const processedContent = message.role === 'assistant' && message.references
+                  ? processInTextCitations(displayContent, message.references)
+                  : displayContent
+
+                return (
+                  <>
+                    <div className="prose prose-sm max-w-none">
+                      <ReactMarkdown
+                        components={{
+                          a: ({ href, children, ...props }) => (
+                            <a
+                              href={href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-blue-600 hover:text-blue-800 hover:underline"
+                              {...props}
+                            >
+                              {children}
+                            </a>
+                          ),
+                        }}
+                      >
+                        {processedContent}
+                      </ReactMarkdown>
+                    </div>
+                    {followUpQuestions.length > 0 && (
+                      <div className="mt-3 pt-2 border-t border-gray-200">
+                        <p className="text-xs font-medium text-gray-500 mb-1.5">Follow-up questions</p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {followUpQuestions.map((q) => (
+                            <button
+                              key={q}
+                              type="button"
+                              onClick={() => {
+                                setInputMessage(q)
+                              }}
+                              disabled={isLoading}
+                              className="text-xs text-left px-2.5 py-1.5 rounded-full border border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 disabled:opacity-50 transition-colors"
+                            >
+                              {q}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )
+              })()}
               
               {/* Show references for assistant messages */}
               {message.role === 'assistant' && message.references && message.references.length > 0 && (

--- a/frontend/lib/chatStore.ts
+++ b/frontend/lib/chatStore.ts
@@ -8,6 +8,13 @@ export interface ChatStep {
   summary?: string
 }
 
+export interface AnswerMetadata {
+  source_count: number
+  evidence_source_count: number
+  parliament_source_count: number
+  date_range?: string
+}
+
 export interface ChatMessage {
   id: string
   role: 'user' | 'assistant'
@@ -17,6 +24,8 @@ export interface ChatMessage {
   steps?: ChatStep[]
   isStreaming?: boolean
   activitySummary?: string
+  answerMetadata?: AnswerMetadata
+  responseId?: string
   error?: string
 }
 
@@ -39,11 +48,13 @@ export interface ChatResponse {
 }
 
 export interface ChatStreamEvent {
-  type: 'agent.status' | 'tool.started' | 'tool.completed' | 'tool.failed' | 'message.completed' | 'message.failed'
+  type: 'agent.status' | 'tool.started' | 'tool.completed' | 'tool.failed' | 'message.completed' | 'message.failed' | 'message.delta'
   step?: ChatStep
   message?: string
   references?: DocumentReference[]
   activity_summary?: string
+  answer_metadata?: AnswerMetadata
+  response_id?: string
   error?: string
 }
 
@@ -115,7 +126,10 @@ function loadMessagesByProject(): MessagesByProject {
             : undefined,
           steps: Array.isArray((candidate as { steps?: unknown }).steps)
             ? (candidate as { steps: ChatStep[] }).steps
-            : undefined
+            : undefined,
+          responseId: typeof (candidate as { responseId?: unknown }).responseId === 'string'
+            ? (candidate as { responseId: string }).responseId
+            : undefined,
         }]
       })
 


### PR DESCRIPTION
## Summary
- Upgrade the chatbot from `gpt-4o-mini` to `gpt-5.4` and migrate tool-calling from Chat Completions to the OpenAI Responses API (`responses.create`), including updated tool definitions (`strict: false`), response parsing, and loop state handling.
- Add richer streaming/chat state features: token deltas (`message.delta`), `previous_response_id` passthrough for cache continuity, `response_id` propagation, and structured `AnswerMetadata` (source counts + year range) from backend to frontend.
- Harden grounding/prompt behaviour (anti-hallucination constraints, better evidence-coverage handling, improved follow-up guidance) and extend document URL fallbacks (`overton_url` -> `landing_page_url` -> `pdf_url`).

## Main changes
- **Backend API migration** (`backend/app/services/chatbot/chat_service.py`)
  - `chat.completions.create` -> `responses.create`
  - `messages` -> `input_items`; `instructions` separated from input
  - tool-call handling now uses `function_call` / `function_call_output`
  - added streaming path (`_create_streaming_response`) and fallback retry without `previous_response_id` cache key when needed
- **Model/config defaults** (`backend/app/core/config.py`)
  - `CHATBOT_MODEL=gpt-5.4`
  - `CHATBOT_REASONING_EFFORT=medium`
- **Models/events** (`backend/app/services/chatbot/models.py`)
  - added `AnswerMetadata`
  - added `message.delta` event type
  - added `previous_response_id` on requests and `response_id` on responses/events
- **Prompt upgrades** (`backend/app/services/chatbot/prompts.py`)
  - stronger grounding requirements
  - explicit no-memory fallback when tools return no coverage
  - response-depth and follow-up guidance updates
- **Frontend/chat state updates**
  - streaming delta handling and response metadata plumbing
  - chat store updates for new fields/event shapes
- **Tests** (`backend/test/test_chatbot_tools.py`)
  - migrated mocks/assertions to Responses API behaviour

## Why
- GPT-5.4 requires the Responses API for tool-calling.
- Improves tool-call robustness, streaming UX, and grounding quality.
- Adds structured metadata + response continuity primitives needed for multi-turn reliability.

## Test plan
- [x] Updated chatbot backend test suite for Responses API (`backend/test/test_chatbot_tools.py`).
- [x] Existing chatbot tests pass against the new mock format and flow.
- [x] Manual validation of streaming and response quality performed on live project chats.
