### PR TITLE
mcp: exploratory spike with PICO picker + agentic evidence search

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -106,6 +106,11 @@ class Settings(BaseSettings):
     SUPABASE_URL: Optional[str] = None
     SUPABASE_KEY: Optional[str] = None
 
+    # MCP (Model Context Protocol) Configuration
+    # API key required for remote (SSE) transport only; stdio is local-trusted.
+    # Set this in production; safe to leave unset for local Claude Desktop / mcp-inspector usage.
+    MCP_API_KEY: Optional[str] = None
+
     # Development/Testing
     MOCK_OPENAI: bool = False
     DEBUG_ANALYSIS_FILES: bool = False  # Keep local analysis files for debugging

--- a/backend/app/mcp/__init__.py
+++ b/backend/app/mcp/__init__.py
@@ -1,0 +1,9 @@
+"""
+MCP (Model Context Protocol) server for Policy Atlas.
+
+Exposes Policy Atlas capabilities as MCP tools so autonomous agents
+(Claude Desktop, Microsoft Copilot Cowork, etc.) can call them.
+
+Tools are thin facades over services in `app/services/`. All business
+logic lives in the service layer — see docs/mcp_integration_plan.md.
+"""

--- a/backend/app/mcp/schemas.py
+++ b/backend/app/mcp/schemas.py
@@ -1,0 +1,224 @@
+"""
+Pydantic schemas for Policy Atlas MCP tools.
+
+These models are the public contract the MCP server exposes to calling agents.
+FastMCP serialises them to JSON Schema and embeds the `description=` strings
+in the tool manifest — so every description is written for an agent reader,
+not a human maintainer.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PicoOption(BaseModel):
+    """A single suggested option for a PICO facet (population, outcome, setting, geography)."""
+
+    label: str = Field(
+        ...,
+        description="Short label suitable for a pick-list, e.g. 'Children with EHCPs specifically'.",
+    )
+    description: str = Field(
+        "",
+        description="One-sentence clarification distinguishing this option from neighbours.",
+    )
+
+
+class SuggestPicoOptionsOutput(BaseModel):
+    """LLM-suggested PICO option sets for a research question.
+
+    Each option list is ordered broad → narrow. The caller (typically an agent
+    or a UI) picks one or more options per facet to assemble a structured
+    search. Options are independent across facets in this version (i.e. outcome
+    suggestions are not conditioned on which population was chosen).
+    """
+
+    research_question: str = Field(
+        ...,
+        description="The original question, echoed back so the output is self-contained.",
+    )
+    population_options: list[PicoOption] = Field(
+        default_factory=list,
+        description="Suggested ways to scope the population this research applies to.",
+    )
+    outcome_options: list[PicoOption] = Field(
+        default_factory=list,
+        description="Suggested outcomes the research could measure progress against.",
+    )
+    inner_setting_options: list[PicoOption] = Field(
+        default_factory=list,
+        description="Suggested implementation settings where the intervention would be delivered.",
+    )
+    # Geography intentionally omitted in the spike — the caller supplies it
+    # directly to search_evidence. Re-add as a facet if/when worth the prompt.
+
+
+class EvidenceResult(BaseModel):
+    """A single paper returned by search_evidence.
+
+    Fields are mostly optional — different sources (OpenAlex, Overton) return
+    different field sets, and the schema absorbs that variation rather than
+    dropping papers with sparse metadata.
+    """
+
+    doc_id: str = Field(
+        ..., description="Stable cross-source identifier, e.g. 'openalex:W12345'."
+    )
+    title: str = Field(..., description="Paper title.")
+    year: int | None = Field(None, description="Year of publication if known.")
+    source: str | None = Field(
+        None, description="Origin database: 'openalex' or 'overton'."
+    )
+    document_type: str | None = Field(
+        None,
+        description="Type label from the source (e.g. 'journal-article', 'report').",
+    )
+    authors: list[str] = Field(
+        default_factory=list, description="Author names as plain strings."
+    )
+    venue: str | None = Field(None, description="Journal, publisher, or hosting org.")
+    cited_by_count: int | None = Field(
+        None, description="Citation count from the source, when available."
+    )
+    abstract_snippet: str | None = Field(
+        None, description="Abstract or summary excerpt (truncated to ~500 chars)."
+    )
+    is_open_access: bool | None = Field(
+        None, description="Whether the paper is open access (when known)."
+    )
+    landing_page_url: str | None = Field(
+        None, description="URL where the agent or a human can read the paper."
+    )
+    # Existing pipeline signals plumbed through for LLM ranking-bias reasoning.
+    # See docs/spec_search_evidence_agentic.md §6.
+    relevance_score: float | None = Field(
+        None,
+        description=(
+            "Source-database relevance score (BM25-ish from OpenAlex). NB: Overton "
+            "documents typically have 0 here because their per-doc similarity score "
+            "isn't extracted upstream — see references.py and the asymmetry note in §7."
+        ),
+    )
+    query_variant: str | None = Field(
+        None,
+        description="Label of the boolean-query variant that retrieved this paper, e.g. 'broad', 'uk-stratified'.",
+    )
+    variant_priority: int | None = Field(
+        None,
+        description="Priority the search strategy assigned to the matching query variant (lower = primary).",
+    )
+
+
+class CompactPaper(BaseModel):
+    """Trimmed paper representation for LLM reasoning over the wider result set.
+
+    The widget never renders these; they're for the agent's gap-analysis
+    reflection over the broader retrieval (papers ranked beyond the top-N).
+    Carries the full abstract (up to ~1800 chars) so the LLM has enough
+    semantic signal to identify study designs, populations, outcomes,
+    time horizons, and intervention types missing from the top-N. See
+    docs/spec_search_evidence_agentic.md §4.
+    """
+
+    doc_id: str = Field(..., description="Stable cross-source identifier.")
+    rank: int = Field(
+        ...,
+        description="1-indexed position in the full sorted result set (1 = top of wider 50).",
+    )
+    title: str = Field(..., description="Paper title.")
+    abstract_snippet: str | None = Field(
+        None,
+        description="Full abstract truncated to ~1800 chars when longer; max signal for gap analysis.",
+    )
+    year: int | None = Field(None, description="Year of publication.")
+    source_country: str | None = Field(
+        None, description="Country of origin / publication."
+    )
+    venue: str | None = Field(None, description="Journal, publisher, or hosting org.")
+    document_type: str | None = Field(
+        None,
+        description="Type label from the source (e.g. 'journal-article', 'report').",
+    )
+    source: str | None = Field(None, description="'openalex' or 'overton'.")
+    relevance_score: float | None = Field(
+        None, description="Source-database relevance score (see §7 asymmetry caveat)."
+    )
+    query_variant: str | None = Field(
+        None, description="Boolean-query variant that retrieved this paper."
+    )
+    variant_priority: int | None = Field(
+        None, description="Priority of the matching query variant (lower = primary)."
+    )
+
+
+class ResultSummary(BaseModel):
+    """Aggregate distributions computed over the FULL fetched result set (not just top-N).
+
+    Rendered as a single summary strip above the widget's results list, and
+    consumed by the LLM for gap-analysis reflection. Same data, two audiences.
+    See docs/spec_search_evidence_agentic.md §8.
+    """
+
+    country_distribution: dict[str, int] = Field(
+        default_factory=dict,
+        description="Count of papers per source_country, e.g. {'US': 30, 'UK': 5, 'AU': 8}.",
+    )
+    year_range: tuple[int, int] | None = Field(
+        None,
+        description="(min_year, max_year) across the result set; None if no year data.",
+    )
+    year_median: int | None = Field(
+        None, description="Median publication year across the result set."
+    )
+    source_mix: dict[str, int] = Field(
+        default_factory=dict,
+        description="Count of papers per source database, e.g. {'openalex': 42, 'overton': 8}.",
+    )
+    document_type_mix: dict[str, int] = Field(
+        default_factory=dict,
+        description="Count of papers per document_type, e.g. {'journal-article': 35, 'report': 10}.",
+    )
+    open_access_fraction: float | None = Field(
+        None,
+        description="Fraction (0-1) of papers known to be open access; None if is_oa data is missing for all.",
+    )
+
+
+class SearchEvidenceOutput(BaseModel):
+    """Result of a single search across OpenAlex and/or Overton.
+
+    Returns three layers:
+      - `results`: top-N papers (capped by max_results), full EvidenceResult shape — rendered by the widget.
+      - `additional_results`: the wider set (papers ranked N+1 onwards) as CompactPaper — NOT rendered by the widget; for LLM gap-analysis reflection.
+      - `result_summary`: aggregate stats over the FULL fetched DataFrame — rendered by the widget as a summary strip, also consumed by the LLM.
+
+    The agentic flow expects the LLM to reflect on `result_summary` + `additional_results` after results return — see docs/spec_search_evidence_agentic.md §4, §8, §12.
+    """
+
+    total_found: int = Field(
+        ..., description="Total number of papers matched across all sources."
+    )
+    results_returned: int = Field(
+        ...,
+        description="Number of papers included in `results` (capped by max_results).",
+    )
+    results: list[EvidenceResult] = Field(
+        default_factory=list,
+        description="Top results ordered by source-defined relevance.",
+    )
+    additional_results: list[CompactPaper] = Field(
+        default_factory=list,
+        description=(
+            "Wider compact set (papers ranked beyond the top-N). Full abstract included "
+            "for gap-analysis reflection. The widget ignores this field."
+        ),
+    )
+    result_summary: ResultSummary | None = Field(
+        None,
+        description="Aggregate distributions over the full fetched set for triage + reflection.",
+    )
+    boolean_queries_used: list[str] = Field(
+        default_factory=list,
+        description="The actual queries sent to OpenAlex — surfaced for auditability.",
+    )

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -1,0 +1,122 @@
+"""
+FastMCP server for Policy Atlas.
+
+Exposes a configured `mcp` FastMCP instance and two transport runners
+(`run_stdio`, `run_sse`). Designed for REPL-friendly debugging:
+
+    # Interactive: inspect the server, then launch when ready
+    $ uv run python -i -m app.mcp.server
+    >>> mcp.list_tools()           # see registered tools
+    >>> run_stdio()                # blocks; Ctrl-C to exit
+
+    # Or from another module / script:
+    from app.mcp.server import mcp, run_sse
+    run_sse(port=8001)
+
+Tools register against `mcp` via @mcp.tool() decorators (see app/mcp/tools.py).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+mcp = FastMCP(
+    name="policy-atlas",
+    instructions=(
+        "Policy Atlas exposes search and synthesis tools for policy "
+        "research. Use suggest_pico_options to frame a question, then "
+        "search_evidence to find papers."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# API-key auth (SSE only)
+# ---------------------------------------------------------------------------
+
+API_KEY_HEADER = "x-mcp-api-key"
+
+
+async def _require_api_key(request: Request) -> JSONResponse | None:
+    """Reject SSE requests that don't present a valid API key.
+
+    Returns a 401 JSONResponse on failure, or None to allow through.
+    Stdio bypasses this entirely (local-trusted).
+    """
+    expected = settings.MCP_API_KEY
+    if not expected:
+        return JSONResponse(
+            {"error": "MCP_API_KEY not configured on server"},
+            status_code=503,
+        )
+    provided = request.headers.get(API_KEY_HEADER)
+    if provided != expected:
+        return JSONResponse(
+            {"error": "invalid or missing api key"},
+            status_code=401,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Transport runners
+# ---------------------------------------------------------------------------
+
+
+def run_stdio() -> None:
+    """Launch the server on stdio (Claude Desktop, mcp-inspector).
+
+    Routes logs to stderr — stdio uses stdout for the JSON-RPC protocol,
+    so any log line on stdout would corrupt the message stream.
+    """
+    logging.basicConfig(
+        level=settings.LOG_LEVEL,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
+    )
+    logger.info("Starting MCP server on stdio")
+    mcp.run(transport="stdio")
+
+
+def run_sse(port: int = 8001, host: str = "0.0.0.0") -> None:
+    """Launch the server on SSE (remote / production).
+
+    Fails fast if MCP_API_KEY is not set, and rejects requests that don't
+    present a matching x-mcp-api-key header.
+    """
+    logging.basicConfig(
+        level=settings.LOG_LEVEL,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    if not settings.MCP_API_KEY:
+        raise RuntimeError("MCP_API_KEY must be set when running SSE transport")
+
+    sse_app = mcp.sse_app()
+
+    @sse_app.middleware("http")
+    async def _auth_middleware(request: Request, call_next):
+        rejection = await _require_api_key(request)
+        if rejection is not None:
+            return rejection
+        return await call_next(request)
+
+    import uvicorn
+
+    logger.info("Starting MCP server on SSE %s:%d", host, port)
+    uvicorn.run(sse_app, host=host, port=port)
+
+
+# Import-for-side-effect: loading this module triggers @mcp.tool() decorators
+# in tools.py, registering them on the `mcp` instance. Must come *after* the
+# `mcp` instance is created above — otherwise tools.py can't import it.
+from app.mcp import tools as _tools  # noqa: E402, F401

--- a/backend/app/mcp/tools.py
+++ b/backend/app/mcp/tools.py
@@ -1,0 +1,603 @@
+"""
+MCP tool implementations.
+
+Each tool is a thin facade over services in app/services/. The MCP layer
+owns transport, schema, and tracing; business logic lives elsewhere.
+
+Tools register against the FastMCP instance from app.mcp.server at import
+time via @mcp.tool() decorators.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+from mcp.server.fastmcp import Context
+from mcp.types import CallToolResult, TextContent
+
+from app.mcp.schemas import (
+    CompactPaper,
+    EvidenceResult,
+    PicoOption,
+    ResultSummary,
+    SearchEvidenceOutput,
+    SuggestPicoOptionsOutput,
+)
+from app.mcp.server import mcp
+from app.services.analysis.references import ReferencesService
+from app.services.search_wizard import SearchWizardService
+
+logger = logging.getLogger(__name__)
+
+# MCP Apps widget URIs — each tool is independently invocable; widgets render
+# whenever a host supports MCP Apps and ignores the _meta.ui.resourceUri annotation
+# otherwise. The picker hands off to search_evidence via app.sendMessage rather
+# than calling it directly, so each widget renders in response to its own
+# LLM-initiated tool call.
+PICO_PICKER_URI = "ui://policy-atlas/pico-picker"
+SEARCH_EVIDENCE_URI = "ui://policy-atlas/search-evidence"
+
+# Built artifacts from widgets/. Build with `npm run build` in that directory;
+# vite-plugin-singlefile inlines all JS/CSS so the iframe sandbox can load them.
+_WIDGETS_DIST = Path(__file__).parent / "widgets" / "dist"
+_PICO_PICKER_HTML = _WIDGETS_DIST / "pico-picker.html"
+_SEARCH_EVIDENCE_HTML = _WIDGETS_DIST / "search-evidence.html"
+
+
+def _read_widget(path: Path) -> str:
+    """Read a built widget file, raising a build-step hint if missing."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Widget {path.name} not built. Run `npm install && npm run build` "
+            f"in {path.parent.parent} to generate it."
+        ) from exc
+
+
+@mcp.resource(
+    PICO_PICKER_URI,
+    name="pico_picker",
+    description="Interactive picker for population, outcome, and inner-setting facets.",
+    mime_type="text/html;profile=mcp-app",
+)
+def pico_picker_widget() -> str:
+    """Serve the built PICO picker widget HTML.
+
+    Read lazily so a `npm run build` during dev is picked up without a Python
+    server restart.
+    """
+    return _read_widget(_PICO_PICKER_HTML)
+
+
+@mcp.resource(
+    SEARCH_EVIDENCE_URI,
+    name="search_evidence_results",
+    description="Renders top-N evidence results from search_evidence as a list.",
+    mime_type="text/html;profile=mcp-app",
+)
+def search_evidence_widget() -> str:
+    """Serve the built search-evidence results widget HTML."""
+    return _read_widget(_SEARCH_EVIDENCE_HTML)
+
+
+def _labels_to_options(labels: list[str]) -> list[PicoOption]:
+    """Convert plain-string labels into PicoOption objects.
+
+    Descriptions stay empty in this spike: the existing wizard prompts return
+    labels only. Upgrading the prompts to emit {label, description} pairs is
+    a follow-up improvement; the schema already accepts the richer shape.
+    """
+    return [PicoOption(label=label, description="") for label in labels if label]
+
+
+@mcp.tool(meta={"ui": {"resourceUri": PICO_PICKER_URI}})
+async def suggest_pico_options(
+    question: str,
+    ctx: Context | None = None,
+) -> SuggestPicoOptionsOutput:
+    """Suggest PICO option sets for a policy research question.
+
+    WHEN TO CALL:
+    Call this FIRST when scoping an unfamiliar research question, before
+    search_evidence. Skip if the user has already given explicit framings
+    (e.g., they typed "search for X with population=Y, outcome=Z").
+
+    WHAT IT RETURNS:
+    3–5 options per PICO facet (population, outcome, inner_setting), ordered
+    broad → narrow. The picker widget renders these for the user to select
+    from; the user may also add their own free-text option per facet.
+    Geography is supplied directly to search_evidence rather than suggested
+    here. Facets are independent — outcome suggestions are not conditioned
+    on which population was picked.
+
+    PRESENTATION:
+    After the tool returns, the widget renders the options. Do not narrate
+    them as a markdown list — the widget already shows them.
+
+    You MAY add a brief (1–2 sentence) critique IF you notice something
+    genuinely useful — for example:
+      - Two or more options collapse to essentially the same framing
+      - A clearly-relevant dimension is missing (e.g., a question about
+        homelessness with no "rough sleepers" or "single-adult vs family"
+        option)
+      - The question's terms are ambiguous and may have produced shallow
+        options
+    Keep critique terse. One sentence. No enumeration of the options
+    themselves. If options look clean, just say so briefly ("framings
+    look reasonable; pick from the widget above").
+
+    POST-CALL:
+    Wait for the user's picks. The picker hands off via app.sendMessage
+    with a structured message; the user explicitly confirms by pressing
+    send. Only then proceed to search_evidence with their picks.
+
+    DO NOT:
+    - Autonomously make picks for the user
+    - Re-call this tool to "refine" picks — users refine via the picker's
+      custom-input field, not by re-generating options
+    - Proceed to search_evidence speculatively before the user confirms
+    - Critique at length; the picker IS the surface for selection, your
+      critique is just a brief steer
+    """
+    wizard = SearchWizardService()
+    if ctx:
+        await ctx.info(
+            "Generating population, outcome, and inner-setting options in parallel…"
+        )
+
+    population, outcome, inner_setting = await asyncio.gather(
+        wizard.generate_population_options(question),
+        wizard.generate_outcome_options(question),
+        wizard.generate_inner_setting_options(question),
+        return_exceptions=True,
+    )
+
+    if ctx:
+        counts = (
+            (len(population) if isinstance(population, list) else 0),
+            (len(outcome) if isinstance(outcome, list) else 0),
+            (len(inner_setting) if isinstance(inner_setting, list) else 0),
+        )
+        await ctx.info(
+            f"Got {counts[0]} population, {counts[1]} outcome, {counts[2]} setting options."
+        )
+
+    def _safe(result: object, fallback_msg: str) -> list[str]:
+        if isinstance(result, BaseException):
+            logger.warning("%s: %s", fallback_msg, result)
+            return []
+        return result if isinstance(result, list) else []
+
+    output = SuggestPicoOptionsOutput(
+        research_question=question,
+        population_options=_labels_to_options(
+            _safe(population, "Population options failed")
+        ),
+        outcome_options=_labels_to_options(_safe(outcome, "Outcome options failed")),
+        inner_setting_options=_labels_to_options(
+            _safe(inner_setting, "Inner setting options failed")
+        ),
+    )
+
+    # Hosts that render the widget show interactive checkboxes; hosts that don't
+    # see only the terse text below. The full data lives in structuredContent —
+    # the widget consumes that via ontoolresult. Keeping `content` to a count
+    # stops the model narrating every option as a markdown list under the iframe.
+    summary = (
+        f"PICO framings ready: {len(output.population_options)} population, "
+        f"{len(output.outcome_options)} outcome, "
+        f"{len(output.inner_setting_options)} inner-setting options. "
+        f"Rendered as an interactive picker."
+    )
+    return CallToolResult(
+        content=[TextContent(type="text", text=summary)],
+        structuredContent=output.model_dump(mode="json", by_alias=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# search_evidence
+# ---------------------------------------------------------------------------
+
+
+def _parse_authors(raw: object) -> list[str]:
+    """Authors round-trip through CSV as a string repr of a list.
+
+    Best-effort parse: try literal_eval first, fall back to a single-element
+    list, never raise.
+    """
+    if raw is None or (isinstance(raw, float) and pd.isna(raw)):
+        return []
+    if isinstance(raw, list):
+        return [str(a) for a in raw if a]
+    try:
+        parsed = ast.literal_eval(str(raw))
+        if isinstance(parsed, list):
+            return [str(a).strip() for a in parsed if a]
+    except (ValueError, SyntaxError):
+        pass
+    return [str(raw)]
+
+
+def _row_to_evidence(row: pd.Series) -> EvidenceResult:
+    """Map one references.csv row to the EvidenceResult schema.
+
+    Defensive about column names — different sources (OpenAlex, Overton)
+    expose different fields, so we coalesce across plausible names and
+    fall back to None.
+    """
+
+    def _g(*cols: str):
+        for col in cols:
+            if col in row.index:
+                val = row[col]
+                if val is None or (isinstance(val, float) and pd.isna(val)):
+                    continue
+                return val
+        return None
+
+    abstract = _g("abstract", "content", "abstract_snippet", "abstract_or_summary")
+    if isinstance(abstract, str) and len(abstract) > 500:
+        abstract = abstract[:500].rstrip() + "…"
+
+    cited = _g("cited_by_count")
+    year = _g("publication_year", "year")
+    rel = _g("relevance_score")
+    vpri = _g("variant_priority")
+
+    return EvidenceResult(
+        doc_id=str(_g("doc_id", "id") or ""),
+        title=str(_g("title") or "No title available"),
+        year=int(year) if year is not None and not pd.isna(year) else None,
+        source=str(_g("source") or "") or None,
+        document_type=str(_g("work_type", "type", "document_type") or "") or None,
+        authors=_parse_authors(_g("authors")),
+        venue=str(_g("venue") or "") or None,
+        cited_by_count=int(cited) if cited is not None else None,
+        abstract_snippet=str(abstract) if abstract else None,
+        is_open_access=bool(_g("is_oa", "is_open_access"))
+        if _g("is_oa", "is_open_access") is not None
+        else None,
+        landing_page_url=str(_g("landing_page_url", "url") or "") or None,
+        relevance_score=float(rel) if rel is not None and not pd.isna(rel) else None,
+        query_variant=str(_g("query_variant") or "") or None,
+        variant_priority=int(vpri) if vpri is not None and not pd.isna(vpri) else None,
+    )
+
+
+# Longer cap than EvidenceResult's 500 chars — the widget never renders these, so
+# we keep up to the full ~1800-char abstract for the LLM's gap-analysis reflection.
+# See docs/spec_search_evidence_agentic.md §4.
+_COMPACT_ABSTRACT_MAX_CHARS = 1800
+
+
+def _row_to_compact_paper(row: pd.Series, rank: int) -> CompactPaper:
+    """Map one references.csv row to the CompactPaper schema.
+
+    Used for `additional_results` — papers in the wider fetched set beyond the
+    top-N. Carries the full abstract (truncated only at ~1800 chars) so the
+    LLM has enough semantic signal to identify what's missing in the top-N.
+    """
+
+    def _g(*cols: str):
+        for col in cols:
+            if col in row.index:
+                val = row[col]
+                if val is None or (isinstance(val, float) and pd.isna(val)):
+                    continue
+                return val
+        return None
+
+    abstract = _g("abstract", "content", "abstract_snippet", "abstract_or_summary")
+    if isinstance(abstract, str) and len(abstract) > _COMPACT_ABSTRACT_MAX_CHARS:
+        abstract = abstract[:_COMPACT_ABSTRACT_MAX_CHARS].rstrip() + "…"
+
+    year = _g("publication_year", "year")
+    rel = _g("relevance_score")
+    vpri = _g("variant_priority")
+
+    return CompactPaper(
+        doc_id=str(_g("doc_id", "id") or ""),
+        rank=rank,
+        title=str(_g("title") or "No title available"),
+        abstract_snippet=str(abstract) if abstract else None,
+        year=int(year) if year is not None and not pd.isna(year) else None,
+        source_country=str(_g("source_country") or "") or None,
+        venue=str(_g("venue") or "") or None,
+        document_type=str(_g("work_type", "type", "document_type") or "") or None,
+        source=str(_g("source") or "") or None,
+        relevance_score=float(rel) if rel is not None and not pd.isna(rel) else None,
+        query_variant=str(_g("query_variant") or "") or None,
+        variant_priority=int(vpri) if vpri is not None and not pd.isna(vpri) else None,
+    )
+
+
+# Country-name normalisation map. OpenAlex's source_country is produced upstream
+# by `convert_country_codes_to_names` (full names like "United States"); Overton
+# uses raw labels (often "USA", "UK", or ISO codes). Without normalisation, the
+# same country surfaces as two entries in the summary strip — seen in the wild as
+# "24% USA · 20% United States · …". Hybrid policy: deterministic dict for
+# known-recurring cross-source mismatches; the LLM's gap-analysis reflection
+# (post-call, per spec §12) catches anything novel. See spec §8.
+_COUNTRY_ALIAS: dict[str, str] = {
+    # United States
+    "us": "US",
+    "usa": "US",
+    "united states": "US",
+    "united states of america": "US",
+    "u.s.": "US",
+    "u.s.a.": "US",
+    # United Kingdom
+    "uk": "UK",
+    "gb": "UK",
+    "great britain": "UK",
+    "britain": "UK",
+    "united kingdom": "UK",
+    "united kingdom of great britain and northern ireland": "UK",
+    "england": "UK",
+    "scotland": "UK",
+    "wales": "UK",
+    "northern ireland": "UK",
+    # Frequently-occurring others worth canonicalising
+    "canada": "Canada",
+    "ca": "Canada",
+    "australia": "Australia",
+    "au": "Australia",
+    "new zealand": "New Zealand",
+    "nz": "New Zealand",
+    "ireland": "Ireland",
+    "ie": "Ireland",
+    "germany": "Germany",
+    "de": "Germany",
+    "france": "France",
+    "fr": "France",
+    "netherlands": "Netherlands",
+    "nl": "Netherlands",
+    "the netherlands": "Netherlands",
+    "spain": "Spain",
+    "es": "Spain",
+    "italy": "Italy",
+    "it": "Italy",
+    "sweden": "Sweden",
+    "se": "Sweden",
+    "norway": "Norway",
+    "no": "Norway",
+    "denmark": "Denmark",
+    "dk": "Denmark",
+    "finland": "Finland",
+    "fi": "Finland",
+}
+
+
+def _normalise_country(raw: str) -> str:
+    """Best-effort country-name normalisation. Falls back to the raw value
+    title-cased if no alias matches — preserves unfamiliar labels rather than
+    collapsing them into 'Unknown'.
+    """
+    key = raw.strip().lower()
+    if not key:
+        return ""
+    if key in _COUNTRY_ALIAS:
+        return _COUNTRY_ALIAS[key]
+    return raw.strip().title()
+
+
+def _compute_result_summary(df: pd.DataFrame) -> ResultSummary:
+    """Compute aggregate distributions over the full fetched DataFrame.
+
+    Runs deterministic pandas operations — no LLM cost, ~10ms server-side.
+    The output drives both the widget's summary strip and the LLM's
+    gap-analysis reflection. See docs/spec_search_evidence_agentic.md §8.
+    """
+    if df.empty:
+        return ResultSummary()
+
+    # Country distribution — normalise across sources before counting so that
+    # OpenAlex's "United States" and Overton's "USA" don't surface as separate
+    # entries. Fall back gracefully when source_country is missing.
+    countries: dict[str, int] = {}
+    if "source_country" in df.columns:
+        counts = df["source_country"].dropna().astype(str).str.strip()
+        counts = counts[counts != ""]
+        normalised = counts.apply(_normalise_country)
+        normalised = normalised[normalised != ""]
+        countries = normalised.value_counts().to_dict()
+
+    # Year range + median across rows that have a year.
+    year_col = "publication_year" if "publication_year" in df.columns else "year"
+    year_range: tuple[int, int] | None = None
+    year_median: int | None = None
+    if year_col in df.columns:
+        years = pd.to_numeric(df[year_col], errors="coerce").dropna().astype(int)
+        if not years.empty:
+            year_range = (int(years.min()), int(years.max()))
+            year_median = int(years.median())
+
+    # Source mix (openalex vs overton vs …).
+    source_mix: dict[str, int] = {}
+    if "source" in df.columns:
+        source_mix = df["source"].dropna().astype(str).value_counts().to_dict()
+
+    # Document-type mix — coalesce across plausible column names.
+    doctype_mix: dict[str, int] = {}
+    for col in ("work_type", "type", "document_type"):
+        if col in df.columns:
+            doctype_mix = df[col].dropna().astype(str).value_counts().to_dict()
+            break
+
+    # Open-access fraction over rows that report it (excluding nulls).
+    oa_fraction: float | None = None
+    for col in ("is_oa", "is_open_access"):
+        if col in df.columns:
+            oa = df[col].dropna()
+            if not oa.empty:
+                oa_fraction = float(oa.astype(bool).mean())
+            break
+
+    return ResultSummary(
+        country_distribution=countries,
+        year_range=year_range,
+        year_median=year_median,
+        source_mix=source_mix,
+        document_type_mix=doctype_mix,
+        open_access_fraction=oa_fraction,
+    )
+
+
+@mcp.tool(meta={"ui": {"resourceUri": SEARCH_EVIDENCE_URI}})
+async def search_evidence(
+    research_question: str,
+    population: list[str] | None = None,
+    outcome: list[str] | None = None,
+    inner_setting: list[str] | None = None,
+    geography: list[str] | None = None,
+    sources: list[str] | None = None,
+    max_results: int = 5,
+    total_limit: int = 50,
+    ctx: Context | None = None,
+) -> SearchEvidenceOutput:
+    """Search OpenAlex (academic papers) and Overton (policy documents) for evidence.
+
+    WHEN TO CALL:
+    Call after the user has confirmed PICO picks (via the picker widget).
+    May also be called standalone if the user gives explicit search terms
+    without going through the picker. Defaults: both sources, max_results=5,
+    total_limit=50.
+
+    WHAT IT RETURNS:
+    Three layers in structuredContent:
+      - results: top-N papers (rendered by the search-evidence widget).
+      - additional_results: ~45 more papers as CompactPaper — full abstracts
+        included — NOT rendered by the widget; for YOUR reasoning over the
+        wider evidence base.
+      - result_summary: aggregate distributions (country, year range/median,
+        source mix, document_type mix, OA fraction) over the FULL fetched
+        set — rendered as a summary strip above the result cards, also
+        available to you for reflection.
+    Each paper also carries: relevance_score (from source API), query_variant
+    (which boolean query matched), variant_priority, source.
+
+    PRESENTATION:
+    The widget renders top-5 + summary strip. Do not re-narrate either.
+    A single brief acknowledgement is enough ("Results above; ~30s search").
+
+    POST-CALL REFLECTION — REQUIRED:
+    Silently perform a research gap analysis against the user's question.
+    Ground it in actual data using result_summary + additional_results — do
+    not speculate beyond what the results show.
+
+    Identify dimensions where the evidence base is THIN or MISSING relative
+    to what would fully answer the user's question:
+      - Study designs (e.g., effectiveness question but no RCTs/quasi-
+        experimental work in the set)
+      - Populations or subgroups the question implies but results don't
+        cover
+      - Intervention types or delivery contexts conspicuously absent
+      - Time periods (e.g., all pre-2015 when the question is current)
+      - Outcomes measured (e.g., question asks about long-term effects;
+        results only report short-term)
+      - Geographies, as ONE dimension among many — not the primary lens
+      - Source-mix asymmetry as a known limitation: Overton policy docs
+        are systematically deprioritised in the merged ranking because
+        their per-doc similarity score isn't extracted upstream. If the
+        question is policy-relevant and few Overton docs surfaced, this
+        may reflect that bias rather than a true literature gap.
+
+    Then propose ONE corrective action in chat, grounded in the gap analysis:
+      - For gaps adjusted search args would address → propose re-calling
+        search_evidence with the relevant change ("no RCTs in the top-50 —
+        want me to retry with stricter study-design filtering?")
+      - For gaps the wider set partly addresses → name the specific buried
+        papers ("Aubry 2020 at rank 12 covers the UK setting your question
+        implied — want to look at it?")
+      - For genuine evidence gaps (literature doesn't exist in the indexed
+        set) → note honestly ("no RCTs on this question appear; only
+        observational evidence available — the synthesis stage can still
+        proceed but flag the limitation")
+
+    Wait for explicit user confirmation before any corrective re-call.
+    Surface gaps even if no corrective action is possible — the user
+    benefits from knowing what's NOT in the evidence base.
+
+    DO NOT:
+    - Narrate the JSON; the widget renders it
+    - Auto-retry without user confirmation
+    - Treat the per-paper relevance_score as semantic relevance — it's a
+      raw BM25-ish score from OpenAlex, not an explained judgement
+    - Propose drilling into a paper's full text — that belongs to the next
+      workflow stage (run_analysis), not search
+    - Use geography as the primary lens of critique; treat it as one
+      dimension in the broader gap analysis
+    """
+    sources_list = sources or ["openalex", "overton"]
+
+    # PICO picks feed the boolean query generator via search_context
+    search_context = {
+        "research_question": research_question,
+        "population": population or [],
+        "outcome": outcome or [],
+        "geography": geography or [],
+    }
+
+    if ctx:
+        await ctx.info(
+            f"Searching {', '.join(sources_list)} for: {research_question[:70]}…"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="mcp_search_") as tmp:
+        service = ReferencesService(export_dir=tmp)
+        csv_path, boolean_queries, _semantic = await service.build_references(
+            query=research_question,
+            sources=sources_list,
+            limit=total_limit,
+            geography_filter=geography,
+            search_context=search_context,
+        )
+        df = pd.read_csv(csv_path)
+
+    total_found = len(df)
+    if ctx:
+        await ctx.info(
+            f"Found {total_found} papers across {len(boolean_queries)} queries; "
+            f"returning top {min(max_results, total_found)}."
+        )
+
+    # Three layers (see docs/spec_search_evidence_agentic.md §4, §6, §8):
+    #   results            — top-N rendered by the widget
+    #   additional_results — wider compact set (full abstracts) for LLM gap analysis
+    #   result_summary     — aggregate stats over the FULL fetched DataFrame
+    top_rows = df.head(max_results)
+    results = [_row_to_evidence(row) for _, row in top_rows.iterrows()]
+    additional_results = [
+        _row_to_compact_paper(row, rank=max_results + i + 1)
+        for i, (_, row) in enumerate(df.iloc[max_results:].iterrows())
+    ]
+    result_summary = _compute_result_summary(df)
+
+    output = SearchEvidenceOutput(
+        total_found=total_found,
+        results_returned=len(results),
+        results=results,
+        additional_results=additional_results,
+        result_summary=result_summary,
+        boolean_queries_used=boolean_queries,
+    )
+
+    # Mirrors the pattern used by suggest_pico_options: terse text so hosts
+    # that don't render the widget still get a useful summary, full data in
+    # structuredContent for the widget to render the results list.
+    summary = (
+        f"Found {total_found} papers across {len(boolean_queries)} queries; "
+        f"showing top {len(results)}. Wider {len(additional_results)} available for "
+        f"reflection. Rendered as an interactive list."
+    )
+    return CallToolResult(
+        content=[TextContent(type="text", text=summary)],
+        structuredContent=output.model_dump(mode="json", by_alias=True),
+    )

--- a/backend/app/mcp/widgets/.gitignore
+++ b/backend/app/mcp/widgets/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/backend/app/mcp/widgets/package-lock.json
+++ b/backend/app/mcp/widgets/package-lock.json
@@ -1,0 +1,2415 @@
+{
+  "name": "policy-atlas-mcp-widgets",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "policy-atlas-mcp-widgets",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.9.1",
+        "typescript": "^5.9.3",
+        "vite": "^6.0.0",
+        "vite-plugin-singlefile": "^2.3.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.2.tgz",
+      "integrity": "sha512-OOWKDxdAjYDcgHkmzVzccyyag3FK+jBWPaWu4WvTxFsU4R/cgOX4eep66zPRA5n4v6WfxUNibPyvX4iJ7egYTg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.22",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
+      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-singlefile": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.3.tgz",
+      "integrity": "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">18.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^4.59.0",
+        "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/backend/app/mcp/widgets/package.json
+++ b/backend/app/mcp/widgets/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "policy-atlas-mcp-widgets",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP Apps widgets for the Policy Atlas FastMCP server.",
+  "scripts": {
+    "build": "rm -rf dist && INPUT=pico-picker.html vite build && INPUT=search-evidence.html vite build",
+    "build:picker": "INPUT=pico-picker.html vite build",
+    "build:results": "INPUT=search-evidence.html vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^5.9.3",
+    "vite": "^6.0.0",
+    "vite-plugin-singlefile": "^2.3.0"
+  }
+}

--- a/backend/app/mcp/widgets/pico-picker.html
+++ b/backend/app/mcp/widgets/pico-picker.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>PICO Picker</title>
+  </head>
+  <body>
+    <main class="container" id="root">
+      <p class="empty">Waiting for options…</p>
+    </main>
+    <script type="module" src="/src/pico-picker.ts"></script>
+  </body>
+</html>

--- a/backend/app/mcp/widgets/search-evidence.html
+++ b/backend/app/mcp/widgets/search-evidence.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Evidence Results</title>
+  </head>
+  <body>
+    <main class="container" id="root">
+      <div class="loading">
+        <p class="loading-text">Searching evidence…</p>
+        <div class="progress"><div class="progress-bar"></div></div>
+        <p class="loading-hint">
+          Querying OpenAlex &amp; Overton — this usually takes ~25 seconds.
+        </p>
+      </div>
+    </main>
+    <script type="module" src="/src/search-evidence.ts"></script>
+  </body>
+</html>

--- a/backend/app/mcp/widgets/src/host-styles.css
+++ b/backend/app/mcp/widgets/src/host-styles.css
@@ -1,0 +1,31 @@
+:root {
+  --pa-fg: var(--color-text-primary, #1a1a1a);
+  --pa-muted: var(--color-text-secondary, #5e6772);
+  --pa-border: var(--color-border-primary, #d8dde3);
+  --pa-bg: var(--color-background-primary, #ffffff);
+  --pa-card: var(--color-background-secondary, #f5f7fa);
+  --pa-accent: var(--color-text-accent, #2a5fb5);
+  --pa-accent-fg: var(--color-text-on-accent, #ffffff);
+  --pa-radius: var(--border-radius-md, 8px);
+  --pa-font: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font: 14px/1.45 var(--pa-font);
+  color: var(--pa-fg);
+  background: var(--pa-bg);
+}
+
+.container {
+  padding: 16px;
+}
+
+.empty {
+  color: var(--pa-muted);
+  font-style: italic;
+  padding: 12px;
+  text-align: center;
+}

--- a/backend/app/mcp/widgets/src/pico-picker.css
+++ b/backend/app/mcp/widgets/src/pico-picker.css
@@ -1,0 +1,122 @@
+@import "./host-styles.css";
+
+h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+p.subtitle {
+  margin: 0 0 16px;
+  color: var(--pa-muted);
+  font-size: 13px;
+}
+
+.facet {
+  margin-bottom: 14px;
+  padding: 12px;
+  border-radius: var(--pa-radius);
+  background: var(--pa-card);
+  border: 1px solid var(--pa-border);
+}
+
+.facet h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--pa-muted);
+}
+
+.option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 4px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.option:hover { background: rgba(127, 127, 127, 0.08); }
+.option input[type="checkbox"] { margin-top: 2px; }
+.option .label { font-weight: 500; }
+.option .desc { color: var(--pa-muted); font-size: 12px; margin-top: 2px; }
+
+.custom-row {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--pa-border);
+}
+
+.custom-row input[type="text"] {
+  flex: 1;
+  font: inherit;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--pa-border);
+  background: var(--pa-bg);
+  color: var(--pa-fg);
+}
+
+.custom-row button {
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.custom-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 4px 0 0;
+  padding: 3px 8px;
+  font-size: 12px;
+  background: var(--pa-bg);
+  border: 1px solid var(--pa-accent);
+  color: var(--pa-accent);
+  border-radius: 12px;
+}
+
+.custom-tag button {
+  background: none;
+  border: none;
+  color: var(--pa-accent);
+  cursor: pointer;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+button {
+  font: inherit;
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--pa-border);
+  background: var(--pa-bg);
+  color: var(--pa-fg);
+  cursor: pointer;
+}
+
+button.primary {
+  background: var(--pa-accent);
+  color: var(--pa-accent-fg);
+  border-color: var(--pa-accent);
+  font-weight: 600;
+}
+
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.status {
+  margin-left: auto;
+  color: var(--pa-muted);
+  font-size: 12px;
+}

--- a/backend/app/mcp/widgets/src/pico-picker.ts
+++ b/backend/app/mcp/widgets/src/pico-picker.ts
@@ -1,0 +1,280 @@
+import {
+  App,
+  applyDocumentTheme,
+  applyHostFonts,
+  applyHostStyleVariables,
+  type McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps";
+import "./pico-picker.css";
+
+type PicoOption = { label: string; description?: string };
+
+type SuggestPicoOptionsOutput = {
+  research_question?: string;
+  population_options?: PicoOption[];
+  outcome_options?: PicoOption[];
+  inner_setting_options?: PicoOption[];
+};
+
+type FacetSlug = "population" | "outcome" | "inner_setting";
+
+const root = document.getElementById("root") as HTMLElement;
+
+let researchQuestion = "";
+let structured: SuggestPicoOptionsOutput = {};
+let pending = false;
+
+// User-added free-text options, in addition to the LLM-generated set.
+const customOptions: Record<FacetSlug, string[]> = {
+  population: [],
+  outcome: [],
+  inner_setting: [],
+};
+
+function handleHostContextChanged(ctx: McpUiHostContext) {
+  if (ctx.theme) applyDocumentTheme(ctx.theme);
+  if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
+  if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+  if (ctx.safeAreaInsets) {
+    const { top, right, bottom, left } = ctx.safeAreaInsets;
+    root.style.padding = `${16 + top}px ${16 + right}px ${16 + bottom}px ${16 + left}px`;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c] as string),
+  );
+}
+
+function renderCustomTags(slug: FacetSlug): string {
+  return customOptions[slug]
+    .map(
+      (val, i) => `
+      <span class="custom-tag">
+        ${escapeHtml(val)}
+        <button type="button" data-remove-slug="${slug}" data-remove-idx="${i}" aria-label="Remove">×</button>
+      </span>
+    `,
+    )
+    .join("");
+}
+
+function renderFacet(title: string, slug: FacetSlug, options?: PicoOption[]): string {
+  const items = (options ?? [])
+    .map((opt, i) => {
+      const id = `${slug}-${i}`;
+      const label = opt.label ?? "";
+      const desc = opt.description ?? "";
+      return `
+        <label class="option" for="${id}">
+          <input type="checkbox" id="${id}" name="${slug}" value="${escapeHtml(label)}" />
+          <span>
+            <span class="label">${escapeHtml(label)}</span>
+            ${desc ? `<div class="desc">${escapeHtml(desc)}</div>` : ""}
+          </span>
+        </label>
+      `;
+    })
+    .join("");
+
+  return `
+    <div class="facet" data-facet="${slug}">
+      <h3>${escapeHtml(title)}</h3>
+      ${items || (customOptions[slug].length === 0 ? `<p class="empty" style="padding:6px 4px;text-align:left;">No suggestions — add your own below.</p>` : "")}
+      <div data-tags="${slug}">${renderCustomTags(slug)}</div>
+      <div class="custom-row">
+        <input type="text" data-custom-slug="${slug}" placeholder="+ add your own ${title.toLowerCase()}…" />
+        <button type="button" data-add-slug="${slug}">Add</button>
+      </div>
+    </div>
+  `;
+}
+
+function gatherSelections(slug: FacetSlug): string[] {
+  const checked = Array.from(
+    document.querySelectorAll<HTMLInputElement>(`input[name="${slug}"]:checked`),
+  ).map((el) => el.value);
+  return [...checked, ...customOptions[slug]];
+}
+
+function setStatus(text: string) {
+  const el = document.getElementById("status");
+  if (el) el.textContent = text;
+}
+
+function addCustomOption(slug: FacetSlug) {
+  const input = document.querySelector<HTMLInputElement>(
+    `input[data-custom-slug="${slug}"]`,
+  );
+  if (!input) return;
+  const val = input.value.trim();
+  if (!val) return;
+  if (customOptions[slug].includes(val)) {
+    input.value = "";
+    return;
+  }
+  customOptions[slug].push(val);
+  input.value = "";
+  refreshTags(slug);
+}
+
+function removeCustomOption(slug: FacetSlug, idx: number) {
+  customOptions[slug].splice(idx, 1);
+  refreshTags(slug);
+}
+
+function refreshTags(slug: FacetSlug) {
+  const container = document.querySelector<HTMLElement>(`[data-tags="${slug}"]`);
+  if (container) container.innerHTML = renderCustomTags(slug);
+}
+
+function bindEvents() {
+  root.addEventListener("click", (ev) => {
+    const target = ev.target as HTMLElement;
+    const addSlug = target.dataset.addSlug as FacetSlug | undefined;
+    if (addSlug) {
+      addCustomOption(addSlug);
+      return;
+    }
+    const removeSlug = target.dataset.removeSlug as FacetSlug | undefined;
+    if (removeSlug && target.dataset.removeIdx != null) {
+      removeCustomOption(removeSlug, Number(target.dataset.removeIdx));
+      return;
+    }
+    if (target.id === "search-btn") {
+      submitSearch();
+    }
+  });
+
+  root.addEventListener("keydown", (ev) => {
+    const target = ev.target as HTMLElement;
+    if (
+      ev.key === "Enter" &&
+      target instanceof HTMLInputElement &&
+      target.dataset.customSlug
+    ) {
+      ev.preventDefault();
+      addCustomOption(target.dataset.customSlug as FacetSlug);
+    }
+  });
+}
+
+function render() {
+  const data = structured;
+  root.innerHTML = `
+    <h2>Frame your research</h2>
+    <p class="subtitle">${
+      researchQuestion
+        ? escapeHtml(researchQuestion)
+        : "Pick one or more options per facet, add your own if needed, then submit."
+    }</p>
+    ${renderFacet("Population", "population", data.population_options)}
+    ${renderFacet("Outcome", "outcome", data.outcome_options)}
+    ${renderFacet("Inner setting", "inner_setting", data.inner_setting_options)}
+    <div class="actions">
+      <button class="primary" id="search-btn">Search evidence</button>
+      <span class="status" id="status"></span>
+    </div>
+  `;
+}
+
+// Structured picks intended for the LLM, not the user. Shipped via
+// updateModelContext so they never appear in the chat textbox.
+function buildContextBlock(
+  question: string,
+  population: string[],
+  outcome: string[],
+  inner_setting: string[],
+): string {
+  const fmt = (label: string, vals: string[]) =>
+    vals.length === 0 ? `${label}: (any)` : `${label}: ${vals.join("; ")}`;
+  return [
+    `The user is framing a research search with the PICO picker.`,
+    `When they ask you to search next, call the search_evidence tool with these exact arguments:`,
+    `- research_question: "${question}"`,
+    `- ${fmt("population", population)}`,
+    `- ${fmt("outcome", outcome)}`,
+    `- ${fmt("inner_setting", inner_setting)}`,
+    `- max_results: 5`,
+    `- total_limit: 30`,
+  ].join("\n");
+}
+
+// Short natural-language trigger the user will see pre-filled in the chat
+// input. Kept friendly so it's coherent if they press send as-is.
+function buildTrigger(question: string): string {
+  return `Search the evidence for "${question}" using the framings I picked.`;
+}
+
+async function submitSearch() {
+  if (pending) return;
+  if (!researchQuestion) {
+    setStatus("No research question received from host.");
+    return;
+  }
+  const btn = document.getElementById("search-btn") as HTMLButtonElement | null;
+  if (!btn) return;
+
+  pending = true;
+  btn.disabled = true;
+  setStatus("Sending to assistant…");
+
+  const contextBlock = buildContextBlock(
+    researchQuestion,
+    gatherSelections("population"),
+    gatherSelections("outcome"),
+    gatherSelections("inner_setting"),
+  );
+  const trigger = buildTrigger(researchQuestion);
+
+  try {
+    // Order matters: ship the structured picks into model context first, then
+    // send the visible trigger. If the trigger landed first the LLM might call
+    // search_evidence before the picks are available to reason over.
+    await app.updateModelContext({
+      content: [{ type: "text", text: contextBlock }],
+    });
+    const { isError } = await app.sendMessage({
+      role: "user",
+      content: [{ type: "text", text: trigger }],
+    });
+    if (isError) {
+      setStatus("Host rejected the message.");
+      btn.disabled = false;
+      pending = false;
+      return;
+    }
+    setStatus("Sent — results will appear in chat.");
+    // Leave the button disabled: the picker has done its job for this round.
+  } catch (e) {
+    setStatus(`Send failed: ${e instanceof Error ? e.message : String(e)}`);
+    btn.disabled = false;
+    pending = false;
+  }
+}
+
+const app = new App({ name: "PICO Picker", version: "0.1.0" });
+
+app.ontoolinput = (params) => {
+  const args = (params.arguments ?? {}) as { question?: string };
+  researchQuestion = args.question ?? "";
+};
+
+app.ontoolresult = (result) => {
+  structured = (result.structuredContent ?? {}) as SuggestPicoOptionsOutput;
+  if (!researchQuestion && structured.research_question) {
+    researchQuestion = structured.research_question;
+  }
+  render();
+};
+
+app.onhostcontextchanged = handleHostContextChanged;
+app.onerror = (err) => console.error("[pico-picker]", err);
+
+bindEvents();
+
+app.connect().then(() => {
+  const ctx = app.getHostContext();
+  if (ctx) handleHostContextChanged(ctx);
+});

--- a/backend/app/mcp/widgets/src/search-evidence.css
+++ b/backend/app/mcp/widgets/src/search-evidence.css
@@ -1,0 +1,164 @@
+@import "./host-styles.css";
+
+.head {
+  margin-bottom: 12px;
+}
+
+.head h2 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--pa-muted);
+  font-size: 13px;
+}
+
+.summary-strip {
+  margin: 6px 0 0;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--pa-muted);
+  background: var(--pa-card);
+  border: 1px solid var(--pa-border);
+  border-radius: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.result {
+  padding: 12px;
+  border-radius: var(--pa-radius);
+  background: var(--pa-card);
+  border: 1px solid var(--pa-border);
+}
+
+.result-head {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.num {
+  color: var(--pa-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  font-weight: 600;
+  min-width: 18px;
+}
+
+.title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+  flex: 1;
+}
+
+.meta {
+  margin: 4px 0 6px 26px;
+  color: var(--pa-muted);
+  font-size: 12px;
+}
+
+.abstract {
+  margin: 0 0 6px 26px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.open {
+  margin-left: 26px;
+  display: inline-block;
+  color: var(--pa-accent);
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.open:hover { text-decoration: underline; }
+
+.badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--pa-accent);
+  border: 1px solid var(--pa-accent);
+  border-radius: 4px;
+}
+
+.doctype-chip {
+  display: inline-block;
+  padding: 1px 7px;
+  margin-right: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: 4px;
+  letter-spacing: 0.02em;
+  background: var(--pa-bg);
+  color: var(--pa-muted);
+  border: 1px solid var(--pa-border);
+  vertical-align: 1px;
+}
+
+/* Loading state ------------------------------------------------------------ */
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px 4px;
+}
+
+.loading-text {
+  font-size: 13px;
+  color: var(--pa-muted);
+  margin: 0;
+}
+
+.loading-text strong {
+  color: var(--pa-fg);
+  font-weight: 600;
+}
+
+.progress {
+  position: relative;
+  height: 4px;
+  background: var(--pa-card);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  position: absolute;
+  inset: 0;
+  width: 30%;
+  background: var(--pa-accent);
+  border-radius: 2px;
+  animation: progress-slide 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@keyframes progress-slide {
+  0% { transform: translateX(-100%); }
+  50% { transform: translateX(150%); }
+  100% { transform: translateX(350%); }
+}
+
+.loading-hint {
+  font-size: 11px;
+  color: var(--pa-muted);
+  margin: 0;
+  font-style: italic;
+}

--- a/backend/app/mcp/widgets/src/search-evidence.ts
+++ b/backend/app/mcp/widgets/src/search-evidence.ts
@@ -1,0 +1,235 @@
+import {
+  App,
+  applyDocumentTheme,
+  applyHostFonts,
+  applyHostStyleVariables,
+  type McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps";
+import "./search-evidence.css";
+
+type EvidenceResult = {
+  doc_id?: string;
+  title?: string;
+  year?: number | null;
+  source?: string | null;
+  document_type?: string | null;
+  authors?: string[];
+  venue?: string | null;
+  cited_by_count?: number | null;
+  abstract_snippet?: string | null;
+  is_open_access?: boolean | null;
+  landing_page_url?: string | null;
+};
+
+type ResultSummary = {
+  country_distribution?: Record<string, number>;
+  year_range?: [number, number] | null;
+  year_median?: number | null;
+  source_mix?: Record<string, number>;
+  document_type_mix?: Record<string, number>;
+  open_access_fraction?: number | null;
+};
+
+type SearchEvidenceOutput = {
+  total_found?: number;
+  results_returned?: number;
+  results?: EvidenceResult[];
+  result_summary?: ResultSummary | null;
+  boolean_queries_used?: string[];
+};
+
+const root = document.getElementById("root") as HTMLElement;
+
+let structured: SearchEvidenceOutput = {};
+let researchQuestion = "";
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c] as string),
+  );
+}
+
+function formatAuthors(authors?: string[]): string {
+  if (!authors || authors.length === 0) return "";
+  if (authors.length === 1) return authors[0];
+  if (authors.length === 2) return authors.join(" & ");
+  return `${authors[0]} et al.`;
+}
+
+// Turn OpenAlex/Overton-style codes like "journal-article" into "Journal Article".
+// Deterministic, no LLM — these strings come straight from the source.
+function humaniseDocType(raw?: string | null): string {
+  if (!raw) return "";
+  return raw
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// Uninformative values to suppress — OpenAlex sometimes emits "unknown" as
+// type_crossref when it has no signal; rendering that as a chip looks like a
+// category label (visually identical to the old evidence-category "Unknown"
+// badge we removed). A missing chip is better than a misleading one.
+const _UNINFORMATIVE_DOCTYPE = new Set(["unknown", "other", "n/a", "none", ""]);
+
+function renderDocTypeChip(doc_type?: string | null): string {
+  if (!doc_type) return "";
+  if (_UNINFORMATIVE_DOCTYPE.has(doc_type.trim().toLowerCase())) return "";
+  const label = humaniseDocType(doc_type);
+  if (!label) return "";
+  return `<span class="doctype-chip">${escapeHtml(label)}</span>`;
+}
+
+// Render the aggregate summary strip from result_summary. Computed server-side
+// over the FULL fetched set (not just top-N). See docs/spec_search_evidence_agentic.md §8.
+function renderSummaryStrip(summary?: ResultSummary | null): string {
+  if (!summary) return "";
+
+  const parts: string[] = [];
+
+  // Country distribution: top-2 by share + "other" rolled up.
+  const countries = summary.country_distribution ?? {};
+  const totalC = Object.values(countries).reduce((a, b) => a + b, 0);
+  if (totalC > 0) {
+    const sorted = Object.entries(countries).sort((a, b) => b[1] - a[1]);
+    const pct = (n: number) => Math.round((n / totalC) * 100);
+    const items = sorted.slice(0, 2).map(([k, v]) => `${pct(v)}% ${k}`);
+    const otherCount = sorted.slice(2).reduce((s, [, c]) => s + c, 0);
+    if (otherCount > 0) items.push(`${pct(otherCount)}% other`);
+    parts.push(items.join(" · "));
+  }
+
+  // Year range + median.
+  if (summary.year_range) {
+    const [yMin, yMax] = summary.year_range;
+    parts.push(
+      summary.year_median != null
+        ? `${yMin}–${yMax} (median ${summary.year_median})`
+        : `${yMin}–${yMax}`,
+    );
+  }
+
+  // Source mix — map known keys to friendlier labels; keep counts.
+  const sources = summary.source_mix ?? {};
+  const sourceLabel: Record<string, string> = {
+    openalex: "academic",
+    overton: "policy",
+  };
+  const sourceParts = Object.entries(sources)
+    .filter(([, n]) => n > 0)
+    .map(([k, n]) => `${n} ${sourceLabel[k] ?? k}`);
+  if (sourceParts.length > 0) parts.push(sourceParts.join(" / "));
+
+  // Open-access fraction when known.
+  if (summary.open_access_fraction != null) {
+    const oaPct = Math.round(summary.open_access_fraction * 100);
+    parts.push(`${oaPct}% open access`);
+  }
+
+  if (parts.length === 0) return "";
+  return `<p class="summary-strip">${escapeHtml(parts.join(" · "))}</p>`;
+}
+
+function renderResult(r: EvidenceResult, idx: number): string {
+  const title = r.title || "Untitled";
+  const metaText = [
+    r.year != null ? String(r.year) : null,
+    formatAuthors(r.authors),
+    r.venue,
+    r.cited_by_count != null ? `cited by ${r.cited_by_count}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const abstract = r.abstract_snippet ?? "";
+  const link = r.landing_page_url
+    ? `<a class="open" href="${escapeHtml(r.landing_page_url)}" target="_blank" rel="noopener noreferrer">Open ↗</a>`
+    : "";
+  const oa = r.is_open_access ? `<span class="badge">Open access</span>` : "";
+  const chip = renderDocTypeChip(r.document_type);
+
+  // Chip inlines at the start of the meta line, grouping "at a glance"
+  // signals together (type · year · authors · venue · citations · OA).
+  const metaInner = [chip, metaText ? escapeHtml(metaText) : "", oa]
+    .filter(Boolean)
+    .join(" ");
+  const metaLine = metaInner ? `<p class="meta">${metaInner}</p>` : "";
+
+  return `
+    <li class="result">
+      <div class="result-head">
+        <span class="num">${idx + 1}</span>
+        <h3 class="title">${escapeHtml(title)}</h3>
+      </div>
+      ${metaLine}
+      ${abstract ? `<p class="abstract">${escapeHtml(abstract)}</p>` : ""}
+      ${link}
+    </li>
+  `;
+}
+
+// Updates the loading view in place if ontoolinput has given us the question.
+// The initial loading markup ships in the static HTML (search-evidence.html)
+// so the progress bar renders the moment the iframe mounts — many hosts
+// (notably Claude Desktop) don't fire ontoolinput before ontoolresult, so
+// relying on it alone left the bar invisible.
+function updateLoadingQuestion() {
+  if (!researchQuestion) return;
+  const textEl = root.querySelector<HTMLElement>(".loading-text");
+  if (textEl) {
+    textEl.innerHTML = `Searching evidence for <strong>"${escapeHtml(researchQuestion)}"</strong>…`;
+  }
+}
+
+function renderResults() {
+  const data = structured;
+  const total = data.total_found ?? 0;
+  const results = data.results ?? [];
+  const returned = results.length;
+
+  if (returned === 0) {
+    const q = researchQuestion ? ` for "${escapeHtml(researchQuestion)}"` : "";
+    root.innerHTML = `<p class="empty">No matching evidence found${q}.</p>`;
+    return;
+  }
+
+  root.innerHTML = `
+    <header class="head">
+      <h2>Evidence results</h2>
+      <p class="subtitle">Found ${total} papers · showing top ${returned}</p>
+      ${renderSummaryStrip(data.result_summary)}
+    </header>
+    <ol class="results">
+      ${results.map(renderResult).join("")}
+    </ol>
+  `;
+}
+
+function handleHostContextChanged(ctx: McpUiHostContext) {
+  if (ctx.theme) applyDocumentTheme(ctx.theme);
+  if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
+  if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+  if (ctx.safeAreaInsets) {
+    const { top, right, bottom, left } = ctx.safeAreaInsets;
+    root.style.padding = `${16 + top}px ${16 + right}px ${16 + bottom}px ${16 + left}px`;
+  }
+}
+
+const app = new App({ name: "Search Evidence Results", version: "0.1.0" });
+
+app.ontoolinput = (params) => {
+  const args = (params.arguments ?? {}) as { research_question?: string };
+  researchQuestion = args.research_question ?? "";
+  updateLoadingQuestion();
+};
+
+app.ontoolresult = (result) => {
+  structured = (result.structuredContent ?? {}) as SearchEvidenceOutput;
+  renderResults();
+};
+
+app.onhostcontextchanged = handleHostContextChanged;
+app.onerror = (err) => console.error("[search-evidence]", err);
+
+app.connect().then(() => {
+  const ctx = app.getHostContext();
+  if (ctx) handleHostContextChanged(ctx);
+});

--- a/backend/app/mcp/widgets/tsconfig.json
+++ b/backend/app/mcp/widgets/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "pico-picker.html"]
+}

--- a/backend/app/mcp/widgets/vite.config.ts
+++ b/backend/app/mcp/widgets/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+const INPUT = process.env.INPUT;
+if (!INPUT) {
+  throw new Error("INPUT environment variable is not set (e.g. INPUT=pico-picker.html)");
+}
+
+export default defineConfig({
+  plugins: [viteSingleFile()],
+  build: {
+    outDir: "dist",
+    emptyOutDir: false,
+    rollupOptions: {
+      input: INPUT,
+    },
+  },
+});

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "vl-convert-python>=1.8.0",
     "argilla>=2.8.0",
     "boto3>=1.42.0",
+    "mcp>=1.0.0",
 ]
 
 [tool.setuptools]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -301,6 +301,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langfuse" },
     { name = "langgraph" },
+    { name = "mcp" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
@@ -354,6 +355,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.1.0" },
     { name = "langfuse", specifier = ">=2.60.7" },
     { name = "langgraph", specifier = ">=0.5.4" },
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.14" },
     { name = "mkdocstrings", specifier = ">=0.29.1" },
@@ -1248,6 +1250,15 @@ wheels = [
 [package.optional-dependencies]
 http2 = [
     { name = "h2" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960 },
 ]
 
 [[package]]
@@ -2247,6 +2258,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516 },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260 },
 ]
 
 [[package]]
@@ -3704,6 +3740,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543 },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040 },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102 },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700 },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700 },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318 },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714 },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800 },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540 },
+]
+
+[[package]]
 name = "pywinpty"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4399,6 +4451,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/89/23/adf3796d740536d63a6fbda113d07e60c734b6ed5d3058d1e47fc0495e47/soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350", size = 117856 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/f3/b67d6ea49ca9154453b6d70b34ea22f3996b9fa55da105a79d8732227adc/soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434", size = 36710 },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514 },
 ]
 
 [[package]]

--- a/docs/mcp_integration_plan.md
+++ b/docs/mcp_integration_plan.md
@@ -1,0 +1,410 @@
+# Policy Atlas MCP Integration Spec
+
+## Context
+
+Policy Atlas is heading towards a world where **Microsoft Copilot Cowork** is the primary consumption surface. Cowork is an autonomous agent (powered by Anthropic's Claude) that plans and executes multi-step workflows inside Microsoft 365. It breaks down a user's request into steps, calls tools autonomously, runs in the background, and checks in at key moments for approval.
+
+This means the MCP server's caller is **an autonomous agent, not a human in a chat**. Policy Atlas provides atomic tools — Cowork decides how to sequence them, when to ask the user for clarification, and when to proceed. The user might say "Research what works for reducing school exclusions and write me a briefing" and Cowork handles the entire orchestration.
+
+### Design principles
+
+1. **Atomic tools, Cowork orchestrates.** We expose focused building blocks. Cowork chains them into workflows.
+2. **Stateless server.** Cowork holds working memory across tool calls. We don't maintain session state.
+3. **First-time user journey.** The tools assume no prior projects exist. The entry point is a policy question, not a project ID.
+4. **Auto-persist on analysis only.** Lightweight search is ephemeral. A project is created only when the full analysis pipeline runs.
+5. **Cost controls + action visibility.** Rate limits per user/org. Every tool call and result is logged and auditable.
+
+### Key references
+
+- [Deep research report](./deep-research-report.md) — Copilot extensibility, Entra ID auth, MCP Apps, civil service adoption
+- [Microsoft Copilot Cowork announcement](https://www.microsoft.com/en-us/microsoft-365/blog/2026/03/09/copilot-cowork-a-new-way-of-getting-work-done/)
+- [MCP in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp)
+- [Build declarative agents with MCP](https://devblogs.microsoft.com/microsoft365dev/build-declarative-agents-for-microsoft-365-copilot-with-mcp/)
+
+---
+
+## Tool surface
+
+### Spike tools (exploration)
+
+| Tool | Purpose | Latency | Consequential |
+|---|---|---|---|
+| `suggest_pico_options` | Suggest LLM-generated PICO option sets (population, outcome, setting, geography) for a policy question | ~3s | No |
+| `search_evidence` | Search OpenAlex/Overton using PICO-structured parameters | ~5-10s | No |
+
+### Full tool surface (post-spike)
+
+| Tool | Purpose | Latency | Consequential |
+|---|---|---|---|
+| `suggest_pico_options` | Suggest PICO option sets for a policy question | ~3s | No |
+| `search_evidence` | Search OpenAlex/Overton using PICO-structured parameters | ~5-10s | No |
+| `run_analysis` | Run full pipeline (screen, extract, synthesize). Creates a project. | Immediate return, minutes to complete | **Yes** |
+| `get_job_status` | Poll analysis progress | instant | No |
+| `get_results` | Retrieve synthesis summary, evidence, interventions from a completed analysis | instant | No |
+| `chat_with_evidence` | RAG Q&A over a completed analysis corpus | ~3-5s | No |
+
+Six tools total. Small enough for reliable Cowork orchestration.
+
+> **Design note:** the original draft of this plan had two tools at the front of the pipeline — `extract_pico` (infer PICO from the question) and `generate_options` (suggest refinements per component). We collapsed them into a single `suggest_pico_options` because (a) the existing app does suggestion, not inference, so that's the genuine domain value; (b) Cowork can do shallow text inference itself with a generic prompt — exposing it as a tool adds no value; (c) fewer tools = more reliable orchestration.
+
+---
+
+## Tool specifications
+
+### `suggest_pico_options`
+
+Takes a policy question and returns LLM-suggested option sets for each PICO facet — population, outcome, inner setting, and geography. Cowork (or a human via Cowork's checkpoint) then picks from these to build a structured search.
+
+Generates all facets in a single call (parallel under the hood). This is the genuine domain-value primitive: anyone can run a prompt to *extract* what's literally in the question; the value-add is *suggesting* useful framings (e.g., "SEND in mainstream schools" vs "SEND with EHCP" vs "all at-risk children") that the user might not have phrased themselves but will recognise as the framing they meant.
+
+**Input:**
+```json
+{
+  "question": "What interventions reduce school exclusions for children with SEND in England?"
+}
+```
+
+**Output:**
+```json
+{
+  "research_question": "What interventions reduce school exclusions for children with SEND in England?",
+  "population_options": [
+    { "label": "Children with SEND in mainstream schools", "description": "Excludes special schools and PRUs" },
+    { "label": "All school-age children at risk of exclusion", "description": "Broader; includes those without SEND diagnosis" },
+    { "label": "Children with EHCPs specifically", "description": "Narrower; only those with formal Education, Health and Care Plans" }
+  ],
+  "outcome_options": [
+    { "label": "School exclusion rates", "description": "Permanent and fixed-term exclusions" },
+    { "label": "Attendance", "description": "Persistent absence, suspensions" },
+    { "label": "Behavioural and wellbeing outcomes", "description": "SEMH measures" }
+  ],
+  "inner_setting_options": [
+    { "label": "Mainstream schools", "description": "" },
+    { "label": "Local authority education services", "description": "" },
+    { "label": "Alternative provision / PRUs", "description": "" }
+  ],
+  "geography_options": [
+    { "label": "England", "description": "Inferred from the question" }
+  ]
+}
+```
+
+**Key decisions:**
+- One tool replaces the original draft's `extract_pico` + `generate_options` pair. Cowork makes one call to get everything.
+- Facets are generated **independently** in this spike — i.e. population options are suggested without knowing which outcome will be chosen. Simple, fast, good enough as a starting point.
+- Options ordered broad → narrow within each facet (matches existing wizard convention).
+- Geography is included as a suggestion (with a single option when it's obvious from the question text) rather than as a separate extraction step — keeps the tool surface uniform.
+
+**Backend:** Thin orchestration over the four existing methods in `app/services/search_wizard.py` (`generate_population_options`, `generate_outcome_options`, `generate_inner_setting_options`, plus a tiny geography helper). Called in parallel via `asyncio.gather` for ~3s total latency. No new prompts needed.
+
+**Deferred enhancements (only if observation justifies them):**
+- **Conditional refinement.** Add an optional `prior_picks` parameter so later calls can refine suggestions based on earlier facet picks (e.g., outcome options conditioned on the population the user just chose). Non-breaking change; defer until we see Cowork making poor downstream picks because earlier suggestions weren't conditioned. There's a precedent in the existing code: `AdditionalQuestionsRequest` already takes `population_selected` + `outcome_selected`.
+- **Confidence / ambiguity signalling.** Per-facet `confidence` and `ambiguous_components` hints to tell Cowork where to checkpoint. Add only if Cowork's default behaviour proves unreliable.
+
+### `search_evidence`
+
+Searches OpenAlex and/or Overton using structured PICO parameters. Uses our domain-tuned boolean query generation. Returns top results with enough detail for Cowork to summarize or present to the user.
+
+**Input:**
+```json
+{
+  "research_question": "What interventions reduce school exclusions for children with SEND in England?",
+  "population": ["children with SEND in mainstream schools"],
+  "outcome": ["school exclusion rates"],
+  "geography": ["England"],
+  "sources": ["openalex", "overton"],
+  "max_results": 50
+}
+```
+
+**Output:**
+```json
+{
+  "total_found": 127,
+  "results_returned": 5,
+  "results": [
+    {
+      "doc_id": "openalex:W12345",
+      "title": "Reducing exclusions through trauma-informed practice: a cluster RCT",
+      "year": 2023,
+      "source": "openalex",
+      "type": "journal-article",
+      "evidence_category": null,
+      "authors": ["Smith, J.", "Jones, A."],
+      "venue": "British Educational Research Journal",
+      "cited_by_count": 45,
+      "abstract_snippet": "This cluster-randomised trial evaluated...",
+      "is_open_access": true
+    }
+  ],
+  "boolean_queries_used": ["(school exclusion OR permanent exclusion) AND (SEND OR special educational needs) AND (intervention OR programme)"],
+  "suggested_actions": [
+    "Run full analysis to screen, extract, and synthesize these results",
+    "Refine search with narrower population or outcome parameters",
+    "Search for systematic reviews specifically"
+  ]
+}
+```
+
+**Key decisions:**
+- Returns top 5 results by default (keeps response compact for LLM context)
+- `evidence_category` is null at search stage (classification requires the full pipeline)
+- `boolean_queries_used` is returned for transparency/auditability
+- `suggested_actions` gives Cowork hints about what to do next
+- Trusts the orchestrator on scope — no server-side rejection of broad queries
+- **Stateless**: Cowork holds these results in working memory. If it later calls `run_analysis`, it passes the results (or re-searches).
+
+**Backend:** Calls `ReferencesService.build_references()` but skips CSV export and project creation. Returns the DataFrame contents directly as JSON.
+
+### `run_analysis` (post-spike)
+
+Triggers the full analysis pipeline: relevance screening, evidence categorization, document acquisition, text extraction, structured data extraction, and synthesis. **Creates a project** as a side effect.
+
+**Input:**
+```json
+{
+  "research_question": "What interventions reduce school exclusions for children with SEND in England?",
+  "pico": {
+    "population": ["children with SEND in mainstream schools"],
+    "outcome": ["school exclusion rates"],
+    "geography": ["England"]
+  },
+  "search_results": [ ... ],
+  "sources": ["openalex", "overton"]
+}
+```
+
+**Output (immediate):**
+```json
+{
+  "project_id": "abc-123",
+  "status": "accepted",
+  "message": "Analysis started. Use get_job_status to check progress.",
+  "estimated_duration_minutes": { "min": 3, "max": 12 }
+}
+```
+
+**Key decisions:**
+- Accepts pre-fetched `search_results` from the search step — does not re-search from scratch
+- Creates and persists a project only at this point (not during search)
+- Returns immediately with a job handle
+- Marked as consequential — Cowork should confirm with the user before running
+
+### `get_job_status` (post-spike)
+
+**Input:** `{ "project_id": "abc-123" }`
+
+**Output:**
+```json
+{
+  "project_id": "abc-123",
+  "status": "running",
+  "stage_label": "Extracting evidence from documents",
+  "progress_percent": 45,
+  "eta_seconds": 180,
+  "documents_processed": 18,
+  "documents_total": 39
+}
+```
+
+### `get_results` (post-spike)
+
+Retrieves findings from a completed analysis. Compact by default.
+
+**Input:** `{ "project_id": "abc-123" }`
+
+**Output:** Compact synthesis summary — top themes, evidence coverage, key interventions, recommendations, suggested next actions. Target <5KB. No inlined citation quote trees.
+
+### `chat_with_evidence` (post-spike)
+
+RAG Q&A over the vectorized corpus of a completed analysis.
+
+**Input:** `{ "project_id": "abc-123", "question": "Which interventions had the strongest RCT evidence?" }`
+
+**Output:** Answer text + top 3 citations with title, year, supporting quote.
+
+---
+
+## Cowork interaction model
+
+A typical Cowork workflow using these tools:
+
+```
+User: "Research what works for reducing school exclusions for SEND children in England"
+
+Cowork plan:
+  1. suggest_pico_options("Research what works for reducing school exclusions...")
+     → Gets option sets for population, outcome, inner_setting, geography
+       in a single call (~3s).
+  2. [CHECKPOINT] Present to user: "Here are a few ways I could frame this.
+     For population: SEND in mainstream schools, all at-risk children,
+     or EHCP children specifically? For outcomes: exclusion rates,
+     attendance, behavioural measures?"
+     (Cowork may auto-pick high-confidence facets like geography=England.)
+  3. User confirms/refines picks.
+  4. search_evidence(research_question=..., population=..., outcome=...,
+                    inner_setting=..., geography=...)
+     → Gets top results.
+  5. [CHECKPOINT] "I found 127 papers. Here are the top 5. Want me to run
+     a full analysis?"
+  6. User approves.
+  7. run_analysis(research_question=..., pico=..., search_results=...)
+     → Gets job handle.
+  8. get_job_status(...) [periodic]
+     → Monitors progress.
+  9. get_results(...)
+     → Gets synthesis summary.
+  10. [CHECKPOINT] Present briefing to user with suggested next actions.
+```
+
+Policy Atlas controls steps 1, 4, 7-9. Cowork controls the plan, checkpoints, user interaction, and sequencing.
+
+---
+
+## Guardrails
+
+### Cost controls
+- Rate limit per user: max N analysis runs per day (configurable per org)
+- Rate limit per org: max M concurrent analysis pipelines
+- Individual tool calls (extract_pico, search_evidence) are lightweight and don't need hard limits
+- Quotas tracked server-side, returned in tool responses when approaching limits
+
+### Action visibility
+- Every tool call logged with: timestamp, user_id, org_id, tool_name, input params, response size, latency
+- Analysis runs logged with full pipeline audit trail (already exists in Supabase pipeline_timings)
+- `boolean_queries_used` returned in search results for transparency
+- `evidence_category` reasoning available on request for any screened document
+
+---
+
+## Exploration spike (2 days)
+
+### Goal
+Technical validation: prove the MCP server works, schemas are right, tool descriptions produce correct orchestration, and the service layer connects cleanly. Deliverable is a working server testable via Claude Desktop or mcp-inspector, plus a recording for stakeholders.
+
+### Day 1 — Server + suggest_pico_options
+
+**Morning: Scaffolding**
+- Add `mcp` Python SDK to `pyproject.toml`
+- Create `app/mcp/server.py` with FastMCP, wired for both stdio (local dev) and SSE (remote) transport
+- Simple API-key auth guard (replaced by OAuth/Entra later; every non-Microsoft MCP client supports it)
+- Verify the server starts and is discoverable by `mcp-inspector`
+
+**Afternoon: `suggest_pico_options`**
+- Create `app/mcp/schemas.py` with `SuggestPicoOptionsInput`, `SuggestPicoOptionsOutput`, `PicoOption`
+- Create `app/mcp/tools.py` with the tool
+- Thin orchestration over the four existing methods in `app/services/search_wizard.py`, parallelised with `asyncio.gather`
+- Geography handled by a tiny inline helper (one-shot LLM call or rule-based country detection — simplest thing that works)
+- Write the tool description carefully — it's the highest-leverage work in the spike
+- Test via Claude Desktop: "Suggest research framings for: What works for reducing homelessness in UK cities?"
+
+### Day 2 — search_evidence + integration test
+
+**Morning: `search_evidence`**
+- Wraps `ReferencesService.build_references()`, skipping CSV export and project creation
+- Returns top 5 results with metadata (title, year, source, authors, venue, abstract snippet, citation count)
+- Input accepts structured PICO parameters from `suggest_pico_options` output (or directly from the agent if it skipped the suggestion step)
+- Test: "Search for evidence on school exclusion interventions for SEND children"
+
+**Afternoon: Integration test + documentation**
+- End-to-end test: `suggest_pico_options` → `search_evidence` as a chained sequence
+- Measure latencies for each tool
+- Document: tool schemas, response examples, service-layer gaps found, recommended next steps
+- Record a demo showing Claude Desktop using the tools in sequence
+
+### Spike deliverables
+- Working MCP server with 2 tools, testable via Claude Desktop / mcp-inspector
+- Tool schemas validated against real responses
+- Latency measurements for each tool
+- Gap notes: what's hard, what needs refactoring in the service layer
+- Screen recording for stakeholder demo
+
+### Files created/modified
+
+| File | Change |
+|---|---|
+| `pyproject.toml` | Add `mcp` SDK dependency |
+| `app/mcp/__init__.py` | New package |
+| `app/mcp/server.py` | FastMCP server setup, transport config, API-key auth |
+| `app/mcp/schemas.py` | `SuggestPicoOptionsInput/Output`, `PicoOption`, `SearchEvidenceInput/Output`, `EvidenceResult` |
+| `app/mcp/tools.py` | 2 tool implementations |
+| `app/core/config.py` | Add `MCP_API_KEY` setting |
+
+---
+
+## Production roadmap (post-spike)
+
+### Phase 1 — Complete the tool surface (2-3 days)
+
+**Depends on:** Spike complete, gap notes reviewed.
+
+- Add `run_analysis`: accepts pre-fetched search results, creates project, returns job handle
+- Add `get_job_status`: wraps existing progress logic from `app/services/analysis/progress.py`
+- Add `get_results`: compact synthesis summary from completed analysis
+- Add `chat_with_evidence`: wraps existing `ChatService`
+- Mark `run_analysis` as consequential
+- Implement cost controls: rate limits per user/org, quota tracking
+- Implement action logging: structured audit log for every tool call
+
+### Phase 2 — Auth + remote transport (2-3 days)
+
+**Depends on:** Decision on Entra ID app registration.
+
+- Replace API-key auth with OAuth 2.1 / Entra ID SSO
+- SSE as primary transport (stdio kept for local dev)
+- CORS configuration for Microsoft's widget renderer domain
+- Token audience binding per MCP spec (RFC 8707)
+- Generate OpenAPI spec as parallel artifact for government security reviews
+
+### Phase 3 — MCP Apps widgets (3-5 days)
+
+**Depends on:** Phase 2 (auth + CORS required).
+
+Three widgets, prioritised by user value:
+
+1. **Evidence explorer** — Filterable table of search results / analysed documents. Sort, filter, browse without re-prompting. This is where the MCP Apps spec adds the most value over text responses.
+2. **Policy options comparison** — Side-by-side structured comparison of top interventions: impact score, evidence strength, transferability, risks.
+3. **Analysis progress** — Live progress card during `run_analysis`.
+
+Widgets are lightweight HTML/JS served from the MCP server, rendered in Microsoft's sandboxed widget host. No React/Next.js dependency.
+
+### Phase 4 — Declarative agent packaging (2-3 days)
+
+**Depends on:** Phases 1-3 complete.
+
+- Declarative agent manifest (plugin manifest schema v2.4+, `RemoteMCPServer` runtime)
+- Store validation: <9s p99 response time, 99.9% availability, privacy/terms documentation
+- IT admin deployment guide
+- End-to-end test in Copilot Cowork
+
+---
+
+## Key risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| **Entra ID integration complexity** | High | Spike with API key. Defer Entra until app registration path is decided. |
+| **Response size bloats agent context** | Medium | Top 5 results default. Compact schemas. No citation trees. |
+| **ReferencesService coupled to CSV/project** | Medium | Spike will expose gaps. May need to extract search logic into a standalone function. |
+| **Cowork orchestration unpredictable** | Medium | Invest in tool descriptions. Test with Claude Desktop simulating Cowork-style chaining. |
+| **MCP Apps spec still maturing** | Medium | Build widgets as lightweight standalone HTML. Don't couple to framework assumptions. |
+| **EU Data Boundary for Anthropic models in Cowork** | Low-Med | Monitor. Flag in admin guide. Not a blocker for spike. |
+
+---
+
+## Compatibility checklist
+
+Decisions made now that keep us aligned with the Copilot Cowork target:
+
+- [x] Atomic tools designed for autonomous agent orchestration
+- [x] Stateless server — Cowork manages working memory
+- [x] First-time user journey — no prior projects required
+- [x] PICO suggestion as a single tool (option-presentation, not inference — matches existing wizard pattern)
+- [x] Cost controls and action visibility from Phase 1
+- [x] Remote transport (SSE) from day 1
+- [x] Tool count within Copilot's recommended limits (6 tools)
+- [x] Write tools marked as consequential
+- [ ] OAuth 2.1 / Entra ID auth (Phase 2)
+- [ ] MCP Apps widgets (Phase 3)
+- [ ] Declarative agent manifest (Phase 4)
+- [ ] OpenAPI spec as parallel artifact (Phase 2)

--- a/docs/mcp_server_overview.md
+++ b/docs/mcp_server_overview.md
@@ -1,0 +1,209 @@
+# Policy Atlas MCP Server — Overview
+
+A concise reference for how the MCP server in `backend/app/mcp/` works end-to-end. For the next-stage design (gap analysis, modular `run_analysis` handoff, etc.), see [`spec_search_evidence_agentic.md`](./spec_search_evidence_agentic.md). For the original spike retrospective, see [`mcp_spike_findings.md`](./mcp_spike_findings.md).
+
+---
+
+## What it is
+
+A FastMCP server that exposes the Policy Atlas search pipeline as MCP tools, with interactive UI widgets rendered inline in MCP-Apps-capable hosts (Claude Desktop, MCP Inspector, etc.). Two tools today; a third (`run_analysis`) is specced but not yet wired.
+
+```
+┌─────────────────────────┐
+│  Claude Desktop / host  │   ← user types a research question
+└────────────┬────────────┘
+             │  MCP protocol (JSON-RPC over stdio or SSE)
+             ▼
+┌─────────────────────────┐
+│  FastMCP server         │
+│  app/mcp/               │
+│   ├── server.py         │   ← FastMCP instance, transports, auth
+│   ├── tools.py          │   ← tool implementations + widget resources
+│   ├── schemas.py        │   ← Pydantic I/O contracts
+│   └── widgets/          │   ← Node toolchain (vite + ext-apps SDK)
+└────────────┬────────────┘
+             │  calls into existing services
+             ▼
+┌─────────────────────────┐
+│  Policy Atlas services  │
+│  app/services/...       │   ← SearchWizardService, ReferencesService,
+│                         │     OpenAlexService, OvertonService
+└─────────────────────────┘
+```
+
+---
+
+## The two tools
+
+### `suggest_pico_options(question)`
+
+LLM-generated PICO framings for a research question — 3-5 options each for population, outcome, and inner setting. The host renders these as an interactive picker widget (`widgets/pico-picker.html`).
+
+**Where the LLM enters:** `SearchWizardService` runs three parallel LLM calls (one per facet) via `asyncio.gather`. Returns labels; future work will add descriptions per option.
+
+**Total latency:** ~3s.
+
+### `search_evidence(question, picks, geography, ...)`
+
+Hits OpenAlex (academic literature) and Overton (policy documents) in parallel via `ReferencesService.build_references()`. Returns three layers:
+
+1. **`results`** — top 5 papers (rendered by the search-evidence widget)
+2. **`additional_results`** — ~45 more papers as `CompactPaper` (full abstracts, ranking signals) — *for the LLM to reason over*, not rendered
+3. **`result_summary`** — aggregate stats (country distribution, year range, source mix, document-type mix, OA fraction) — rendered as a summary strip above the cards *and* used by the LLM for gap-analysis reflection
+
+**Total latency:** ~28s (limited by OpenAlex multi-query + Overton fetches).
+
+**Critical behaviour:** the tool's docstring instructs the LLM to perform a *research gap analysis* post-call using `result_summary` + `additional_results`. Drift, missing methodologies, source-mix asymmetry, and other quality issues become diagnosable.
+
+---
+
+## End-to-end flow
+
+```
+1. User: "What works for reducing obesity in UK cities?"
+2. Claude → suggest_pico_options(question)
+3. Server returns PICO framings + widget URI
+4. Host renders pico-picker widget; user ticks options + optional custom inputs
+5. Picker widget posts via app.updateModelContext + app.sendMessage:
+     - structured PICO picks → invisible LLM context
+     - friendly natural-language trigger → chat textbox (user confirms)
+6. Claude → search_evidence(question, picks, ...)
+7. Server returns top-5 + wider compact set + summary strip + widget URI
+8. Host renders search-evidence widget with summary + cards
+9. Claude (per docstring) silently does gap analysis using additional_results;
+   surfaces concerns + 1 corrective action in chat
+10. User confirms or refines; possibly re-run search_evidence with adjusted args
+```
+
+---
+
+## Two widgets
+
+Each widget is a self-contained single-file HTML built with vite + `vite-plugin-singlefile` + `@modelcontextprotocol/ext-apps`. The build inlines all JS and CSS so the iframe sandbox can load them without external fetches.
+
+| Widget | Tool | What it shows |
+|---|---|---|
+| `pico-picker.html` (~348 KB) | `suggest_pico_options` | Checkbox list per facet + "+ add your own…" inputs + Search button |
+| `search-evidence.html` (~348 KB) | `search_evidence` | Top-5 cards + aggregate summary strip + animated progress bar during loading |
+
+**Build pipeline** (in `backend/app/mcp/widgets/`):
+
+```bash
+npm install                    # one-time
+npm run build                  # produces dist/*.html for both widgets
+```
+
+The Python server reads the built `dist/*.html` lazily at resource-fetch time (`tools.py` `_read_widget`), so rebuilding the widget doesn't require restarting the Python server — the next tool call serves the new HTML.
+
+**MCP Apps SDK lifecycle inside each widget:**
+
+```typescript
+const app = new App({ name, version });
+app.ontoolinput = (params) => { /* args available */ };
+app.ontoolresult = (result) => { /* structuredContent available */ };
+app.onhostcontextchanged = (ctx) => { /* theme, fonts, safe-area */ };
+await app.connect();
+// later, from button click:
+await app.callServerTool({ name, arguments });   // direct tool invocation
+await app.sendMessage({ role: "user", content }); // chat hand-off
+await app.updateModelContext({ content });        // invisible LLM context
+```
+
+---
+
+## Transports
+
+Defined in `server.py`:
+
+| Transport | When to use | Auth |
+|---|---|---|
+| **stdio** (`run_stdio()`) | Claude Desktop, MCP Inspector — local subprocess | None (local-trusted) |
+| **SSE** (`run_sse(port, host)`) | Remote / production deployments | API key via `x-mcp-api-key` header, validated against `settings.MCP_API_KEY` |
+
+stdio is the most common today.
+
+---
+
+## Key design decisions (summary)
+
+For full rationale see [`spec_search_evidence_agentic.md`](./spec_search_evidence_agentic.md). The headline calls:
+
+| Decision | Implementation |
+|---|---|
+| **Three-stage tool surface** (no per-operation tools) | `suggest_pico_options` (framing) → `search_evidence` (retrieval) → `run_analysis` (deep analysis, planned) |
+| **Wider compact set in `additional_results`** | Top-5 rendered by widget; ~45 more carried as `CompactPaper` (with full abstracts up to 1800 chars) for LLM gap analysis |
+| **Aggregate `result_summary`** | Country / year / source-mix / doc-type / OA-fraction; widget renders strip, LLM uses for reflection |
+| **Cross-source country normalisation** | Deterministic alias map collapses `"USA" + "United States" → "US"` etc. inline in `_compute_result_summary` |
+| **Picker → search hand-off via `sendMessage` + `updateModelContext`** | Structured picks invisible in LLM context; user sees friendly trigger pre-filled in chat |
+| **Tool docstrings as agent instructions** | Each docstring follows the §12 contract: WHEN / RETURNS / PRESENTATION / POST-CALL / DO-NOT |
+| **Known limitation: Overton ranking asymmetry** | Overton docs default to `relevance_score = 0` → systematically deprioritised in merge. Documented in `references.py:756` + `overton.py:144`; agentic critique flags it when relevant. |
+
+---
+
+## Running locally
+
+```bash
+# Backend (from repo root)
+cd backend
+uv sync                                            # install Python deps
+
+# Widget build (one-time, then on every widget source change)
+cd app/mcp/widgets
+npm install
+npm run build                                      # produces dist/pico-picker.html, dist/search-evidence.html
+
+# Run the MCP server (stdio for Claude Desktop)
+cd ../../../..
+uv run python -m app.mcp.server
+```
+
+For Claude Desktop integration, point your config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS) at this server. Use the absolute path to `uv` (GUI-spawned processes don't inherit shell `PATH`), and bake the working directory into the args via `uv run --directory <path>` — `cwd` in the JSON config is unreliable across Claude Desktop versions.
+
+```json
+{
+  "mcpServers": {
+    "policy-atlas": {
+      "command": "/opt/homebrew/bin/uv",
+      "args": [
+        "run", "--directory", "/abs/path/to/discovery_policy_atlas/backend",
+        "python", "-m", "app.mcp.server"
+      ]
+    }
+  }
+}
+```
+
+After config changes, fully quit Claude Desktop (⌘Q, not just window close) before relaunching.
+
+---
+
+## Where things live
+
+| Path | What's in it |
+|---|---|
+| `backend/app/mcp/server.py` | FastMCP instance, stdio + SSE transports, API-key auth middleware |
+| `backend/app/mcp/tools.py` | `suggest_pico_options` + `search_evidence` implementations, widget resource registrations, helpers (`_row_to_evidence`, `_row_to_compact_paper`, `_compute_result_summary`, `_normalise_country`) |
+| `backend/app/mcp/schemas.py` | Pydantic models: `PicoOption`, `SuggestPicoOptionsOutput`, `EvidenceResult`, `CompactPaper`, `ResultSummary`, `SearchEvidenceOutput` |
+| `backend/app/mcp/widgets/` | Vite project: TS sources in `src/`, HTML entries at root, built artifacts in `dist/` |
+| `backend/app/mcp/widgets/src/pico-picker.ts` | Picker widget logic (checkboxes, custom inputs, sendMessage hand-off) |
+| `backend/app/mcp/widgets/src/search-evidence.ts` | Results widget logic (cards, summary strip, doctype chip suppression) |
+| `backend/app/core/config.py` | `MCP_API_KEY` setting for SSE auth |
+| `~/Library/Logs/Claude/mcp-server-policy-atlas.log` | stderr from the stdio server when run via Claude Desktop — first place to look when something breaks |
+
+---
+
+## Debugging quickstart
+
+| Symptom | Where to look |
+|---|---|
+| Widget renders empty / iframe blank | DevTools console in the iframe (right-click → Inspect Element); look for `[pico-picker]` or `[search-evidence]` errors |
+| Tool call returns error | `~/Library/Logs/Claude/mcp-server-policy-atlas.log` — full Python traceback lands here |
+| Overton silently returns 0 results | Same log file — grep for `Reference fetch error (overton_search)` or `Overton semantic search`. Auth, query-format, or geography-filter mismatch are usual causes |
+| Stale widget after edit | Rebuild via `npm run build`; re-issue the tool call (no Python restart needed — resource is read lazily) |
+| Stale Python behaviour | Restart Claude Desktop fully (⌘Q), not just close window |
+
+---
+
+## What's planned next
+
+See [`spec_search_evidence_agentic.md`](./spec_search_evidence_agentic.md) §10 for the `run_analysis` integration design (currently REST; planned to become a third MCP tool consuming `search_evidence`'s output). The handoff payload shape, auth model, and MCP/REST coexistence are deferred to that spec's next implementation pass.

--- a/docs/mcp_spike_findings.md
+++ b/docs/mcp_spike_findings.md
@@ -1,0 +1,185 @@
+# MCP Integration Spike — Findings
+
+Retrospective companion to [`mcp_integration_plan.md`](./mcp_integration_plan.md). The plan describes what we intended to build; this doc captures what we *learned* doing it.
+
+---
+
+## TL;DR
+
+The spike shipped on plan: a working FastMCP server with two tools (`suggest_pico_options`, `search_evidence`) discoverable by Claude Desktop and the MCP SDK client. End-to-end protocol handshake, tool invocation, and structured response — all confirmed. Three material findings affect production readiness:
+
+1. **`search_evidence` latency is ~28s** — well over Microsoft's 9s p99 validation threshold. Plan called this risk out; now we have a measurement. Mitigation = job-handle pattern (deferred).
+2. **`build_references` is HTTP-shaped, not MCP-shaped.** It writes to disk as a side effect. Worked around with a `TemporaryDirectory()`; a clean entry point would be better.
+3. **MCP Apps widget rendering in Claude Desktop 1.7196.0 is partial — feature scaffolded but widget content does not display.** Server-side implementation conforms to spec; gap is client-side renderer not yet shipped. See Finding #11.
+
+Everything else is iterable in normal product work.
+
+---
+
+## Measurements
+
+| Operation | Measured latency | Notes |
+|---|---|---|
+| MCP protocol handshake (initialize) | ~50ms | Well within budget |
+| `suggest_pico_options` (3 LLM calls in parallel) | ~3s | OK; fan-out via `asyncio.gather` is load-bearing here |
+| `search_evidence` (full multi-query + 12 source fetches) | **~28s** | Over Microsoft's 9s threshold |
+| End-to-end chain via MCP SDK client | _filled in below_ | See "Chained test" section |
+| Tool registration on server load | <100ms | Decorator-driven |
+
+---
+
+## Findings, grouped
+
+### 1. Latency
+
+- `search_evidence` exceeds the 9s p99 threshold by ~3x. Breakdown: ~6–8s for multi-query LLM generation, ~10–15s for the parallel OpenAlex+Overton fetches, the rest ranking/dedup.
+- The CSV write+read round-trip is a non-issue (~50ms in a 28s call).
+- Mitigation path is clear: **adopt the job-handle pattern** for `search_evidence` (same shape as `run_analysis`) — sync return when fast, async job handle when slow. This adds 2 tools (`get_search_status`, `get_search_results`) but keeps every individual call inside the budget.
+
+### 2. Service-layer coupling
+
+- `ReferencesService.build_references()` is HTTP/project-shaped: writes `references.csv` and debug JSON files as side effects, returns paths rather than data.
+- Workaround in the MCP tool: `tempfile.TemporaryDirectory()` to absorb the side effects with automatic cleanup. Costs ~50ms; auto-cleans on exceptions.
+- Clean fix later: add a `write_csv: bool = True` flag to `build_references` so callers can opt out, or extract a pure inner function that returns the DataFrame directly.
+
+### 3. Wizard output is thin for agent consumption
+
+- `generate_population_options` and friends return `list[str]` — just labels, no descriptions.
+- In practice the agent (Claude) filled in descriptive context itself ("Who you're studying", "What success looks like"). The descriptions were valuable; they should come from the *tool*, not be reconstructed by the agent.
+- **Follow-up:** upgrade wizard prompts to emit `{label, description}` pairs. Touches `prompts.py` + the four wizard methods + their return types. Higher effort, higher value than option count changes.
+- `max_options` defaults to 3 — felt thin in agent use. Bumping to 5 in the MCP tool's call to the wizard is a one-line change with no downside.
+
+### 4. Wizard prompts miss obvious domain framings
+
+- For "homelessness in UK cities" the wizard returned 3 populations that all collapsed to "homeless people"; missed framings the agent then flagged (rough sleepers as a UK-specific category, single-adult vs family homelessness, co-occurring mental health & substance use).
+- This is a *prompt content* gap, not a tool architecture issue. Real signal for prompt iteration: take Claude's free-of-charge critique and bake it into the wizard's system prompt.
+
+### 5. Geography precision is weak
+
+- Asked for evidence on UK homelessness; top 5 results were predominantly Australian and American. Geography flowed through `search_context` to the boolean-query generator but didn't influence ranking strongly.
+- Worth investigating upstream in `references.py`: is `geography` actually getting into the boolean queries, and if so is it appearing as a clause or just metadata?
+- Workaround: pass `geography_filter` directly with country codes (the parameter exists). Less clean for an agent caller because it expects ISO codes, not free-text names.
+
+### 6. Agent verbosity / presentation
+
+- Claude Desktop by default added ~3x the volume of useful content as commentary — gap analysis, critique, suggested next steps. Helpful for human chat, undesirable for autonomous agent flows.
+- Mitigation applied: explicit `Presentation:` block in each tool's docstring — *"Be concise — no gap analysis, no critique, no suggested next steps. Ask the user which options to pick before calling the next tool; do not proceed autonomously."*
+- Compliance is probabilistic, not deterministic — agents partly comply. For Cowork the production system prompt is the real backstop; for Claude Desktop the docstring nudge is the only lever.
+
+### 7. Tool docstrings as protocol surface
+
+- The most surprising finding of the spike: docstrings are **load-bearing agent instructions**, not internal docs. Every word in `suggest_pico_options`'s docstring was visible in Claude's responses — Claude was explaining our design choices to the user verbatim ("The tool's docstring notes that geography gets passed directly to the evidence-search step").
+- Pattern to encode going forward: write docstrings *for the agent*. Imperative, specific, concrete exclusions ("no gap analysis") rather than vague guidance ("be concise").
+
+### 8. UI affordances
+
+- Claude Desktop has no native interactive UI (buttons, selects, forms) for tool outputs — everything is markdown text.
+- MCP Elicitation primitive exists in spec but client support is patchy (Claude Desktop ~partial, Cowork unclear).
+- For Cowork specifically: rich UI is the Microsoft "MCP Apps" widgets path (Phase 3 in the plan). Not portable to Claude Desktop; that's expected.
+- Decision: don't chase native picker UI for Claude Desktop. Demos use numbered lists + text picks.
+
+### 9. Progress notifications work and are essential UX
+
+- 28-second tool calls with no progress indicator caused user confusion ("is it stuck?"). Adding four `ctx.info()` markers — bracketing the slow phases in each tool — gives the client a real-time status stream over the MCP `notifications/message` channel.
+- FastMCP exposes this via type-annotated `Context` parameter injection: add `ctx: Context | None = None` to the tool signature and FastMCP passes it in automatically. Same pattern as FastAPI's `Request` injection.
+- Confirmed working end-to-end through the SDK client: messages arrive in real time as the tool executes, not batched at the end. Claude Desktop renders them as status text under the tool call.
+- Notes:
+  - `set_logging_level` (client → server subscription) requires the server to declare the `logging` capability, which FastMCP doesn't do by default. Skipping the subscription works fine — server sends regardless, SDK client receives regardless.
+  - For finer-grained progress *inside* `build_references` (per-source, per-query), the cleanest path is a logger forwarder that catches existing `app.services.analysis.references` log records and routes them through `ctx.info()`. Deferred — coarse-grained is sufficient for the spike.
+
+### 11. MCP Apps widget rendering — server works, Claude Desktop partial
+
+Built a full MCP Apps widget for `suggest_pico_options` to render PICO options as interactive checkboxes rather than text. Architecture worked end-to-end on the server side; the client (Claude Desktop 1.7196.0, build `2dbd78` from 2026-05-12) acknowledges but does not display.
+
+**What we built:**
+- `backend/app/mcp/widgets/pico_picker.html` — vanilla HTML/JS, listens for `ui/notifications/tool-result`, renders three facet sections with checkboxes, submits via `tools/call` postMessage to invoke `search_evidence` with the user's picks
+- Resource registered at `ui://policy-atlas/pico-picker` with MIME `text/html;profile=mcp-app` via `@mcp.resource()` in `tools.py`
+- `suggest_pico_options` annotated with `meta={"ui": {"resourceUri": PICO_PICKER_URI}}` per spec
+
+**What Claude Desktop 1.7196.0 does:**
+- ✅ Reads our `_meta.ui.resourceUri` annotation on the tool definition
+- ✅ Tells the LLM "a widget rendered, don't repeat the content" (suppression notice observed in chat output)
+- ✅ Reserves vertical space in the chat layout for the iframe
+- ❌ **Does not display widget content** — even a minimal debug HTML (bright yellow background, "HELLO FROM WIDGET" banner, JS heartbeat counter, no external dependencies) renders as empty space
+- ⚠️ Falls back inconsistently — sometimes Claude renders the structured content as text *anyway*, sometimes leaves the slot blank
+
+**Diagnosis:**
+The feature appears scaffolded but not wired up in this Claude Desktop build. Anthropic's MCP Apps documentation explicitly lists Claude as a supported client, but rendering support has not landed (or is gated behind a flag we couldn't find) in the public 1.7196.0 build as of 2026-05-23. Server-side implementation conforms to the spec at `https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx`.
+
+**What this means for the spike:**
+- The widget artifact is **shipped and reusable** — when Claude Desktop ships full renderer support, our existing implementation lights up automatically with no server changes.
+- The widget should render correctly in `mcp-inspector` (the reference MCP-Apps client) — useful to verify and screenshot for stakeholder demos.
+- For other supported clients (ChatGPT, VS Code, Goose, Postman, MCPJam), behaviour will vary; testing required per-client.
+
+**Earlier framing in the plan that should be updated:**
+- The plan's "Key risks" table called MCP Apps maturity "Medium" risk — that risk *materialised* for Claude Desktop today. Reality is worse than predicted on that specific row.
+- The previous framing in `mcp_integration_plan.md` of MCP Apps widgets as a "Phase 3 / Microsoft Copilot only" concern was wrong on both axes — the spec is supported in principle by Claude Desktop too, but in practice no client we tested rendered widgets in their current ship. The plan should be revised when MCP Apps maturity is re-assessed.
+
+---
+
+### 10. Client-side gotchas (Claude Desktop)
+
+- **`cwd` in the JSON config is unreliable** — sometimes honored, sometimes not, version-dependent. Use `uv run --directory <path>` in the args instead. The flag bakes the directory into the command itself, regardless of how the client spawns it.
+- **`command` needs the absolute path to `uv`** — GUI-spawned processes don't inherit shell `PATH`. Use `/opt/homebrew/bin/uv` (or wherever `which uv` reports).
+- **Manifest cache** — Claude Desktop needs a full quit-and-restart (⌘Q, not just window close) to pick up server config changes or tool description edits.
+- **Logs** — `~/Library/Logs/Claude/mcp-server-<name>.log`. Per-server log file; check first for `ModuleNotFoundError` / handshake failures.
+
+---
+
+## Files shipped
+
+| File | Purpose |
+|---|---|
+| `backend/app/mcp/__init__.py` | Package docstring |
+| `backend/app/mcp/server.py` | FastMCP instance, stdio + SSE transports, API-key auth |
+| `backend/app/mcp/schemas.py` | `PicoOption`, `SuggestPicoOptionsOutput`, `EvidenceResult`, `SearchEvidenceOutput` |
+| `backend/app/mcp/tools.py` | `suggest_pico_options`, `search_evidence`, helpers |
+| `backend/app/core/config.py` (modified) | Added `MCP_API_KEY: Optional[str] = None` |
+| `backend/pyproject.toml` (modified) | Added `mcp>=1.0.0` |
+
+---
+
+## Recommended next steps, prioritised
+
+In order of value-per-effort:
+
+1. **Bump `max_options` from 3 → 5** in the `suggest_pico_options` wrapper call. One line; observable quality improvement.
+2. **Plan the job-handle redesign for `search_evidence`.** Either as a separate doc or an update to `mcp_integration_plan.md`. Blocker for any production deployment targeting Microsoft store.
+3. **Upgrade wizard prompts to emit `{label, description}` pairs.** Eliminates the "agent reconstructs the description" pattern; tightens the tool's contract.
+4. **Add a `write_csv: bool = True` flag to `build_references`** (or extract a pure inner function). Lets MCP and any future non-HTTP caller skip the disk round-trip.
+5. **Improve geography signal in boolean queries.** Investigate why "UK" returned mostly Australian/US results; likely a prompt-content issue in `references.py`.
+6. **Domain-saturate the population wizard prompt** with framings Claude correctly identified as missing (rough sleepers, co-occurring needs, families vs. singles).
+7. **Investigate MCP Elicitation maturity** in Claude Desktop and Copilot to see if server-driven user picks are viable yet.
+
+Lower priority / known and deferred:
+
+- **Conditional refinement (`prior_picks` parameter)** — non-breaking optional addition; defer until evidence Cowork makes bad downstream picks.
+- **`run_analysis`, `get_job_status`, `get_results`, `chat_with_evidence`** — remaining tools from the plan's full surface. Not in scope for spike.
+- **OAuth 2.1 / Entra ID auth** — Phase 2 of the plan; spike used API-key.
+- **MCP Apps widgets for Cowork** — Phase 3; not portable to Claude Desktop anyway.
+
+---
+
+## Chained test
+
+End-to-end test: `suggest_pico_options` → first-option-pick (agent stand-in) → `search_evidence`, all via the MCP SDK client (the same harness an autonomous agent would use).
+
+**Question:** "What works for reducing chronic homelessness in UK cities?"
+
+**Timing breakdown:**
+
+| Step | Latency |
+|---|---|
+| `suggest_pico_options` (3 LLM calls in parallel) | 2.2s |
+| `search_evidence` (multi-query + 14 source fetches, 150 unique docs → top 5) | 26.4s |
+| MCP protocol overhead (subprocess spawn, handshake, serialisation) | 4.2s |
+| **Total wall-clock** | **32.8s** |
+
+**Sample top-5 results:** Goering 2011 (At Home/Chez Soi RCT), Lim 2018 (NYC supportive housing Medicaid impact), Aubry 2020 (permanent supportive housing effectiveness), Marshall 1995 (case-management RCT), Culhane 2002 (public-service cost reductions). Quality is good — these are canonical papers in the housing-first / supportive-housing literature.
+
+**Observations:**
+
+- **Protocol works end-to-end agent-style.** The MCP SDK client spawned our server, completed handshake, called two tools in sequence, parsed both structured responses. That's the Cowork pattern, condensed.
+- **Result quality varies run-to-run.** Multi-query generation runs with temperature > 0, so the same question produces different boolean queries each call. Headline results were better than the first solo test (more canonical references, fewer Australian-leaning hits). This is feature not bug for diversity, but worth knowing if reproducibility matters for a particular use case.
+- **Geography signal still weak.** Asked for UK cities; got predominantly Canadian/American papers. Reinforces the geography-precision gap noted above.
+- **`results_returned: 5` of `total_found: 60`** — the funnel is informing the agent without overflowing its context budget. Exactly the design intent.

--- a/docs/spec_search_evidence_agentic.md
+++ b/docs/spec_search_evidence_agentic.md
@@ -1,0 +1,509 @@
+# Search Evidence: Agentic Spec
+
+**Status:** Draft — in active spec discussion. Decisions below are confirmed during interview; open questions are flagged at the bottom.
+
+This document captures the design for making `search_evidence` and its surrounding flow more agentic, in the MCP server. The frame is Claude Code's design pattern: small tools, transparency, soft gates, never re-traverse completed steps.
+
+---
+
+## Confirmed decisions
+
+### 1. Self-correction: surface critique, propose fix
+
+When `search_evidence` returns results that don't match the user's intent (e.g., the spike-finding example — UK obesity question returning predominantly US papers), the system should not silently retry. Instead, Claude reflects on the result quality and surfaces a critique with a proposed fix.
+
+**Rejected alternatives:**
+- *Silent auto-retry* — opaque; expensive on cascading failures; the user has no way to know the agent corrected itself
+- *Quality flag per paper* — passive; doesn't propose an action
+- *No reflection at all* — misses the spike's documented pain points (e.g., geography drift)
+
+### 2. Pipeline architecture: many small tools, no formal gates
+
+Following Claude Code's design pattern:
+
+- Each step is a small, single-purpose tool
+- The LLM chains tools autonomously based on conversation context
+- No "may I proceed?" prompts between tools
+
+Three soft-control mechanisms layered on top of the no-gates default:
+
+1. **Pre-flight summary** — before starting a chain, Claude emits a one-sentence plan: *"I'll search the evidence, screen for UK relevance, and cluster by intervention — ~30s"*. The user has ~1s to interrupt before the chain runs.
+2. **Plan widget** — if a chain has >4 steps, a dedicated widget renders an updating checklist. Inspired by Claude Code's `TaskCreate`/`TaskUpdate` surface.
+3. **Host transparency + user interrupt** — every tool call is visible in Claude Desktop chat; user can interrupt by sending a new message.
+
+**Rationale:** matches Claude Desktop UX expectations. Forces fewer modals; lets the user steer via the chat surface they already understand. Avoids the AutoGPT-style "trust the chain" failure mode by exposing every step.
+
+### 3. Critique detection: LLM reflection
+
+When critique runs, Claude reads the structured output and judges quality against the original question.
+
+Deterministic heuristics (country counts, year skew, source mix) are computed alongside and **fed into** the LLM's reflection — but they don't make the judgement themselves. The LLM reasons over both the aggregate signal and the concrete papers.
+
+**Rejected alternatives:**
+- *Pure heuristics* — fast, but misses semantic drift that doesn't show up in metadata
+- *Hybrid with heuristics making the call* — adds complexity for marginal gain over LLM-with-context
+- *User-triggered only* — misses problems users don't notice
+
+### 4. Critique input: top-N + wider compact set
+
+For LLM reflection to be useful, it needs visibility beyond the top-5 papers shown to the user. Otherwise it can detect drift but cannot distinguish **search-bias** ("the search itself returned mostly US papers") from **rank-bias** ("the search was fine but ranking pushed US to the top").
+
+`search_evidence` therefore returns two layers:
+
+```python
+class CompactPaper(BaseModel):
+    """Trimmed paper representation for LLM reasoning over the wider result set."""
+    doc_id: str
+    rank: int                       # position in the full ranked set
+    title: str
+    abstract_snippet: str | None    # full abstract up to ~1800 chars; max signal for gap analysis
+    year: int | None
+    source_country: str | None
+    venue: str | None
+    document_type: str | None
+    source: str | None              # 'openalex' or 'overton' (see §7 asymmetry)
+    relevance_score: float | None   # from source API; may be 0 for Overton (see §7)
+    query_variant: str | None       # which boolean query matched this paper
+    variant_priority: int | None    # search strategy's priority for that query
+
+class SearchEvidenceOutput(BaseModel):
+    total_found: int
+    results_returned: int
+    results: list[EvidenceResult]          # top-N (default 5), rendered by widget
+    additional_results: list[CompactPaper] # remaining ~45 in trimmed form, for LLM
+    result_summary: ResultSummary | None   # aggregate stats; widget renders strip
+    boolean_queries_used: list[str]
+```
+
+**Token cost:** ~20k tokens per call for `additional_results` (45 papers × ~450 tokens/paper at full-abstract snippets up to 1800 chars). Trivial in Claude Opus 4.7's 1M context — roughly 0.002% of the window.
+
+**Why `abstract_snippet` is load-bearing:** title-only gap analysis is essentially keyword-matching. Abstract-augmented gap analysis lets the LLM identify *population subgroups, study design, outcomes measured, time horizon, intervention type* — exactly the dimensions that matter for "what's missing from this evidence base?" reflection (see §12). Including author conclusions (the last segment of an abstract) is also useful — the LLM can reason about *claimed* effect sizes and how the wider literature frames them, which informs gap analysis even when those framings need critique.
+
+**Why the full abstract:** with a 1M context window, the constraint is information density, not size. 1800 chars captures essentially the complete abstract for almost all OpenAlex / Overton documents — intro, methods, results, discussion. Truncating earlier just discards signal for no real-world benefit.
+
+**Asymmetry with the widget cards (intentional):** widget renders top-5 abstracts at 500 chars (enough for human glance — a long abstract on every card would crowd the UI). LLM reads `additional_results` at full-abstract length (it never needs to render them; it just reasons over them). One schema, two cuts of the same data, sized to each consumer.
+
+**Key property:** the widget consumes `results`; the LLM also has access to `additional_results`. Different schemas serving different audiences via the same tool result.
+
+### 5. Corrective action: surface from wider set first, re-search as fallback
+
+When critique fires, the LLM's default behaviour:
+
+- **If the wider set contains better candidates** → Claude surfaces them in chat with context: *"Goering 2011 at rank 11 is a Canadian Housing First RCT more relevant to UK context — want me to drill in?"* No new tool call.
+- **If the wider set doesn't have better candidates** → Claude proposes re-calling `search_evidence` with adjusted args. User confirms; a second tool call happens. Original results stay in scroll-back for compare.
+
+**No new tools needed.** The wider compact set is already in the LLM's context from the original `search_evidence` call.
+
+This is the Claude-Code-style design: **transparency replaces formal gates**. The user sees the critique, sees the proposed fix, and can interrupt before the action by typing anything other than "yes."
+
+### 6. Provenance: surface existing pipeline signals, no LLM rationale at search time
+
+The `references.py` pipeline already computes three signals per paper that drive ranking:
+
+| Field | Source | Type |
+|---|---|---|
+| `relevance_score` | OpenAlex API (BM25-ish text match score) | float |
+| `query_variant` | Recorded at query-execution time | string label, e.g. `"broad"`, `"uk-stratified"` |
+| `variant_priority` | Set at query generation time by the search strategy | int |
+
+The final ranking is `sort_values(["relevance_score", "variant_priority"])` — these signals already drive the order, but `_row_to_evidence` in `tools.py` drops them at the MCP boundary.
+
+**Decision:** plumb all three through to `EvidenceResult` (and `CompactPaper`). One-line addition to `_row_to_evidence`. The LLM critique can now reason about *why* the order is what it is, not just what the order is. Concretely, it can say *"top-5 all came from the broad query — papers from the uk-stratified query exist at rank 8+ but were tie-broken down by relevance_score; want to re-prioritise?"*.
+
+**Rejected alternative — call `RelevanceService.check_relevance` inside `search_evidence`:**
+
+The `RelevanceService` exists at `app/services/analysis/relevance.py` and *does* produce a `relevance_reason` (1-2 sentence LLM-written explanation) per paper. But this is structurally identical to the evidence categorisation we removed:
+
+| | Evidence categorisation | LLM relevance check |
+|---|---|---|
+| Adds LLM call inside `search_evidence` | ✅ | ✅ |
+| Latency ~5–15s for top-N | ✅ | ✅ |
+| Runs on sparse metadata | ✅ | ✅ |
+| Already runs in `run_analysis` | ✅ | ✅ |
+| Risks rationalisation/wrong labels | ✅ | ✅ |
+
+By the same logic that removed categorisation, LLM relevance assessment belongs at the *analysis* stage, not the *search* stage. Search returns candidates; analysis explains them.
+
+### 7. Cross-source ranking asymmetry (known limitation, surface via critique)
+
+The pipeline today has a latent ranking bug between OpenAlex and Overton:
+
+- **OpenAlex papers** carry a numeric `relevance_score` from OpenAlex's API (BM25-ish text match score, typically 0.1–0.8).
+- **Overton policy documents** *would* have a semantic-similarity score available from the Overton API (which uses `squery` + `min_similarity: 0.3`), but the score is **dropped at the `OvertonService.search` boundary** — only metadata is extracted.
+- In `references.py:756-757`, missing `relevance_score` defaults to `0`. Every Overton document therefore carries `relevance_score = 0` into the merged DataFrame.
+- The final ranking is `sort_values(["relevance_score", "variant_priority"])`. Overton documents are systematically deprioritised in the merged top-N — not because they're less relevant, but because they're unscored.
+
+**Decision (Option A):** for this spec, *acknowledge the asymmetry rather than fix the ranking*. The fix touches multiple subsystems (Overton extraction, score normalisation across BM25 vs cosine-similarity metrics) and deserves its own design pass. Address the user-visible symptom through the agent's critique flow instead.
+
+Concretely:
+
+1. **Plumb `source` through `EvidenceResult` and `CompactPaper`** so the LLM can see at a glance which docs came from where.
+2. **Have the LLM critique watch for source-mix skew.** When fewer policy documents than expected appear in the top-N — *and* the user's question is policy-relevant — the critique surfaces this as a candidate problem:
+   > *"Top-5 are all academic papers; only 1 policy document despite querying both sources. This may reflect a known scoring asymmetry. Want me to re-run with source=overton only?"*
+3. **Document the asymmetry in code** (`references.py` and `overton.py`) so future maintainers and the LLM (via tool docstring) know it exists.
+
+**Rejected alternatives:**
+- *Option B (extract Overton's similarity score):* OpenAlex BM25 and Overton cosine similarity aren't directly comparable. Normalising both into a unified score is a meaningful design decision in its own right.
+- *Option C (rank separately, interleave):* Changes the result-list shape and the meaning of `total_found` / `max_results`. Worth doing, but bigger surface area than this spec should take on.
+
+**Future spec:** "Cross-source ranking unification" — proper fix, tracked separately.
+
+### 8. Result viz: aggregate summary strip, not charts
+
+The widget renders results as a list of cards (already does). The only addition is a single-line **aggregate summary strip** above the cards, showing the composition of *the wider 50*, not just the top-5:
+
+```
+Evidence results
+Found 50 papers · showing top 5
+60% US · 20% UK · 20% other · 1998–2024 (median 2011) · 42 academic / 8 policy
+```
+
+Computed deterministically from the wider compact set (pandas `value_counts` on country / source / year). The widget reads it from a new `result_summary` field on `SearchEvidenceOutput`.
+
+**Country-name normalisation** is applied inline during summary computation. OpenAlex's `source_country` is produced by `convert_country_codes_to_names` (full names like "United States"); Overton uses raw labels (often "USA", "UK", or ISO codes). Without normalisation the same country surfaces as two entries in the summary strip — observed in the wild as `"24% USA · 20% United States · …"`. Policy: hybrid — a small deterministic alias dict catches the predictable cross-source mismatches (US/UK and ~15 common others); novel weirdness in stats is caught by the LLM's gap-analysis reflection on the post-call surface (no extra LLM call needed for normalisation itself).
+
+**Rejected alternatives:**
+
+- *Timeline (year-vs-citation scatter)* — citation count is age-confounded; old papers always dominate, the chart screams "look how this paper is cited" rather than "is this evidence current?"
+- *Geographic map* — needs a map library (~50–100 KB inlined) for what "60% US, 20% UK" already says faster
+- *Cluster scatter (themes)* — needs embeddings + dim reduction; the LLM already describes themes in chat for free from the wider compact set
+- *Multiple viz tabs* — turns the widget into its own app rather than a chat-embedded helper; overkill for top-5 + ~50
+
+**Why text wins at this scale:**
+
+The user's triage decision after a search is *"use these top-5, or refine?"* — and that decision is about the *retrieval*, not the *ranking*. A summary strip describing the wider 50 puts the decision-relevant info inside a single text line: zero interpretation step (`60% US` maps directly to a decision; a bar chart requires reading the axis, parsing the bars, translating to a number).
+
+Charts would earn their place at a different scale (compare 3 searches, explore 200+ papers, interactive brush-to-filter). At top-5 + ~50, text wins.
+
+The summary strip is **dual-purpose**: the widget renders it; the LLM also sees it in context and uses it for critique reasoning. Same data, two audiences — same pattern as the wider compact set itself.
+
+### 9. Tool surface: three workflow-stage tools, no per-operation tools
+
+The agentic surface has **three** MCP tools, each representing a *workflow stage*:
+
+| Tool | Stage | What it does |
+|---|---|---|
+| `suggest_pico_options(question)` | Framing | Generates LLM-suggested PICO option sets for triage |
+| `search_evidence(question, picks, …)` | Retrieval / triage | Hits OpenAlex/Overton; returns top-N + wider compact set + summary strip |
+| `run_analysis(...)` | Deep analysis | Picks up from search_evidence's output; screens, extracts findings, synthesises across papers (NEW: see #10) |
+
+That's it. No per-operation tools (`screen_results`, `cluster_results`, `compare_papers`, `expand_paper` etc.). The principle:
+
+> **Tools represent distinct workflow stages with distinct external interactions, not distinct cognitive operations.**
+
+Cognitive operations (compare, theme, drill into ranking, describe distributions) happen in chat via LLM reasoning over the wider compact set that `search_evidence` already returns. Only when the next operation needs **substantially different external interactions or compute** (deep extraction, full-text fetch, synthesis across many papers) does it become its own tool.
+
+This works *because* of decision #4 (wider compact set). By pre-loading ~50 papers' metadata into LLM context per search, every subsequent reasoning operation between stages becomes chat-work — no second tool call needed.
+
+**Rejected candidates and why:**
+
+| Candidate | Why rejected |
+|---|---|
+| `screen_results(doc_ids, criteria)` | Most criteria (geography, source, year) are encodable as `search_evidence` args. Re-call covers it. Subtle criteria become chat work over the wider set. |
+| `cluster_results(doc_ids)` | LLM can describe themes over the wider compact set in chat. No widget needed unless rendering as a viz. |
+| `compare_papers(doc_ids)` | LLM has the top-5 abstracts already; comparison is chat work. |
+| `expand_paper(doc_id)` | Full-text drill-in belongs to `run_analysis`, not search. From search, users go external (Open ↗ link) to read. |
+
+### 10. `run_analysis` becomes a third MCP tool (data handoff from `search_evidence`)
+
+`run_analysis` is currently a REST endpoint at `POST /{project_id}/run-analysis` (`backend/app/api/projects.py:815`) — project-tied, auth-gated, takes `query + search_context` and runs its own search before screening/extracting/synthesising. The current setup duplicates retrieval work that `search_evidence` already did.
+
+**Decision:** make `run_analysis` an MCP tool that accepts the handoff payload from `search_evidence`, so retrieval is done once and the deep-analysis stage picks up where triage left off.
+
+This deliberately crosses the "minimal tool surface" line — and is the right call here because `run_analysis` represents a **distinct workflow stage**, not a cognitive operation that the LLM could do in chat. It involves heavy work (screening 50–200 docs, extracting structured findings, synthesising across the set) that no amount of LLM-chat reasoning replicates.
+
+End-to-end agent flow becomes:
+
+```
+User: "What works for reducing obesity in UK cities?"
+Claude: [calls suggest_pico_options]           ← picker widget
+User: [submits picks via picker]
+Claude: "I'll search, then if results look strong I'll run full analysis (~5 min total)."
+Claude: [calls search_evidence]                 ← results widget + summary strip
+Claude: [critiques in chat: results look good, no source-mix issue]
+Claude: [calls run_analysis with the handoff payload from search_evidence]
+Claude: "Here's the synthesis…"
+```
+
+Soft control points still apply: pre-flight summary before the chain, host transparency on each tool call, user can interrupt by typing.
+
+**Deferred decisions** (next implementation pass, not this spec):
+
+- *Handoff payload shape* — what `search_evidence` returns that `run_analysis` consumes. Candidates: `doc_ids` only, full wider compact set, a cached references-CSV path, or a `search_id` that resolves to server-side state. Each has different state-management implications.
+- *REST vs MCP coexistence* — does the existing REST endpoint stay (for the Policy Atlas app UI) and the MCP tool wrap it, or does the MCP tool replace it? Implementation detail; cleanest is probably "MCP tool wraps the REST endpoint, both stay alive."
+- *Auth / project_id handling in MCP context* — current REST endpoint requires `current_user` and an existing project. MCP needs an answer for whether analysis runs ephemerally or always against a project, and how auth is presented.
+
+These are real design problems but they're scoped to the analysis-integration spec, not this one.
+
+---
+
+### 12. Tool docstrings are agent instructions, not documentation
+
+Per spike finding #7, MCP tool docstrings are not internal documentation — they're **load-bearing agent instructions** the LLM reads verbatim and treats as policy. Every word matters; vague guidance produces vague behaviour.
+
+Each tool's docstring must cover **five sections**, in this order:
+
+1. **When to call** — the precondition the LLM should verify before invoking
+2. **What it returns** — schema-level summary, not implementation detail
+3. **Presentation guidance** — how to present results to the user (terseness, format, what to omit)
+4. **Post-call behaviour** — what reflection or follow-up is expected (critique, summary strip use, gating before next step)
+5. **Hard constraints** — explicit "do not" clauses; concrete exclusions beat vague "be concise"
+
+#### Concrete docstring contract per tool
+
+**`suggest_pico_options(question: str)`**
+
+```text
+WHEN: Call this FIRST when scoping an unfamiliar research question, before
+search_evidence. Skip if the user has already given explicit framings.
+
+RETURNS: 3–5 options per facet (population, outcome, inner_setting). The picker
+widget renders these for the user to select from.
+
+PRESENTATION: After the tool returns, the widget will render the options. Do
+not narrate the options as a markdown list — the widget shows them.
+
+You MAY add a brief (1–2 sentence) critique if you notice something genuinely
+useful: e.g. two or more options collapse to the same framing, a clearly-
+relevant dimension is missing, or the question's terms are ambiguous and
+produced shallow options. Keep critique terse — one sentence, no enumeration
+of the options themselves. If options look clean, just say so briefly.
+
+POST-CALL: Wait for the user's picks (delivered via app.sendMessage from the
+picker). Do not call search_evidence without explicit user-confirmed picks.
+
+DO NOT:
+- Autonomously make picks for the user
+- Re-call this tool to "refine" picks; users refine via the picker's custom inputs
+- Proceed to search_evidence speculatively
+- Critique at length; the picker is the selection surface, your critique is
+  just a brief steer
+```
+
+**`search_evidence(question, population, outcome, inner_setting, geography, ...)`**
+
+```text
+WHEN: Call after the user has confirmed PICO picks (via the picker widget). May
+also be called standalone if the user gives explicit search terms without going
+through the picker.
+
+RETURNS:
+- results: top-5 papers (rendered by the search-evidence widget)
+- additional_results: wider compact set of ~45 more papers (metadata only, for
+  YOUR reasoning — not shown to the user)
+- result_summary: aggregate stats over the wider 50 (rendered above the results
+  by the widget; also available to you)
+- boolean_queries_used: query variants run (auditability)
+- (each paper carries: relevance_score, query_variant, variant_priority, source)
+
+PRESENTATION: The widget renders top-5 + summary strip. Do not re-narrate
+either. A single brief acknowledgement is enough ("Results above; ~30s search").
+
+POST-CALL REFLECTION — REQUIRED:
+After results return, silently perform a research gap analysis against the
+user's question. Use result_summary (aggregate stats over the wider 50) +
+additional_results (compact metadata of the wider set) to ground this in
+actual data — don't speculate beyond what the results show.
+
+Identify dimensions where the evidence base is THIN or MISSING relative to
+what would fully answer the user's question:
+  - Study designs (e.g. effectiveness question but no RCTs/quasi-experimental
+    work in the set)
+  - Populations or subgroups the question implies but results don't cover
+  - Intervention types or delivery contexts that are conspicuously absent
+  - Time periods (e.g. all pre-2015 when the question is about current
+    practice)
+  - Outcomes measured (e.g. question asks about long-term effects, results
+    only report short-term)
+  - Geographies, *as one dimension among many* — not the primary lens
+  - Source-mix asymmetry as a known limitation (see §7): if the question is
+    policy-relevant and few Overton docs surfaced, that may reflect ranking
+    bias against policy documents, not a true literature gap
+
+Then propose corrective actions grounded in the gap analysis:
+  - For gaps that adjusted search args would address → propose re-calling
+    search_evidence with the relevant change ("no RCTs in the top-50 — want
+    me to retry with stricter study-design filtering?")
+  - For gaps the wider set already partly addresses → name the specific
+    buried papers ("Aubry 2020 at rank 12 covers the UK setting your
+    question implied — want to look at it?")
+  - For genuine evidence gaps (the literature simply doesn't exist in the
+    indexed set) → note honestly ("no RCTs on this question appear in the
+    indexed set — only observational evidence is available; the synthesis
+    stage can still proceed on that, but flag the limitation")
+
+Wait for explicit user confirmation before any corrective re-call. Surface
+gaps even if no corrective action is possible — the user benefits from
+knowing what's not in the evidence base.
+
+DO NOT:
+- Narrate the JSON; the widget renders it
+- Auto-retry without user confirmation
+- Treat the per-paper relevance_score as semantic relevance — it's a raw
+  BM25-ish score, not an explained judgement
+- Propose drilling into a paper's full text — that belongs to run_analysis
+```
+
+**`run_analysis(handoff_payload)`** — *contract sketched; exact signature pending §10 decisions*
+
+```text
+WHEN: Call ONLY after search_evidence has returned and the user has explicitly
+confirmed they want deep analysis. Never auto-chain from search_evidence.
+
+RETURNS: Synthesised findings across the analysed papers (schema TBD per the
+analysis-integration spec).
+
+PRESENTATION: Pre-flight summary REQUIRED before invoking, because this is
+heavy (~5 min). Say what you'll do, give an ETA, allow user interrupt:
+  "I'll run full analysis on these N papers — extracting findings and
+   synthesising across them. ~5 min. OK to proceed?"
+Wait for explicit "yes" or equivalent before calling.
+
+POST-CALL: Walk the user through findings concisely; full report is in the
+analysis widget. Don't re-narrate the whole report.
+
+DO NOT:
+- Auto-chain from search_evidence without explicit user signal
+- Re-do the retrieval — use the handoff payload from search_evidence
+- Run on uncritiqued search results (if critique flagged issues, address them
+  before escalating to analysis)
+```
+
+#### Why this matters
+
+From the spike findings: *"docstrings are load-bearing agent instructions, not internal docs. Every word in `suggest_pico_options`'s docstring was visible in Claude's responses."* The agentic behaviour designed in §§1–11 only manifests if the docstrings *say* so. Reflection won't happen unless we instruct it; critique won't propose corrective action unless we specify the action shape; the wider compact set won't be used unless we tell the LLM what it's for.
+
+The docstrings are the spec **made executable**. They live in `app/mcp/tools.py` and ship with every `tools/list` response — they are quite literally what the LLM sees and reasons over.
+
+### 11. Cross-session state: LLM context is the memory
+
+No server-side session cache, no `search_id` token system, no project-tied persistence at the search stage. The wider compact set from each `search_evidence` call lives in Claude's conversation context naturally; that's the memory.
+
+**Implications:**
+
+- *Cheap and free.* No state to manage; no cache invalidation; no auth tied to session state.
+- *Lossy by design.* Context can drift, old searches may eventually fall out of the LLM's effective context window over a long conversation.
+- *The LLM can naturally reference earlier searches* in the same conversation ("this paper also appeared in your earlier search of X").
+- *Project-tied persistence happens at the `run_analysis` stage*, not search. Search is ephemeral by design.
+
+**Rejected alternatives:**
+
+| Candidate | Why rejected |
+|---|---|
+| No state at all | Loses the natural cross-search reasoning the LLM can do in chat |
+| Server-side session cache keyed by `search_id` | Adds state management for a benefit (cross-search compare) that the LLM already does for free via its context |
+| Persistent project-tied state | Mixes search-stage (ephemeral) and analysis-stage (persistent) concerns. Search stays light. |
+
+---
+
+## Implementation checklist
+
+Concrete code changes needed to realise the spec. Listed by file in dependency order.
+
+### 1. Schema (`backend/app/mcp/schemas.py`)
+
+- [ ] Add `ResultSummary` model with fields: `country_distribution: dict[str, int]`, `year_range: tuple[int, int]`, `year_median: int | None`, `source_mix: dict[str, int]`, `document_type_mix: dict[str, int]`, `open_access_fraction: float | None`
+- [ ] Add `CompactPaper` model per §4 schema (10 fields including 1000-char `abstract_snippet`)
+- [ ] Extend `EvidenceResult` with three new optional fields: `relevance_score: float | None`, `query_variant: str | None`, `variant_priority: int | None`
+- [ ] Extend `SearchEvidenceOutput` with `additional_results: list[CompactPaper]` and `result_summary: ResultSummary | None`
+
+### 2. Tool implementation (`backend/app/mcp/tools.py`)
+
+- [ ] Extend `_row_to_evidence()` to extract the three new EvidenceResult fields (`relevance_score`, `query_variant`, `variant_priority`)
+- [ ] Add helper `_row_to_compact_paper(row, rank)` that builds a `CompactPaper` with the 1000-char abstract snippet
+- [ ] Add helper `_compute_result_summary(df)` that runs pandas `value_counts` over the full fetched DataFrame for country / source / document_type / year and computes OA fraction
+- [ ] Update `search_evidence()` to:
+  - Build `additional_results` from `df.iloc[max_results:]` (papers ranked 6+ in the wider 50)
+  - Build `result_summary` from the *full* fetched DataFrame (not just the top-N)
+  - Return all three layers (`results`, `additional_results`, `result_summary`)
+- [ ] **Rewrite `suggest_pico_options` docstring** per §12 contract (when-call, returns, presentation, post-call, do-not)
+- [ ] **Rewrite `search_evidence` docstring** per §12 contract — this is the substantive one; the gap-analysis post-call block is the load-bearing part
+
+### 3. Widget (`backend/app/mcp/widgets/src/search-evidence.ts`)
+
+- [ ] Add `ResultSummary` TypeScript type mirroring the Pydantic shape
+- [ ] Add `renderSummaryStrip(summary)` function that produces the one-line aggregate strip (per §8 format)
+- [ ] Call it above the `<ol class="results">` block in `renderResults()`
+- [ ] Update the loading-state HTML to also have a placeholder for where the strip will appear (avoids layout jump on results arrival)
+
+### 4. Widget CSS (`backend/app/mcp/widgets/src/search-evidence.css`)
+
+- [ ] Add `.summary-strip` rule: muted text colour, smaller font, sits below the `Found N papers · showing top M` line, above `.results`
+
+### 5. Build & smoke test
+
+- [ ] `npm run build` in `backend/app/mcp/widgets/` — confirm both `pico-picker.html` and `search-evidence.html` rebuild cleanly
+- [ ] `uv run python -c "from app.mcp import tools; from app.mcp.schemas import CompactPaper, ResultSummary, SearchEvidenceOutput; print('schema ok')"` — confirm imports
+- [ ] Restart MCP server and run an end-to-end search; verify:
+  - Widget renders with the summary strip
+  - `additional_results` appears in the tool result `structuredContent` (inspect via MCP inspector or stderr logs)
+  - LLM's response includes reflection / gap analysis without prompting
+
+### 6. Deferred (next spec, do not implement here)
+
+- `run_analysis` MCP tool wiring (decision §10 — needs handoff payload + auth design)
+- Cross-source ranking unification (decision §7 — separate spec for BM25/cosine normalization)
+- Error handling specifics (0-result searches, API timeouts)
+- Telemetry / metrics
+
+### Effort estimate
+
+| Section | Lines of code | Risk |
+|---|---|---|
+| Schema additions | ~30 | Low — pure data classes |
+| Tool wiring (3 helpers + search_evidence update) | ~80 | Low — read existing columns into existing patterns |
+| Docstring rewrites | ~120 (across two tools) | Medium — these *are* the agentic behaviour; subtle wording matters |
+| Widget + CSS | ~60 | Low — incremental on existing widget |
+| **Total** | **~290 lines** | **Mostly low** |
+
+The docstrings are the highest-leverage and highest-risk part. Everything else is mechanical plumbing.
+
+---
+
+## Out of scope for this spec
+
+These dimensions came up during interview but were explicitly deferred:
+
+- **Plan widget design** — only worth building if chains grow past ~4 steps. Today's three-tool surface plus pre-flight summary handles control flow.
+- **Cross-source ranking unification** — fixing the OpenAlex / Overton scoring asymmetry properly. Documented as known limitation in §7; needs its own spec (BM25 vs cosine normalization is a real design decision).
+- **`run_analysis` handoff payload shape** — covered in §10; deferred to the analysis-integration spec.
+- **Auth / project_id handling for `run_analysis` in MCP context** — also in §10; analysis-integration concern.
+- **Error handling specifics** — 0-result searches, API failures, partial source outages. These are real concerns but more implementation than spec; the agentic critique flow naturally handles "0 results" by reflecting on why and proposing a refined search.
+- **Telemetry for measuring "agentic"-ness** — how to know if the design is working in practice (e.g., critique-acceptance rate, search-to-analysis conversion). Worth tracking but no design decisions blocked on it.
+
+---
+
+## Design principles applied
+
+From Claude Code's tool-use design, translated to MCP:
+
+| Principle | MCP analogue |
+|---|---|
+| Tool calls are visible turns; opacity is the enemy of trust | Claude Desktop renders every `tools/call` in chat — already works |
+| Soft gates over hard gates | Pre-flight summary; user interrupt by typing |
+| Reversibility through chat history (scroll == undo) | Chat history preserves all tool results; refined results appear *below* originals |
+| No "rewinds" through earlier UI steps | When the user clicks "search" in the picker, they don't get sent *back* to the picker on critique — they get a new search inline |
+| Progressive disclosure | Critique surfaces a fix; user accepts (or doesn't) before action |
+
+---
+
+## MCP-specific considerations
+
+- **`_meta.ui.resourceUri` annotations** link each tool to its widget. `search_evidence` → results widget; `suggest_pico_options` → picker widget.
+- **Structured output serves two audiences**: `results` for widget rendering, `additional_results` for LLM reasoning. Don't force one schema to serve both.
+- **Widget-initiated calls** (`app.callServerTool`) don't reliably surface in host chat. Use `app.sendMessage` + `app.updateModelContext` for hand-offs (picker → search hand-off uses this).
+- **Tool result `content` should be terse** — a one-line summary, not a full JSON dump. The LLM uses `structuredContent` for data, not `content`. Otherwise the LLM narrates the dump and duplicates the widget.
+- **`CallToolResult` direct return** in FastMCP gives full control over `content` and `structuredContent` separately — bypasses FastMCP's default Pydantic auto-serialisation.
+
+---
+
+## Latency budget reference
+
+| Step | Current | Target |
+|---|---|---|
+| `suggest_pico_options` (3 parallel LLM calls) | ~3s | unchanged |
+| `search_evidence` (multi-query + 12+ source fetches) | ~28s | unchanged |
+| Critique (LLM reflection over top-5 + wider 45) | new — est. ~3–5s | <5s |
+| End-to-end picker → critique decision | est. ~35–40s | <45s |
+
+The 9s Microsoft p99 threshold is exceeded by `search_evidence` alone (will be addressed via job-handle pattern in a separate spec — out of scope for this one).


### PR DESCRIPTION
## What this is

An exploratory **MCP PoC** for Policy Atlas, living under `backend/app/mcp/`. It exposes two tools (`suggest_pico_options`, `search_evidence`) that surface our existing search pipeline to any MCP capable host, plus two interactive widgets that render inline in MCP Apps capable hosts like Claude Desktop. The design is spec-led with documented decisions and known deferred items. **This is PoC code, not production** — it's here so you (and the rest of the team) can poke at it, get a feel for what MCP brings us, and form opinions about where this should go next.

This PR is not asking for a code review. It's an orientation + setup guide so you can run the MCP server against your own Claude Desktop and play with it.

## Suggested reading order

1. **`docs/mcp_server_overview.md`** ... start here. Operational reference: what the system looks like today, file layout under `backend/app/mcp/`
2. **The three commits, in order.** Each commit message has a 1-2 paragraph \"why\" body:
   - `27920dc` mcp: add FastMCP server exposing PICO + evidence-search tools
   - `a7be375` mcp: add interactive widgets (vite + ext-apps SDK)
   - `1655f1a` mcp: add spec, overview, PoC retrospective, and integration plan
3. **`docs/spec_search_evidence_agentic.md`** — when curious about *why* a particular thing is the way it is. 12 numbered design decisions and a list of deferred items. The overview cross references specific sections of this spec.
4. **`docs/mcp_spike_findings.md`** — empirical pain-points encountered during the PoC (docstrings being load-bearing as agent instructions, Claude Desktop's renderer being partial earlier on, etc.). These are the empirical anchors behind the spec's decisions.

## How to run it in your Claude Desktop

The practical heart of this PR. Follow these steps and you'll have the MCP server wired into Claude Desktop in a few minutes.

### One-time setup

```bash
cd backend && uv sync
cd backend/app/mcp/widgets && npm install && npm run build
```

The `npm run build` step bundles the widget JS/CSS and inlines it into single-file HTMLs —> necessary because the iframe sandbox in Claude Desktop's MCP-Apps renderer can't fetch external assets.

### Claude Desktop config

Open (or create) `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS and add:

```json
{
  \"mcpServers\": {
    \"policy-atlas\": {
      \"command\": \"/opt/homebrew/bin/uv\",
      \"args\": [
        \"run\", \"--directory\", \"<REPLACE WITH ABSOLUTE PATH>/discovery_policy_atlas/backend\",
        \"python\", \"-m\", \"app.mcp.server\"
      ]
    }
  }
}
```

Replace `<REPLACE WITH ABSOLUTE PATH>` with the absolute path to wherever you've cloned the repo.

### Gotchas (read these — they will save you 20 minutes)

- **Use the absolute path to `uv`.** GUI-spawned processes (Claude Desktop is one) don't inherit your shell PATH, so `\"command\": \"uv\"` will silently fail to launch the server. Run `which uv` to find yours — on macOS with Homebrew it's typically `/opt/homebrew/bin/uv`.
- **Fully quit Claude Desktop with ⌘Q before relaunching.** Just closing the window doesn't kill the process, and config changes won't load. ⌘Q, wait a second, reopen.

## What you'll see when you try it

1. Type a research question into Claude Desktop, e.g. *\"What works for reducing homelessness in UK cities?\"*
2. Claude calls `suggest_pico_options` → an interactive **picker widget** renders inline in the chat. It shows checkboxes per PICO facet (population / outcome / inner-setting / etc.) plus a `+ add your own…` text field for each facet so you can extend the suggestions.
3. Tick the framings you want and click **Search evidence**. A friendly message gets pre-filled into the chat textbox — press send.
4. Claude calls `search_evidence` → the **search-evidence widget** renders with an animated progress bar. Expect ~25-30s for the search itself (multi-query LLM + parallel source fetches).
5. When results land, the widget displays the top 5 papers plus an aggregate summary strip — something like *\"60% US · 30% UK · 10% other · 1998–2024 · 42 academic / 8 policy\"*.
6. Claude then performs a **research gap analysis** in chat — flagging missing methodologies, geographic drift, gaps in the evidence base, etc. Note: the gap analysis is reasoning over the wider compact set of ~50 papers Claude has in context, not just the 5 rendered in the widget.

## Known limitations (already documented, don't worry about these)

- **`search_evidence` takes ~25-30s.** Multi-query LLM expansion + parallel source fetches. Microsoft's 9s p99 threshold for MCP tools is documented as an out-of-scope concern for the spike.
- **Overton policy documents are systematically deprioritised** in the merged ranking — a known cross-source scoring asymmetry. `docs/spec_search_evidence_agentic.md` §7 walks through why.
- **Claude Desktop's MCP Apps widget renderer** has shipped support, but had partial rendering issues earlier in the spike. Covered in `docs/mcp_spike_findings.md` finding #11. Should mostly work now — if a widget doesn't render, that's the place to look.
- **LLM-derived rationales** (evidence categorisation, per-paper relevance explanations) were *deliberately not* surfaced at the search stage. They belong to the analysis stage, which is currently REST-only and planned to become a third MCP tool. See `docs/spec_search_evidence_agentic.md` §10.