### PR TITLE
Adding user context

### DIFF
--- a/backend/app/services/analysis/schemas.py
+++ b/backend/app/services/analysis/schemas.py
@@ -78,6 +78,7 @@ class SearchContext(BaseModel):
     max_results: Optional[int] = None
     additional_questions: List[str] = Field(default_factory=list)
     implementation_constraints: Optional[ImplementationConstraints] = None
+    user_context: Optional[str] = None
     # Collected for analytics; does not affect search behavior in alpha
     # Keep in sync with frontend/components/search/SearchWizard.tsx UseCase type
     use_case: Optional[

--- a/backend/app/services/synthesis/nodes/briefing.py
+++ b/backend/app/services/synthesis/nodes/briefing.py
@@ -248,6 +248,14 @@ async def generate_briefing(state: SynthesisState) -> SynthesisState:
         if research_question:
             instructions = f"Research Question: {research_question}\n\n{instructions}"
 
+        # Inject user context to tailor audience framing.
+        user_context = state.get("user_context") or ""
+        if user_context:
+            instructions = (
+                f"Audience context: {user_context}\n"
+                "Frame your output for this audience.\n\n" + instructions
+            )
+
         # Inject user intent (population/outcomes) to tailor generation without displaying it explicitly.
         target_population = state.get("target_population") or []
         target_outcomes = state.get("target_outcomes") or []

--- a/backend/app/services/synthesis/nodes/data_loading.py
+++ b/backend/app/services/synthesis/nodes/data_loading.py
@@ -73,6 +73,7 @@ async def load_raw_extractions(state: SynthesisState) -> SynthesisState:
     target_geography = search_query.get("geography") or ["UK"]
     target_inner_setting = search_query.get("inner_setting") or []
     implementation_constraints = search_query.get("implementation_constraints") or {}
+    user_context = search_query.get("user_context") or ""
     # Normalise to list[str]
     if isinstance(target_population, str):
         target_population = [target_population]
@@ -262,6 +263,7 @@ async def load_raw_extractions(state: SynthesisState) -> SynthesisState:
         "target_geography": target_geography,
         "target_inner_setting": target_inner_setting,
         "implementation_constraints": implementation_constraints,
+        "user_context": user_context,
         "doc_metadata": doc_metadata,
         "doc_scores": doc_scores,
         "extraction_to_doc": extraction_to_doc,

--- a/backend/app/services/synthesis/nodes/theme_discovery.py
+++ b/backend/app/services/synthesis/nodes/theme_discovery.py
@@ -64,7 +64,8 @@ async def _discover_themes(
         f"model:{THEME_MODEL}",
     ]
     instructions = make_discover_themes_instructions(None)
-    prompt = build_discover_themes_prompt()
+    user_context = state.get("user_context") or ""
+    prompt = build_discover_themes_prompt(user_context=user_context)
     llm = get_llm(THEME_MODEL, temperature=0.0).with_structured_output(ThemesOut)
 
     try:

--- a/backend/app/services/synthesis/prompts.py
+++ b/backend/app/services/synthesis/prompts.py
@@ -4,21 +4,32 @@ from typing import Optional
 
 from langchain_core.prompts import ChatPromptTemplate
 
+DEFAULT_AUDIENCE = "senior UK policymakers"
 
-def build_discover_themes_prompt() -> ChatPromptTemplate:
+
+def _audience_phrase(user_context: str) -> str:
+    """Return an audience phrase from user_context, falling back to the default."""
+    return user_context.strip() if user_context.strip() else DEFAULT_AUDIENCE
+
+
+def build_discover_themes_prompt(user_context: str = "") -> ChatPromptTemplate:
     """Prompt for discovering themes from concept descriptions, guided by a research question.
+
+    Args:
+        user_context: Free-text user profile for audience framing.
 
     Returns:
         ChatPromptTemplate: Template expecting variables: critique_instruction, rq, concepts
     """
+    audience = _audience_phrase(user_context)
     system = (
         "You are an expert in qualitative data analysis, specialising in synthesising "
-        "complex information for senior UK policymakers. Your core skill is to identify "
+        f"complex information for: {audience}. Your core skill is to identify "
         "a clear, logical, and insightful thematic structure from diverse sources."
     )
     user = (
         "<role>\n"
-        "You are an expert in qualitative data analysis, specialising in synthesising complex information for senior UK policymakers. "
+        f"You are an expert in qualitative data analysis, specialising in synthesising complex information for: {audience}. "
         "Your core skill is to identify a clear, logical, and insightful thematic structure from diverse sources.\n"
         "</role>\n"
         "<task>\n"
@@ -142,22 +153,26 @@ def build_classify_concept_prompt() -> ChatPromptTemplate:
     return ChatPromptTemplate.from_messages([("system", system), ("user", user)])
 
 
-def build_impact_summary_prompt() -> ChatPromptTemplate:
+def build_impact_summary_prompt(user_context: str = "") -> ChatPromptTemplate:
     """Prompt for writing a short impact summary for a theme.
+
+    Args:
+        user_context: Free-text user profile for audience framing.
 
     Returns:
         ChatPromptTemplate: Template expecting variables: name, sample
     """
-    system = "You are a specialist in policy communication. Your expertise is distilling complex evidence into concise, clear, and impactful summaries for senior government officials."
+    audience = _audience_phrase(user_context)
+    system = f"You are a specialist in policy communication. Your expertise is distilling complex evidence into concise, clear, and impactful summaries for: {audience}."
     user = (
         "<role>\n"
-        "You are a specialist in policy communication. Your expertise is distilling complex evidence into concise, clear, and impactful summaries for senior government officials.\n"
+        f"You are a specialist in policy communication. Your expertise is distilling complex evidence into concise, clear, and impactful summaries for: {audience}.\n"
         "</role>\n"
         "<task>\n"
         "Write an evidence-based summary for the policy theme provided below. The summary must focus exclusively on the expected impacts and overall effectiveness of the interventions described in the representative concepts.\n"
         "</task>\n"
         "<constraints>\n\n"
-        "Audience: The summary is for a senior UK policy advisor who needs to understand the key takeaway in under 30 seconds.\n\n"
+        f"Audience: The summary is for: {audience}. They need to understand the key takeaway in under 30 seconds.\n\n"
         "Focus: Synthesise the outcomes and results from the concepts. Do not describe the concepts themselves, only their impact.\n\n"
         "Tone: The tone must be objective, formal, and confident.\n\n"
         "Word Count: Your response must be strictly between 35 and 45 words.\n\n"
@@ -173,19 +188,23 @@ def build_impact_summary_prompt() -> ChatPromptTemplate:
     return ChatPromptTemplate.from_messages([("system", system), ("user", user)])
 
 
-def build_executive_briefing_prompt() -> ChatPromptTemplate:
+def build_executive_briefing_prompt(user_context: str = "") -> ChatPromptTemplate:
     """Prompt for synthesising the final executive briefing.
+
+    Args:
+        user_context: Free-text user profile for audience framing.
 
     Returns:
         ChatPromptTemplate: Template expecting variables: rq, payload
     """
+    audience = _audience_phrase(user_context)
     system = (
-        "You are a Principal Private Secretary in the UK Civil Service. Your primary responsibility is to synthesise complex information into "
-        "authoritative, concise, and politically neutral executive briefings for cabinet ministers."
+        f"You are writing for: {audience}. Your primary responsibility is to synthesise complex information into "
+        "authoritative, concise, and politically neutral executive briefings."
     )
     user = (
         "<role>\n"
-        "You are a Principal Private Secretary in the UK Civil Service. Your primary responsibility is to synthesise complex information into authoritative, concise, and politically neutral executive briefings for cabinet ministers.\n"
+        f"You are writing for: {audience}. Your primary responsibility is to synthesise complex information into authoritative, concise, and politically neutral executive briefings.\n"
         "</role>\n"
         "<task>\n"
         "Synthesise the provided STRUCTURED DATA into a formal executive briefing that directly answers the user's RESEARCH QUESTION. The output must be highly structured and scannable.\n"
@@ -198,7 +217,7 @@ def build_executive_briefing_prompt() -> ChatPromptTemplate:
         "Promising Interventions: Under this heading, provide 2-3 concise bullet points summarising the most effective solutions or policy levers.\n"
         "</briefing_structure>\n\n"
         "<constraints>\n\n"
-        "Audience & Tone: The reader is a time-poor cabinet minister. The tone must be formal, objective, and confident.\n\n"
+        f"Audience & Tone: The reader is: {audience}. The tone must be formal, objective, and confident.\n\n"
         "Evidence Grounding: Your briefing must be a direct synthesis of the provided STRUCTURED DATA only. Do not invent information or draw external conclusions.\n\n"
         "Conciseness: Each bullet point must be a single, clear, and impactful phrase or sentence. Avoid compound sentences.\n\n"
         "Directness: Do not restate or quote the research question in the output; provide the answer as a clear conclusion.\n\n"
@@ -307,20 +326,24 @@ def build_impact_snapshot_prompt() -> ChatPromptTemplate:
 # =============================================================================
 
 
-def build_background_section_prompt() -> ChatPromptTemplate:
+def build_background_section_prompt(user_context: str = "") -> ChatPromptTemplate:
     """Prompt for generating the background/context section using RAG evidence.
+
+    Args:
+        user_context: Free-text user profile for audience framing.
 
     Returns:
         ChatPromptTemplate: Template expecting variables:
             research_question, issues_summary, evidence_context
     """
+    audience = _audience_phrase(user_context)
     system = (
         "You are a policy research analyst. Your task is to write a concise background "
         "section that contextualises a policy issue using evidence from retrieved documents."
     )
     user = (
         "<role>\n"
-        "You are a policy research analyst writing for senior UK government officials.\n"
+        f"You are a policy research analyst writing for: {audience}.\n"
         "</role>\n\n"
         "<task>\n"
         "Write a background section (2-3 paragraphs) that contextualises the policy issue. "
@@ -401,21 +424,25 @@ def build_intervention_impact_prompt() -> ChatPromptTemplate:
     return ChatPromptTemplate.from_messages([("system", system), ("user", user)])
 
 
-def build_recommendations_prompt() -> ChatPromptTemplate:
+def build_recommendations_prompt(user_context: str = "") -> ChatPromptTemplate:
     """Prompt for generating RAG-grounded policy recommendations.
+
+    Args:
+        user_context: Free-text user profile for audience framing.
 
     Returns:
         ChatPromptTemplate: Template expecting variables:
             research_question, top_interventions, evidence_context
     """
+    audience = _audience_phrase(user_context)
     system = (
         "You are a senior policy advisor. Your task is to write actionable, "
-        "evidence-based recommendations for government ministers. "
+        f"evidence-based recommendations for: {audience}. "
         "You will output structured JSON with exactly 3-4 recommendations."
     )
     user = (
         "<role>\n"
-        "You are a senior policy advisor writing recommendations for UK cabinet ministers.\n"
+        f"You are a senior policy advisor writing recommendations for: {audience}.\n"
         "</role>\n\n"
         "<task>\n"
         "Write exactly 3-4 policy recommendations based on the evidence below.\n"
@@ -494,20 +521,24 @@ def build_impact_narrative_prompt() -> ChatPromptTemplate:
     return ChatPromptTemplate.from_messages([("system", system), ("user", user)])
 
 
-def build_core_answer_prompt() -> ChatPromptTemplate:
+def build_core_answer_prompt(user_context: str = "") -> ChatPromptTemplate:
     """Prompt for generating the core answer at the top of the briefing.
+
+    Args:
+        user_context: Free-text user profile for audience framing.
 
     Returns:
         ChatPromptTemplate: Template expecting variables:
             research_question, top_interventions, intervention_count, background_context
     """
+    audience = _audience_phrase(user_context)
     system = (
-        "You are a Principal Private Secretary. Your task is to write a headline "
-        "answer that directly addresses a minister's research question."
+        f"You are writing for: {audience}. Your task is to write a headline "
+        "answer that directly addresses their research question."
     )
     user = (
         "<role>\n"
-        "You are a Principal Private Secretary writing executive summaries for UK ministers.\n"
+        f"You are writing executive summaries for: {audience}.\n"
         "</role>\n\n"
         "<task>\n"
         "Write a headline answer (2-3 sentences) that directly addresses the research question. "

--- a/backend/app/services/synthesis/state.py
+++ b/backend/app/services/synthesis/state.py
@@ -73,6 +73,7 @@ class SynthesisState(TypedDict, total=False):
     target_outcomes: List[str]  # e.g., ["body weight/size reduction"]
     target_geography: List[str]  # e.g., ["UK"]
     target_inner_setting: List[str]  # e.g., ["Schools"]
+    user_context: str  # Free-text user profile for audience framing
 
     # Raw data
     raw_extractions: List[Dict]

--- a/backend/app/services/synthesis/tools/orchestrator.py
+++ b/backend/app/services/synthesis/tools/orchestrator.py
@@ -1658,8 +1658,14 @@ Additional guidance:
         """Generate recommendations using structured output to ensure format consistency."""
         evidence_context = await self._format_evidence_for_generation(ctx)
 
+        user_context = ctx.state.get("user_context") or ""
+        audience_line = (
+            f"You are writing policy recommendations for the following audience: {user_context}"
+            if user_context
+            else "You are writing policy recommendations for UK cabinet ministers."
+        )
         prompt = f"""
-You are writing policy recommendations for UK cabinet ministers.
+{audience_line}
 
 Requirements:
 - Output exactly 3-4 recommendations.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -352,7 +352,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=0.1.0" },
     { name = "langchain-core", specifier = ">=0.1.0" },
     { name = "langchain-openai", specifier = ">=0.1.0" },
-    { name = "langfuse", specifier = ">=2.60.7" },
+    { name = "langfuse", specifier = "<4" },
     { name = "langgraph", specifier = ">=0.5.4" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.14" },

--- a/frontend/app/(main)/search/page.tsx
+++ b/frontend/app/(main)/search/page.tsx
@@ -100,6 +100,7 @@ export default function SearchPage() {
         max_results: context.maxResults,
         additional_questions: context.additionalQuestions,
         use_case: context.useCase ?? undefined,
+        user_context: context.userContext || undefined,
         ...(hasImplementationConstraints
           ? { implementation_constraints: implementationConstraints }
           : {}),

--- a/frontend/components/results/SearchPlanModal.tsx
+++ b/frontend/components/results/SearchPlanModal.tsx
@@ -205,6 +205,12 @@ export function SearchPlanModal({ project }: SearchPlanModalProps) {
 
           <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
             <div className="text-xs uppercase tracking-wide text-gray-500">Refinement</div>
+            {searchQuery.user_context && (
+              <div>
+                <span className="font-medium text-sm">Your context</span>
+                <div className="mt-2 text-sm text-gray-700 line-clamp-2">{searchQuery.user_context}</div>
+              </div>
+            )}
             <div>
               <span className="font-medium text-sm">Implementation constraints</span>
               {hasImplementationConstraints ? (

--- a/frontend/components/search/SearchWizard.tsx
+++ b/frontend/components/search/SearchWizard.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { create } from "zustand";
 import { useAPI } from '@/lib/api';
 import type { AnalysisProject } from '@/lib/analysisProjectStore';
+import { useUserProfileStore } from '@/lib/userProfileStore';
 import { estimateAnalysisDurationRange } from '@/lib/analysisTimingHeuristic';
 import { RefineTutorial } from './RefineTutorial';
 import { Badge } from '@/components/ui/badge';
@@ -195,6 +196,7 @@ export type SearchContext = {
   additionalQuestions: string[]; // Additional research questions
   maxResults: number;
   useCase: UseCase | null;
+  userContext: string;
 };
 
 // ---------------- STATE ----------------
@@ -225,6 +227,7 @@ interface WizardState {
   };
   screeningFactors: string[];
   additionalQuestions: string[];
+  userContext: string;
   maxResults: number;
   allStepsVisited: boolean;
   parentProjectId: string | null;
@@ -263,6 +266,7 @@ const INITIAL_WIZARD_STATE = {
   },
   screeningFactors: [] as string[],
   additionalQuestions: [] as string[],
+  userContext: "",
   maxResults: 30,
   allStepsVisited: false,
   parentProjectId: null as string | null,
@@ -304,6 +308,7 @@ export const useWizard = create<WizardState>((set, get) => ({
       additionalQuestions: s.additionalQuestions,
       maxResults: s.maxResults,
       useCase: s.useCase,
+      userContext: s.userContext || useUserProfileStore.getState().userContext,
     };
   },
   initFromSearchQuery: (sq: NonNullable<AnalysisProject['search_query']>, parentProjectId: string) => {
@@ -347,6 +352,7 @@ export const useWizard = create<WizardState>((set, get) => ({
       generatedInnerSettingOptions: innerSetting,
       generatedOutcomeOptions: outcome,
       screeningFactors,
+      userContext: sq.user_context || useUserProfileStore.getState().userContext,
       parameters: {
         sources,
         access: {
@@ -1289,6 +1295,13 @@ function ScreenScreening() {
   const s = useWizard();
   const [customInput, setCustomInput] = useState("");
   const constraintOptions = ["Any", "Low", "Moderate", "High"];
+  const profileStore = useUserProfileStore();
+  const currentContext = s.userContext || profileStore.userContext;
+
+  const handleContextChange = (value: string) => {
+    s.set({ userContext: value });
+    profileStore.setUserContext(value);
+  };
 
   const addFactor = () => {
     if (customInput.trim() && !s.screeningFactors.includes(customInput.trim())) {
@@ -1311,6 +1324,21 @@ function ScreenScreening() {
       </div>
 
       <div className="space-y-6 max-w-2xl mx-auto">
+        <div className="space-y-3">
+          <h3 className="font-semibold text-lg">What is your context</h3>
+          <p className="text-sm text-gray-600">
+            Describe your role and how you&apos;ll use the outputs. This shapes how synthesis results are framed.
+          </p>
+          <textarea
+            className="w-full rounded-xl ring-1 ring-gray-300 px-4 py-3 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-600 resize-y min-h-[80px]"
+            rows={3}
+            value={currentContext}
+            onChange={(e) => handleContextChange(e.target.value)}
+          />
+        </div>
+
+        <div className="h-px bg-gray-100" />
+
         <div className="space-y-4">
           <h3 className="font-semibold text-lg">Implementation constraints</h3>
           <div className="flex items-center gap-2 text-sm text-gray-600">
@@ -1626,6 +1654,12 @@ function ScreenSummary({ isRunning: _isRunning = false }: { isRunning?: boolean 
 
           <div className="rounded-xl border border-gray-200 bg-white p-4 space-y-3">
             <div className="text-xs uppercase tracking-wide text-gray-500">Refinement</div>
+            <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
+              <span className="font-medium">Your context</span>
+              <div className="mt-2 text-sm text-gray-700 line-clamp-2">
+                {context.userContext || <span className="text-gray-500">Not set</span>}
+              </div>
+            </button>
             <button type="button" onClick={() => goToStep("SCREENING")} className="block w-full text-left rounded-lg p-1 transition hover:bg-gray-50">
               <span className="font-medium">Implementation constraints</span>
               {hasImplementationConstraints ? (

--- a/frontend/lib/analysisProjectStore.ts
+++ b/frontend/lib/analysisProjectStore.ts
@@ -51,6 +51,7 @@ export interface AnalysisProject {
     relevance_enabled?: boolean
     use_abstracts_only?: boolean
     use_case?: string
+    user_context?: string
   }
   progress?: {
     stage_label: string

--- a/frontend/lib/userProfileStore.ts
+++ b/frontend/lib/userProfileStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export const DEFAULT_USER_CONTEXT =
+  'I am a senior UK policy advisor in central government. I need evidence synthesised into concise, actionable briefings suitable for ministerial audiences.'
+
+interface UserProfileState {
+  userContext: string
+  setUserContext: (context: string) => void
+}
+
+export const useUserProfileStore = create<UserProfileState>()(
+  persist(
+    (set) => ({
+      userContext: DEFAULT_USER_CONTEXT,
+      setUserContext: (context) => set({ userContext: context }),
+    }),
+    {
+      name: 'user-profile-storage',
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- Add a "What is your context" field to the search wizard's "Additional criteria" step, allowing users to describe their role/audience so synthesis outputs are framed appropriately
- User profile persists in localStorage (Zustand store) so it only needs to be entered once
- Backend synthesis prompts dynamically use the user-provided context instead of hardcoded "senior UK policymaker" framing

<img width="677" height="608" alt="Screenshot 2026-06-16 at 16 45 28" src="https://github.com/user-attachments/assets/ea7c7574-091c-4992-a570-18b0d0f966c8" />

## Details

**Frontend:**

- New `userProfileStore.ts` with Zustand `persist` middleware (defaults to existing UK policy advisor boilerplate)

**Backend:**

- `user_context` extracted from `search_query` in `data_loading.py` and added to `SynthesisState`
- Injected into briefing section generation (all sections), theme discovery, and orchestrator recommendations
- Falls back to default "senior UK policymakers" when empty
- Does NOT affect impact/transferability assessment (intentionally unchanged)

## Caveats

This does not affect how interventions are extracted - so we will still show interventions that might no be relevant to the local context (eg national level policies for a local authority)