### PR TITLE
Fix public citation sidebar context loading

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -21,7 +21,6 @@ from app.services.synthesis.schemas import (
     Finding,
     ThematicGroup,
     EvidenceItem,
-    DocumentContextInfo,
     ChunkContextResponse,
 )
 from app.services.synthesis.findings import get_findings
@@ -39,13 +38,7 @@ from app.services.analysis.schemas import (
 )
 from app.services.analysis.progress import get_synthesis_project_progress
 from app.services.analysis.evidence.strength import get_or_calculate_document_evidence
-from app.services.synthesis.utils import (
-    normalize_source_type,
-    extract_author_short,
-    extract_author_display,
-    extract_author_list,
-    infer_source_value,
-)
+from app.services.synthesis.citation_context import get_chunk_context_response
 from app.utils.project_data import (
     filter_prevalence_only_results,
     filter_prevalence_only_extractions,
@@ -291,105 +284,7 @@ async def get_chunk_context(
     """Get target chunk and adjacent context for citation inspection."""
     try:
         get_project_with_auth_check(project_id, current_user, "id, organization_id")
-
-        target_res = (
-            vectorization_service.supabase.table("chunks")
-            .select("id, content, chunk_index, document_id, project_id")
-            .eq("id", chunk_id)
-            .eq("project_id", project_id)
-            .limit(1)
-            .execute()
-        )
-        if not target_res.data:
-            raise HTTPException(
-                status_code=404, detail="Chunk not found for this project"
-            )
-
-        target_chunk = target_res.data[0]
-        target_index = int(target_chunk.get("chunk_index") or 0)
-        document_id = str(target_chunk.get("document_id") or "")
-        if not document_id:
-            raise HTTPException(status_code=404, detail="Chunk has no source document")
-
-        adjacent_indices = [target_index - 1, target_index + 1]
-        adjacent_res = (
-            vectorization_service.supabase.table("chunks")
-            .select("content, chunk_index")
-            .eq("document_id", document_id)
-            .eq("project_id", project_id)
-            .in_("chunk_index", adjacent_indices)
-            .order("chunk_index")
-            .execute()
-        )
-
-        previous_chunk_content: Optional[str] = None
-        next_chunk_content: Optional[str] = None
-        for row in adjacent_res.data or []:
-            idx = int(row.get("chunk_index") or 0)
-            content = str(row.get("content") or "")
-            if idx == target_index - 1:
-                previous_chunk_content = content
-            elif idx == target_index + 1:
-                next_chunk_content = content
-
-        doc_res = (
-            vectorization_service.supabase.table("analysis_documents")
-            .select(
-                "id, doc_id, title, authors, author_institutions, year, venue, source_country, source, document_type, evidence_category, evidence_category_reasoning, extraction_results, impact_score, impact_score_label, impact_score_breakdown, transferability_score, transferability_breakdown, pdf_url, landing_page_url, overton_url"
-            )
-            .eq("id", document_id)
-            .eq("analysis_project_id", project_id)
-            .limit(1)
-            .execute()
-        )
-        if not doc_res.data:
-            raise HTTPException(
-                status_code=404, detail="Source document not found for this chunk"
-            )
-
-        doc = doc_res.data[0]
-        evidence_info = get_or_calculate_document_evidence(doc)
-        stars = evidence_info.get("stars")
-        evidence_score = int(stars) if isinstance(stars, (int, float)) else None
-
-        source_value = infer_source_value(doc.get("source"), doc.get("doc_id"))
-
-        document = DocumentContextInfo(
-            analysis_document_id=str(doc.get("id") or document_id),
-            title=str(doc.get("title") or "Unknown source"),
-            author_display=extract_author_display(doc.get("authors")),
-            authors=extract_author_list(doc.get("authors")),
-            author_institutions=extract_author_list(doc.get("author_institutions")),
-            author_short=extract_author_short(doc.get("authors")),
-            year=doc.get("year"),
-            venue=doc.get("venue"),
-            country=doc.get("source_country"),
-            url=doc.get("pdf_url")
-            or doc.get("landing_page_url")
-            or doc.get("overton_url"),
-            source_type=normalize_source_type(
-                source_value, str(doc.get("document_type") or "")
-            ),
-            document_type=doc.get("document_type"),
-            evidence_category=doc.get("evidence_category"),
-            evidence_category_reasoning=doc.get("evidence_category_reasoning"),
-            evidence_score=evidence_score,
-            evidence_strength_justification=evidence_info.get("justification"),
-            impact_score=doc.get("impact_score"),
-            impact_score_label=doc.get("impact_score_label"),
-            impact_score_breakdown=doc.get("impact_score_breakdown"),
-            transferability_score=doc.get("transferability_score"),
-            transferability_breakdown=doc.get("transferability_breakdown"),
-        )
-
-        return ChunkContextResponse(
-            chunk_id=str(target_chunk.get("id") or chunk_id),
-            chunk_content=str(target_chunk.get("content") or ""),
-            chunk_index=target_index,
-            previous_chunk_content=previous_chunk_content,
-            next_chunk_content=next_chunk_content,
-            document=document,
-        )
+        return get_chunk_context_response(project_id, chunk_id)
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/app/api/public.py
+++ b/backend/app/api/public.py
@@ -6,7 +6,8 @@ These endpoints serve read-only project data for projects marked as public.
 from fastapi import APIRouter, HTTPException
 
 from app.services.vectorization import vectorization_service
-from app.services.synthesis.schemas import SynthesisSummary
+from app.services.synthesis.schemas import SynthesisSummary, ChunkContextResponse
+from app.services.synthesis.citation_context import get_chunk_context_response
 from app.services.synthesis.logbook import get_synthesis_status
 from app.utils.project_data import (
     get_project_documents_data,
@@ -127,3 +128,13 @@ async def get_public_outcome_contributions(project_id: str, outcome_theme_id: st
     """Get contributing outcome extractions for a synthesis outcome theme."""
     get_public_project(project_id, "id, is_public")
     return get_outcome_contributions_data(project_id, outcome_theme_id)
+
+
+@router.get(
+    "/projects/{project_id}/chunks/{chunk_id}/context",
+    response_model=ChunkContextResponse,
+)
+async def get_public_chunk_context(project_id: str, chunk_id: str):
+    """Get citation chunk context for a public project."""
+    get_public_project(project_id, "id, is_public")
+    return get_chunk_context_response(project_id, chunk_id)

--- a/backend/app/services/synthesis/citation_context.py
+++ b/backend/app/services/synthesis/citation_context.py
@@ -1,0 +1,113 @@
+"""Shared helpers for citation chunk context retrieval."""
+
+from typing import Optional
+
+from fastapi import HTTPException
+
+from app.services.analysis.evidence.strength import get_or_calculate_document_evidence
+from app.services.synthesis.schemas import ChunkContextResponse, DocumentContextInfo
+from app.services.synthesis.utils import (
+    extract_author_display,
+    extract_author_list,
+    extract_author_short,
+    infer_source_value,
+    normalize_source_type,
+)
+from app.services.vectorization import vectorization_service
+
+
+def get_chunk_context_response(project_id: str, chunk_id: str) -> ChunkContextResponse:
+    """Build chunk context payload for a project and chunk."""
+    target_res = (
+        vectorization_service.supabase.table("chunks")
+        .select("id, content, chunk_index, document_id, project_id")
+        .eq("id", chunk_id)
+        .eq("project_id", project_id)
+        .limit(1)
+        .execute()
+    )
+    if not target_res.data:
+        raise HTTPException(status_code=404, detail="Chunk not found for this project")
+
+    target_chunk = target_res.data[0]
+    target_index = int(target_chunk.get("chunk_index") or 0)
+    document_id = str(target_chunk.get("document_id") or "")
+    if not document_id:
+        raise HTTPException(status_code=404, detail="Chunk has no source document")
+
+    adjacent_indices = [target_index - 1, target_index + 1]
+    adjacent_res = (
+        vectorization_service.supabase.table("chunks")
+        .select("content, chunk_index")
+        .eq("document_id", document_id)
+        .eq("project_id", project_id)
+        .in_("chunk_index", adjacent_indices)
+        .order("chunk_index")
+        .execute()
+    )
+
+    previous_chunk_content: Optional[str] = None
+    next_chunk_content: Optional[str] = None
+    for row in adjacent_res.data or []:
+        idx = int(row.get("chunk_index") or 0)
+        content = str(row.get("content") or "")
+        if idx == target_index - 1:
+            previous_chunk_content = content
+        elif idx == target_index + 1:
+            next_chunk_content = content
+
+    doc_res = (
+        vectorization_service.supabase.table("analysis_documents")
+        .select(
+            "id, doc_id, title, authors, author_institutions, year, venue, source_country, source, document_type, evidence_category, evidence_category_reasoning, extraction_results, impact_score, impact_score_label, impact_score_breakdown, transferability_score, transferability_breakdown, pdf_url, landing_page_url, overton_url"
+        )
+        .eq("id", document_id)
+        .eq("analysis_project_id", project_id)
+        .limit(1)
+        .execute()
+    )
+    if not doc_res.data:
+        raise HTTPException(
+            status_code=404, detail="Source document not found for this chunk"
+        )
+
+    doc = doc_res.data[0]
+    evidence_info = get_or_calculate_document_evidence(doc)
+    stars = evidence_info.get("stars")
+    evidence_score = int(stars) if isinstance(stars, (int, float)) else None
+    source_value = infer_source_value(doc.get("source"), doc.get("doc_id"))
+
+    document = DocumentContextInfo(
+        analysis_document_id=str(doc.get("id") or document_id),
+        title=str(doc.get("title") or "Unknown source"),
+        author_display=extract_author_display(doc.get("authors")),
+        authors=extract_author_list(doc.get("authors")),
+        author_institutions=extract_author_list(doc.get("author_institutions")),
+        author_short=extract_author_short(doc.get("authors")),
+        year=doc.get("year"),
+        venue=doc.get("venue"),
+        country=doc.get("source_country"),
+        url=doc.get("pdf_url") or doc.get("landing_page_url") or doc.get("overton_url"),
+        source_type=normalize_source_type(
+            source_value, str(doc.get("document_type") or "")
+        ),
+        document_type=doc.get("document_type"),
+        evidence_category=doc.get("evidence_category"),
+        evidence_category_reasoning=doc.get("evidence_category_reasoning"),
+        evidence_score=evidence_score,
+        evidence_strength_justification=evidence_info.get("justification"),
+        impact_score=doc.get("impact_score"),
+        impact_score_label=doc.get("impact_score_label"),
+        impact_score_breakdown=doc.get("impact_score_breakdown"),
+        transferability_score=doc.get("transferability_score"),
+        transferability_breakdown=doc.get("transferability_breakdown"),
+    )
+
+    return ChunkContextResponse(
+        chunk_id=str(target_chunk.get("id") or chunk_id),
+        chunk_content=str(target_chunk.get("content") or ""),
+        chunk_index=target_index,
+        previous_chunk_content=previous_chunk_content,
+        next_chunk_content=next_chunk_content,
+        document=document,
+    )

--- a/frontend/app/(main)/results/ExecutiveBriefing.tsx
+++ b/frontend/app/(main)/results/ExecutiveBriefing.tsx
@@ -32,6 +32,7 @@ import { CitationContextPanel } from "@/components/synthesis/CitationContextPane
 
 interface ExecutiveBriefingProps {
   projectId: string;
+  isPublic?: boolean;
   briefing: string;
   structuredBriefing?: StructuredBriefing;
   citationMap?: Record<string, CitationInfo>;
@@ -936,6 +937,7 @@ function ReferencesList({
 
 export function ExecutiveBriefing({ 
   projectId,
+  isPublic = false,
   briefing, 
   structuredBriefing,
   citationMap, 
@@ -1517,6 +1519,7 @@ export function ExecutiveBriefing({
       <CitationContextPanel
         isOpen={Boolean(inspectedCitation)}
         projectId={projectId}
+        isPublic={isPublic}
         citationInfo={inspectedCitation?.citationInfo ?? null}
         chunkId={inspectedCitation?.chunkId}
         supportingQuote={inspectedCitation?.quote}

--- a/frontend/app/public/projects/[projectId]/page.tsx
+++ b/frontend/app/public/projects/[projectId]/page.tsx
@@ -523,6 +523,7 @@ export default function PublicProjectPage() {
                     <div className="space-y-8">
                       <ExecutiveBriefing 
                         projectId={projectId}
+                        isPublic={true}
                         briefing={summaryData.executive_briefing}
                         structuredBriefing={summaryData.structured_briefing}
                         citationMap={summaryData.citation_map}

--- a/frontend/components/synthesis/CitationContextPanel.tsx
+++ b/frontend/components/synthesis/CitationContextPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertCircle, ExternalLink, X } from "lucide-react";
 import * as fuzz from "fuzzball";
 import { fetchWithAuthExternal } from "@/lib/api";
+import { getPublicChunkContext } from "@/lib/publicApi";
 import { Tooltip } from "@/components/ui/tooltip";
 import { getEvidenceCategoryColors, getEvidenceCategoryShortName } from "@/lib/evidenceCategories";
 import {
@@ -47,6 +48,7 @@ interface ChunkContextResponse {
 interface CitationContextPanelProps {
   isOpen: boolean;
   projectId: string;
+  isPublic?: boolean;
   citationInfo: CitationInfo | null;
   chunkId?: string;
   supportingQuote?: string;
@@ -253,6 +255,7 @@ function formatOutOfFive(value: number | null | undefined): string {
 export function CitationContextPanel({
   isOpen,
   projectId,
+  isPublic = false,
   citationInfo,
   chunkId,
   supportingQuote,
@@ -283,9 +286,11 @@ export function CitationContextPanel({
       setError(null);
 
       try {
-        const res = (await fetchWithAuthExternal(
-          `api/analysis-projects/${projectId}/chunks/${chunkId}/context`
-        )) as ChunkContextResponse | null;
+        const res = isPublic
+          ? ((await getPublicChunkContext(projectId, chunkId)) as ChunkContextResponse | null)
+          : ((await fetchWithAuthExternal(
+              `api/analysis-projects/${projectId}/chunks/${chunkId}/context`
+            )) as ChunkContextResponse | null);
 
         if (!cancelled) {
           if (res) {
@@ -310,7 +315,7 @@ export function CitationContextPanel({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, projectId, chunkId, citationInfo]);
+  }, [isOpen, projectId, chunkId, citationInfo, isPublic]);
 
   const freshData = dataIsStale ? null : contextData;
 

--- a/frontend/lib/publicApi.ts
+++ b/frontend/lib/publicApi.ts
@@ -73,3 +73,7 @@ export async function getPublicOutcomeContributions(
     `api/public/projects/${projectId}/synthesis/outcome-themes/${outcomeThemeId}/contributions`
   );
 }
+
+export async function getPublicChunkContext(projectId: string, chunkId: string) {
+  return fetchPublic(`api/public/projects/${projectId}/chunks/${chunkId}/context`);
+}


### PR DESCRIPTION
## Summary
- add a public chunk-context endpoint for citation sidebar lookups on shared project pages
- extract shared chunk-context assembly into a reusable backend helper used by both authenticated and public routes
- route public executive briefing citation clicks through the public API client so signed-out users can view full citation context

## Test plan
- [x] Verify modified frontend and backend files have no new lint diagnostics
- [x] Open a public project link while signed out and confirm citation sidebar shows chunk context, not metadata only
- [x] Open the same project while signed in and confirm authenticated citation sidebar behaviour is unchanged